### PR TITLE
Parser Changes to Support Some Programs

### DIFF
--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -290,6 +290,7 @@ def parseShiftExpr: Parser ShiftCountExpr := do
     let _ ← pstring "%cl"
     pure .cl)
 
+
 -- ============================================================================
 -- Condition Code Parsing
 -- ============================================================================
@@ -314,6 +315,10 @@ def parseComma : Parser Unit := do
   skipHWs
   let _ ← pchar ','
   skipHWs
+
+/-- Try to parse a shift count followed by a comma; if that fails, default to 1. -/
+def parseOptionalShiftAndComma : Parser ShiftCountExpr :=
+  (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
 
 def ascribe {T: Width → Type} (w: Width) (v: MaybeTyped T): Parser (T w) := do
   match v with
@@ -619,7 +624,6 @@ def parseInstr : Parser Instr := do
   -- Shift instructions - 64-bit
   | "shl"
   | "sal" =>
-    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
     let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
@@ -628,13 +632,11 @@ def parseInstr : Parser Instr := do
   | "shlq" | "shll" | "shlw" | "shlb"
   | "salq" | "sall" | "salw" | "salb" =>
     let w ← instrWidth mn
-    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
     let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMemWithType w
     pure ⟨ .W64, w, .shl dst cnt ⟩
 
   | "shr" =>
-    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
     let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
@@ -642,13 +644,11 @@ def parseInstr : Parser Instr := do
 
   | "shrq" | "shrl" | "shrw" | "shrb" =>
     let w ← instrWidth mn
-    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
     let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMemWithType w
     pure ⟨ .W64, w, .shr dst cnt ⟩
 
   | "sar" =>
-    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
     let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
@@ -656,7 +656,6 @@ def parseInstr : Parser Instr := do
 
   | "sarq" | "sarl" | "sarw" | "sarb" =>
     let w ← instrWidth mn
-    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
     let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMemWithType w
     pure ⟨ .W64, w, .sar dst cnt ⟩
@@ -681,7 +680,6 @@ def parseInstr : Parser Instr := do
 
   -- Rotate instructions - 64-bit
   | "rol" =>
-    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
     let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
@@ -689,13 +687,11 @@ def parseInstr : Parser Instr := do
 
   | "rolq" | "roll" | "rolw" | "rolb" =>
     let w ← instrWidth mn
-    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
     let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMemWithType w
     pure ⟨ .W64, w, .rol dst cnt ⟩
 
   | "ror" =>
-    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
     let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
@@ -703,7 +699,6 @@ def parseInstr : Parser Instr := do
 
   | "rorq" | "rorl" | "rorw" | "rorb" =>
     let w ← instrWidth mn
-    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
     let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMemWithType w
     pure ⟨ .W64, w, .ror dst cnt ⟩

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -4,7 +4,8 @@ Kraken Parser - x86_64 AT&T Assembly Parser
 Parses AT&T syntax assembly strings into Kraken's Program type.
 Uses Lean's built-in Std.Internal.Parsec library.
 
-Compatible with Lean 4.22.0+.
+The primary reference for the syntax is the GAS manual:
+https://sourceware.org/binutils/docs/as/
 -/
 
 import Kraken.Semantics
@@ -442,6 +443,11 @@ def parseInstr : Parser Instr := do
   | "mul" =>
     let src ← parseRegOrMem
     let ⟨ w, src ⟩ ← assertW src
+    pure ⟨ .W64, w, .mul src ⟩
+
+  | "mulq" | "mull" | "mulw" | "mulb" =>
+    let w ← instrWidth mn
+    let src ← parseRegOrMemWithType w
     pure ⟨ .W64, w, .mul src ⟩
 
   | "mulx" =>

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -618,7 +618,8 @@ def parseInstr : Parser Instr := do
   -- Shift instructions - 64-bit
   | "shl"
   | "sal" =>
-    let cnt ← parseShiftExpr; parseComma
+    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
+    let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
     pure ⟨ .W64, w, .shl dst cnt ⟩
@@ -626,31 +627,36 @@ def parseInstr : Parser Instr := do
   | "shlq" | "shll" | "shlw" | "shlb"
   | "salq" | "sall" | "salw" | "salb" =>
     let w ← instrWidth mn
-    let cnt ← parseShiftExpr; parseComma
+    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
+    let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMemWithType w
     pure ⟨ .W64, w, .shl dst cnt ⟩
 
   | "shr" =>
-    let cnt ← parseShiftExpr; parseComma
+    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
+    let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
     pure ⟨ .W64, w, .shr dst cnt ⟩
 
   | "shrq" | "shrl" | "shrw" | "shrb" =>
     let w ← instrWidth mn
-    let cnt ← parseShiftExpr; parseComma
+    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
+    let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMemWithType w
     pure ⟨ .W64, w, .shr dst cnt ⟩
 
   | "sar" =>
-    let cnt ← parseShiftExpr; parseComma
+    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
+    let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
     pure ⟨ .W64, w, .sar dst cnt ⟩
 
   | "sarq" | "sarl" | "sarw" | "sarb" =>
     let w ← instrWidth mn
-    let cnt ← parseShiftExpr; parseComma
+    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
+    let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMemWithType w
     pure ⟨ .W64, w, .sar dst cnt ⟩
 
@@ -674,26 +680,30 @@ def parseInstr : Parser Instr := do
 
   -- Rotate instructions - 64-bit
   | "rol" =>
-    let cnt ← parseShiftExpr; parseComma
+    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
+    let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
     pure ⟨ .W64, w, .rol dst cnt ⟩
 
   | "rolq" | "roll" | "rolw" | "rolb" =>
     let w ← instrWidth mn
-    let cnt ← parseShiftExpr; parseComma
+    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
+    let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMemWithType w
     pure ⟨ .W64, w, .rol dst cnt ⟩
 
   | "ror" =>
-    let cnt ← parseShiftExpr; parseComma
+    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
+    let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
     pure ⟨ .W64, w, .ror dst cnt ⟩
 
   | "rorq" | "rorl" | "rorw" | "rorb" =>
     let w ← instrWidth mn
-    let cnt ← parseShiftExpr; parseComma
+    let parseOptionalShiftAndComma := (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
+    let cnt ← parseOptionalShiftAndComma
     let dst ← parseRegOrMemWithType w
     pure ⟨ .W64, w, .ror dst cnt ⟩
 

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -177,6 +177,7 @@ def parseMemory : Parser AddrExpr := do
   skipHWs
   -- Optional displacement; TODO: parse ConstExpr generally
   let disp ← (do let i ← parseInt; pure (.Int64 (Int64.ofInt i))) <|> parseLabel <|> pure (.Int64 0)
+  skipHWs
   let _ ← pchar '('
 
   skipHWs

--- a/asm-tests/test_displacement_whitespace.S
+++ b/asm-tests/test_displacement_whitespace.S
@@ -1,0 +1,96 @@
+# Test: Displacement-parenthesis whitespace tolerance
+# Commit: 2b0af28 - Parser whitespace fix
+# Tests: Tolerate spaces between displacement and open parenthesis in memory
+#        operands, e.g. `leaq 0 (%rdi), %rax` instead of `leaq 0(%rdi), %rax`
+#
+# GNU AS accepts whitespace between displacement and '(' in memory operands.
+# This test uses leaq to exercise the parser fix without requiring actual
+# memory access (Kraken has limited memory support).
+
+.data
+.align 8
+final_rax: .quad 0
+final_rbx: .quad 0
+final_rcx: .quad 0
+final_rdx: .quad 0
+final_rsi: .quad 0
+final_rdi: .quad 0
+final_rsp: .quad 0
+final_rbp: .quad 0
+final_r8: .quad 0
+final_r9: .quad 0
+final_r10: .quad 0
+final_r11: .quad 0
+final_r12: .quad 0
+final_r13: .quad 0
+final_r14: .quad 0
+final_r15: .quad 0
+final_flags: .quad 0
+
+.text
+.globl _start
+_start:
+    # Setup base values
+    movq $1000, %rdi
+    movq $2000, %rbx
+    movq $3, %rcx
+
+    # Test 1: leaq with space between 0 and (
+    leaq 0 (%rdi), %rax             # rax = 1000
+
+    # Test 2: leaq with space between displacement and (
+    leaq 8 (%rdi), %rdx             # rdx = 1008
+
+    # Test 3: leaq with displacement + base + index*scale, with spacing
+    leaq 16 (%rbx, %rcx, 4), %rsi   # rsi = 2000 + 16 + 3*4 = 2028
+
+    # Test 4: Negative displacement with space
+    leaq -8 (%rdi), %r8             # r8 = 992
+
+    # Test 5: Large displacement with space
+    leaq 256 (%rbx), %r9            # r9 = 2256
+
+    # Test 6: Zero displacement with index and scale, with spacing
+    leaq 0 (%rdi, %rcx, 8), %r10    # r10 = 1000 + 3*8 = 1024
+
+    # Test 7: addq to put a deterministic value in r11 (so we test more regs)
+    movq $42, %r11
+
+    # Final expected:
+    # rax = 1000, rbx = 2000, rcx = 3, rdx = 1008
+    # rsi = 2028, rdi = 1000
+    # r8 = 992, r9 = 2256, r10 = 1024, r11 = 42
+
+    jmp _kraken_capture
+
+# ====== KRAKEN CAPTURE EPILOGUE ======
+_kraken_capture:
+    movq %rax, final_rax(%rip)
+    movq %rbx, final_rbx(%rip)
+    movq %rcx, final_rcx(%rip)
+    movq %rdx, final_rdx(%rip)
+    movq %rsi, final_rsi(%rip)
+    movq %rdi, final_rdi(%rip)
+    movq %rsp, final_rsp(%rip)
+    movq %rbp, final_rbp(%rip)
+    movq %r8,  final_r8(%rip)
+    movq %r9,  final_r9(%rip)
+    movq %r10, final_r10(%rip)
+    movq %r11, final_r11(%rip)
+    movq %r12, final_r12(%rip)
+    movq %r13, final_r13(%rip)
+    movq %r14, final_r14(%rip)
+    movq %r15, final_r15(%rip)
+    pushfq
+    popq %rax
+    movq %rax, final_flags(%rip)
+
+    movq $1, %rax
+    movq $1, %rdi
+    leaq final_rax(%rip), %rsi
+    movq $136, %rdx
+    syscall
+
+    movq $60, %rax
+    xorq %rdi, %rdi
+    syscall

--- a/asm-tests/test_mul_suffixed.S
+++ b/asm-tests/test_mul_suffixed.S
@@ -1,0 +1,110 @@
+# Test: Suffixed mul instruction variants
+# Commit: 20d9d63 - Parser fixes for missing instruction variants
+# Tests: mulq, mull (suffixed one-operand multiply, which were previously
+#        missing from the parser)
+#
+# `mulq %reg` performs unsigned rdx:rax = rax * reg (64-bit)
+# `mull %reg` performs unsigned edx:eax = eax * reg (32-bit)
+
+.data
+.align 8
+final_rax: .quad 0
+final_rbx: .quad 0
+final_rcx: .quad 0
+final_rdx: .quad 0
+final_rsi: .quad 0
+final_rdi: .quad 0
+final_rsp: .quad 0
+final_rbp: .quad 0
+final_r8: .quad 0
+final_r9: .quad 0
+final_r10: .quad 0
+final_r11: .quad 0
+final_r12: .quad 0
+final_r13: .quad 0
+final_r14: .quad 0
+final_r15: .quad 0
+final_flags: .quad 0
+
+.text
+.globl _start
+_start:
+    # ----- Test 1: mulq (64-bit, suffixed) -----
+    movq $100, %rax
+    movq $7, %rbx
+    mulq %rbx                        # rdx:rax = 100 * 7 = 700
+    # Expected: rax = 700 (0x2BC), rdx = 0
+
+    # Save results
+    movq %rax, %r8                   # r8 = 700
+    movq %rdx, %r9                   # r9 = 0
+
+    # ----- Test 2: mulq with larger values producing high bits -----
+    movq $0x100000000, %rax          # 2^32
+    movq $0x100000000, %rcx          # 2^32
+    mulq %rcx                        # rdx:rax = 2^64
+    # Expected: rax = 0, rdx = 1
+
+    # Save results
+    movq %rax, %r10                  # r10 = 0
+    movq %rdx, %r11                  # r11 = 1
+
+    # ----- Test 3: mull (32-bit, suffixed) -----
+    movl $50, %eax
+    movl $6, %esi
+    mull %esi                        # edx:eax = 50 * 6 = 300
+    # Expected: eax = 300 (0x12C), edx = 0
+
+    # Save results
+    movq %rax, %r12                  # r12 = 300
+    movq %rdx, %r13                  # r13 = 0
+
+    # ----- Test 4: Unsuffixed mul still works -----
+    movq $25, %rax
+    movq $4, %rdi
+    mul %rdi                         # rdx:rax = 25 * 4 = 100
+    # Expected: rax = 100, rdx = 0
+
+    # Restore saved values for capture
+    movq %rax, %r14                  # r14 = 100
+    movq %rdx, %r15                  # r15 = 0
+    movq %r8, %rax                   # rax = 700 (test 1 result)
+    movq %r9, %rbx                   # rbx = 0   (test 1 high)
+    movq %r10, %rcx                  # rcx = 0   (test 2 low)
+    movq %r11, %rdx                  # rdx = 1   (test 2 high)
+    # rsi = clobbered by mull, but we saved to r12
+    # rdi = 4 (from test 4)
+
+    jmp _kraken_capture
+
+# ====== KRAKEN CAPTURE EPILOGUE ======
+_kraken_capture:
+    movq %rax, final_rax(%rip)
+    movq %rbx, final_rbx(%rip)
+    movq %rcx, final_rcx(%rip)
+    movq %rdx, final_rdx(%rip)
+    movq %rsi, final_rsi(%rip)
+    movq %rdi, final_rdi(%rip)
+    movq %rsp, final_rsp(%rip)
+    movq %rbp, final_rbp(%rip)
+    movq %r8,  final_r8(%rip)
+    movq %r9,  final_r9(%rip)
+    movq %r10, final_r10(%rip)
+    movq %r11, final_r11(%rip)
+    movq %r12, final_r12(%rip)
+    movq %r13, final_r13(%rip)
+    movq %r14, final_r14(%rip)
+    movq %r15, final_r15(%rip)
+    pushfq
+    popq %rax
+    movq %rax, final_flags(%rip)
+
+    movq $1, %rax
+    movq $1, %rdi
+    leaq final_rax(%rip), %rsi
+    movq $136, %rdx
+    syscall
+
+    movq $60, %rax
+    xorq %rdi, %rdi
+    syscall

--- a/asm-tests/test_single_arg_shift.S
+++ b/asm-tests/test_single_arg_shift.S
@@ -1,0 +1,123 @@
+# Test: Single-argument shift/rotate syntax (implicit count = 1)
+# Commit: 9e82042 - Support GNU AS single argument shift syntax
+# Tests: shl, shr, sar, sal, rol, ror with no explicit shift count
+#
+# GNU AS allows `shr %reg` as shorthand for `shr $1, %reg`.
+# This test verifies all shift/rotate families in both suffixed and
+# unsuffixed forms.
+#
+# Note: The last flag-setting instruction is `addq $0` which sets AF
+# deterministically, avoiding the known AF-undefined issue with shifts.
+
+.data
+.align 8
+final_rax: .quad 0
+final_rbx: .quad 0
+final_rcx: .quad 0
+final_rdx: .quad 0
+final_rsi: .quad 0
+final_rdi: .quad 0
+final_rsp: .quad 0
+final_rbp: .quad 0
+final_r8: .quad 0
+final_r9: .quad 0
+final_r10: .quad 0
+final_r11: .quad 0
+final_r12: .quad 0
+final_r13: .quad 0
+final_r14: .quad 0
+final_r15: .quad 0
+final_flags: .quad 0
+
+.text
+.globl _start
+_start:
+    # ----- SHR single-arg (implicit $1) -----
+    movq $0x8000000000000004, %rax
+    shrq %rax                        # rax >>= 1
+    # Expected: rax = 0x4000000000000002
+
+    # ----- SHL single-arg (implicit $1) -----
+    movq $0x4000000000000001, %rbx
+    shlq %rbx                        # rbx <<= 1
+    # Expected: rbx = 0x8000000000000002
+
+    # ----- SAR single-arg (sign-extending) -----
+    movq $0x8000000000000004, %rcx
+    sarq %rcx                        # arithmetic shift right by 1
+    # Expected: rcx = 0xC000000000000002 (sign bit preserved)
+
+    # ----- SAL single-arg (same as SHL) -----
+    movq $0x4000000000000001, %rdx
+    salq %rdx                        # rdx <<= 1
+    # Expected: rdx = 0x8000000000000002
+
+    # ----- ROL single-arg (rotate left by 1) -----
+    movq $0x8000000000000001, %rsi
+    rolq %rsi
+    # Expected: rsi = 0x0000000000000003 (MSB wraps to LSB)
+
+    # ----- ROR single-arg (rotate right by 1) -----
+    movq $0x8000000000000001, %rdi
+    rorq %rdi
+    # Expected: rdi = 0xC000000000000000 (LSB wraps to MSB + sign)
+
+    # ----- 32-bit single-arg shift (shrl) -----
+    movl $0x80000004, %r8d
+    shrl %r8d
+    # Expected: r8d = 0x40000002 -> r8 = 0x40000002
+
+    # ----- Unsuffixed single-arg shift -----
+    movq $0x100, %r9
+    shr %r9                          # unsuffixed, implicit $1
+    # Expected: r9 = 0x80
+
+    # ----- Unsuffixed single-arg rotate -----
+    movq $0x8000000000000001, %r10
+    rol %r10
+    # Expected: r10 = 0x0000000000000003
+
+    # ----- Verify two-arg still works alongside single-arg -----
+    movq $0xFF, %r11
+    shrq $4, %r11                    # explicit $4
+    # Expected: r11 = 0x0F
+
+    # Set flags deterministically: AF is undefined after shifts,
+    # Kraken models this as `true` but for some real hardware it will be false.
+    # The test harness compares all flags including AF. Use addq $0 to reset
+    # AF to a known state matching both hardware and Kraken.
+    addq $0, %r11
+
+    jmp _kraken_capture
+
+# ====== KRAKEN CAPTURE EPILOGUE ======
+_kraken_capture:
+    movq %rax, final_rax(%rip)
+    movq %rbx, final_rbx(%rip)
+    movq %rcx, final_rcx(%rip)
+    movq %rdx, final_rdx(%rip)
+    movq %rsi, final_rsi(%rip)
+    movq %rdi, final_rdi(%rip)
+    movq %rsp, final_rsp(%rip)
+    movq %rbp, final_rbp(%rip)
+    movq %r8,  final_r8(%rip)
+    movq %r9,  final_r9(%rip)
+    movq %r10, final_r10(%rip)
+    movq %r11, final_r11(%rip)
+    movq %r12, final_r12(%rip)
+    movq %r13, final_r13(%rip)
+    movq %r14, final_r14(%rip)
+    movq %r15, final_r15(%rip)
+    pushfq
+    popq %rax
+    movq %rax, final_flags(%rip)
+
+    movq $1, %rax
+    movq $1, %rdi
+    leaq final_rax(%rip), %rsi
+    movq $136, %rdx
+    syscall
+
+    movq $60, %rax
+    xorq %rdi, %rdi
+    syscall


### PR DESCRIPTION
This PR batches changes to support some specific programs. These changes affect only the parser.

The changes are as follows:
1) Supporting AT&T Suffix variants for mul which are mulq, mull, mulw, mulb
2) Support a syntax GNU AS supports for single operand shifts, which is a shorthand for shifting by 1
3) Fix whitespace -- it is permitted for a space to come between a displacement and an open parenthesis

A comment is added to explain that the GNU documentation is the source of truth.

More details on these changes:

----------------------------
Suffixes:
----------------------------
Their implementation here is based off of:
- GNU AS, which is the de facto ref manual for AT&T syntax AFAICT
and especially the suffix descriptions
https://sourceware.org/binutils/docs/as/i386_002dMnemonics.html#Instruction-Naming
- the implementation of other suffixed instructions in the Parser

Also adds GNU AS docs as a link in a comment at the top declaring it
is the primary reference for this file.

----------------------------
Single Operand Shifts:
----------------------------
GNU AS permits writing single argument shift as a shorthand
for shift by 1. Here is an example:
```
  shl %r9
```

I cannot find a document that explains this encoding but running GNU on this
instruction validates that this is permitted by GNU and it has this
functionality.

Here is a test you can use to confirm this:
```
.global main
.text main:
  mov $42, %r9
  shr %r9
  mov %r9, %rax
  ret
```
which will return exit code 21 (shifting 42 right by 1).

It appears supported for shifts and rotates generally, so this also
adds support for this syntax for other shifts and rotates using the same
solution.

----------------------------
Whitespace fix
----------------------------
Tolerate a space between displacements and open parenthesis as in:
```
mov %rax, 0 (%rdi)
```

where the space after the 0 is the important part that this change allows