### PR TITLE
A revised version of width-polymorphic semantics, fixes #16

### DIFF
--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -11,12 +11,6 @@ For tactics, see Kraken/Tactics.lean.
 import Std
 import Lean.Elab.Tactic.Grind
 
-class Throw α where
-  throw: String → α
-
-def throw {α} [inst: Throw α] :=
-  inst.throw
-
 -- ============================================================================
 -- Width Type
 -- ============================================================================
@@ -493,6 +487,12 @@ def MachineState.getReg (s : MachineState) (r : Reg) : UInt64 :=
 
 def MachineState.setReg (s : MachineState) (r : Reg) (v : UInt64) : MachineState :=
   { s with regs := s.regs.set r v }
+
+class Throw α where
+  throw: String → α
+
+def throw {α} [inst: Throw α] :=
+  inst.throw
 
 def MachineState.readMem [Throw α] (s : MachineState) (addr : Address) (width: Width) (ret: Word → α): α :=
   if addr % 8 != 0 then


### PR DESCRIPTION
This takes into the account the discussions in #16 and in #4 and overhauls Semantics.lean.

The main change from the previous version is:
- memory is now annotated with an operand size (and we assume address size is always 64 bits)
- this is enough to determine the variant of instruction that is used in every single case, except for the `push` operation
- for that latter case, I have a `TypedOperand` that adds extra width information to the immediate case

Generally speaking, I tried hard to address code duplication in the current version of the semantics. I noticed that a lot of matches were quite big, and could be simplified with a modest amount of dependent types. I was initially reluctant to introduce dependent types in the semantics, on the basis that it might complicate writing the interpreter, but it turns out that Lean was quite good at things and I was never in dependent type hell where types don't reduce and I have to sprinkle annotations and/or manually do type conversions. Look at `Registers.get` and `Registers.set` and notice how much shorter this is now.

A nice side-effect of sprinkling dependent types is that a few operations that were previously throwing are now total. We could probably make a lot more operations direct (instead of CPS) by filling out readMem, setMem and so on for non-aligned cases, which in turn could make effective_addr non-CPS, provided the caller proves that the operand is a `.mem`. This would require changing the type of `.lea` to take exactly a register and exactly a memory. This is fine, and I've done it for a few other cases. We may want to address this soon (but as a separate issue) as it may simplify things and/or influence how proofs are written against those semantics.

The main difficulty of this PR is going to be proofreading the semantics. I noticed several errors in the shifts and rotates (unless I misunderstood the manual), so these should be assumed to be incorrect and we'll track those via #32 -- let's leave it aside for now. But I'd be particularly interested in feedback on {add,sub}_{overflow_,}_with_carry, as well as the rest of the semantics, notably .mov and .movzx

@aferr I did not fix the parser -- for now, I'd like to get feedback on the Semantics. Once we're good, I'm hoping you can help me fix the parser since you're familiar with that part of the code. Thanks.