### PR TITLE
Start cleaning up tests: share prologue / epilogue

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -30,6 +30,5 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
-        with:
-          test-cmd: lake build krakentest
+      - run: lake build krakentest
       - run: ./scripts/run_all_asm_tests.sh

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
+      - name: Build Kraken Test
+        run: lake build krakentest
 
   build-experimental:
     name: Build KrakenExp (4.28.0)
@@ -21,3 +23,13 @@ jobs:
       - name: Override Lean toolchain with 4.28
         run: echo "leanprover/lean4:v4.28.0" > lean-toolchain
       - uses: leanprover/lean-action@v1
+
+  run-asm-tests:
+    name: Run ASM tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: leanprover/lean-action@v1
+        with:
+          test-cmd: lake build krakentest
+      - run: ./scripts/run_all_asm_tests.sh

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -586,6 +586,16 @@ def parseInstr : Parser Instr := do
     let w ← instrWidth mn
     commaSeparated w parseOperand parseRegOrMem .and
 
+  | "not" =>
+    let dst ← parseRegOrMem
+    let ⟨ w, dst ⟩ ← assertW dst
+    pure ⟨ .W64, w, .not dst ⟩
+
+  | "notq" | "notl" | "notw" | "notb" =>
+    let w ← instrWidth mn
+    let dst ← parseRegOrMemWithType w
+    pure ⟨ .W64, w, .not dst ⟩
+
   | "or" =>
     commaSeparated .none parseOperand parseRegOrMem .or
 

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -557,7 +557,7 @@ def parseInstr : Parser Instr := do
     let w_dst ← instrWidth mn
     let c_src ← String.Pos.Raw.get? mn (.mk (mn.length - 2))
     let w_src ← Char.toWidth c_src
-    let src ← parseRegWithType w_src
+    let src ← parseRegWithType w_src; parseComma
     let dst ← parseRegWithType w_dst
     pure ⟨ .W64, w_dst, .movzx dst (.Reg src) ⟩
 
@@ -565,7 +565,7 @@ def parseInstr : Parser Instr := do
     let w_dst ← instrWidth mn
     let c_src ← String.Pos.Raw.get? mn (.mk (mn.length - 2))
     let w_src ← Char.toWidth c_src
-    let src ← parseRegWithType w_src
+    let src ← parseRegWithType w_src; parseComma
     let dst ← parseRegWithType w_dst
     pure ⟨ .W64, w_dst, .movzx dst (.Reg src) ⟩
 

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -503,13 +503,13 @@ def parseInstr : Parser Instr := do
   | "imulq" | "imull" | "imulw" | "imulb" =>
     let w ← instrWidth mn
     let src1 ← parseOperandWithType w; parseComma
-    (do
+    (attempt do
       let src2 ← parseRegOrMemWithType w; parseComma
       let dst ← parseRegWithType w
       pure ⟨ .W64, w, .imul (.some dst) src2 src1 ⟩
     ) <|>
     (do
-      let src2 ← parseRegOrMemWithType w; parseComma
+      let src2 ← parseRegOrMemWithType w
       pure ⟨ .W64, w, .imul none src2 src1 ⟩
     )
 

--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -12,7 +12,7 @@ instance : Coe Bool Nat where coe := Bool.toNat
 def BitVec.take {w} (x : BitVec w) (n : Nat) : BitVec n := x.extractLsb' 0 n
 def BitVec.drop {w} (x : BitVec w) (n : Nat) : BitVec (w - n) := x.extractLsb' n (w-n)
 def BitVec.replaceLow {w n} (old : BitVec w) (new : BitVec n) : BitVec w :=
-  (BitVec.append (old.drop w) new).setWidth _
+  (BitVec.append (old.drop n) new).setWidth _
 
 inductive Width | W8 | W16 | W32 | W64 deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 

--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -123,15 +123,32 @@ def throw {α} [inst: Throw α] :=
 def Reg.interp {α w} (r : Reg w) (s : MachineData) (_ : Std.Rco Int64) (ret : w.type → α) :=
   ret (s.regs.get r) -- the unused argument is present ^ for uniformity with RegOrMem.interp
 
+def MachineData.loadOpt {α} [Throw α] (s : MachineData) (addr : BitVec 64) (ret : Option UInt64 → α): α :=
+  if addr % 8 != 0 then
+    throw (s!"Unimplemented: only 8-byte-aligned memory access is supported")
+  else
+    ret (s.dmem[UInt64.ofBitVec addr]?)
+
 def MachineData.load {α} [Throw α] (s : MachineData) (addr : BitVec 64) (w : Width) (ret : w.type → α): α :=
-  if addr % 8 != 0 then throw (s!"Unimplemented: only 8-byte-aligned memory access is supported")
-  else match s.dmem[UInt64.ofBitVec addr]? with
-  | .some v => ret (v.toBitVec.truncate _)
-  | .none => throw (s!"Memory accessed but not mapped (addr={repr addr})")
+  loadOpt s addr (fun v =>
+    match v with
+    | .some v => ret (v.toBitVec.truncate _)
+    | .none => throw (s!"Memory accessed but not mapped (addr={repr addr})"))
 
 def MachineData.store {α} [Throw α] (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.type) (ret: MachineData → α) : α :=
-  s.load addr .W64 (fun old =>
-  ret { s with dmem := s.dmem.insert (.ofBitVec addr) (.ofBitVec (old.replaceLow v)) })
+  s.loadOpt addr (fun old =>
+    match old with
+    | .some old =>
+      ret { s with dmem := s.dmem.insert (.ofBitVec addr) (.ofBitVec (old.toBitVec.replaceLow v)) }
+    | .none =>
+      if h: w = .W64 then
+        -- We know how to perform full writes even though there is not previous
+        -- value
+        have : w.type = BitVec 64 := by simp [h,Width.type,Width.bits]
+        ret { s with dmem := s.dmem.insert (.ofBitVec addr) (UInt64.ofBitVec (this ▸ v)) }
+      else
+        throw (s!"Cannot perform a partial write at {addr} because there is no previous value")
+  )
 
 abbrev Label := String
 

--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -283,6 +283,7 @@ inductive Operation (w : Width)
   -- Bitwise
   | test (a : RegOrMem w) (b : Operand w)
   | and  (_ : Dst w) (src : Operand w)
+  | not  (_ : Dst w)
   | or   (_ : Dst w) (src : Operand w)
   | xor  (_ : Dst w) (src : Operand w)
   | shl  (_ : Dst w) (_ : ShiftCountExpr)
@@ -480,6 +481,10 @@ def Operation.interp {α} [∀ w : Width, Undefined w.type α] [Undefined Status
     undefined (fun af =>
     let status := .from_result v { cf := false, of := false, af }
     { s with status }.set dst v p next)))
+  | .not dst =>
+    dst.interp s p (fun a =>
+    let v := ~~~a
+    s.set dst v p next)
   | .shl dst count =>
     dst.interp s p (fun a =>
     let count := count.interpMasked s p w

--- a/Kraken/TestHarness.lean
+++ b/Kraken/TestHarness.lean
@@ -358,6 +358,7 @@ def runKraken (asmCode : String)
     : Except String MachineState := do
   let prog ← Parser.parse (startGadget ++ asmCode ++ endGadget)
   let initState: MachineState := ({}, prog.fakeLayout.labels.label "__start")
+  let initState := ({ initState.1 with status := { initState.1.status with zf := true, pf := true }}, initState.2)
   prog.fakeLayout.eval initState (finishCriterion prog)
 
 def test1 := "

--- a/Kraken/TestHarness.lean
+++ b/Kraken/TestHarness.lean
@@ -158,6 +158,8 @@ def genCaptureEpilogue (memRegions : List MemRegion := []) : String :=
 -- Assembly Modification
 -- ============================================================================
 
+#eval System.Platform.isOSX
+
 /-- Wrap user's assembly code with capture infrastructure.
 
     The user's code should be a complete program (with .text, .globl _start, etc.)
@@ -173,10 +175,17 @@ def wrapAssembly (userAsm : String) (memRegions : List MemRegion := []) : String
 
     Example: makeTestProgram "addq $1, %rax" -/
 def makeTestProgram (instructions : String) (memRegions : List MemRegion := []) : String :=
+  let prologue :=
+    if System.Platform.isOSX then
+      ".text\n" ++
+      ".globl _main\n" ++
+      "_main:\n"
+    else
+      ".text\n" ++
+      ".globl _start\n" ++
+      "_start:\n"
   genCaptureData memRegions ++ "\n" ++
-  ".text\n" ++
-  ".globl _start\n" ++
-  "_start:\n" ++
+  prologue ++
   instructions ++ "\n" ++
   genCaptureEpilogue memRegions
 
@@ -414,7 +423,7 @@ def extractTestableCode (asmCode : String) : String :=
   let lines := asmCode.splitOn "\n"
   let inTest := lines.foldl (fun (acc, inBlock) line =>
     let trimmed := line.trim
-    if trimmed.startsWith "_start:" then (acc, true)
+    if trimmed.startsWith "_start:" || trimmed.startsWith "_main:" then (acc, true)
     else if inBlock && trimmed.startsWith "jmp" && trimmed.endsWith "_kraken_capture" then
       (acc, false)
     else if inBlock then
@@ -448,7 +457,7 @@ def runTest (asmCode : String) (asOutput : ByteArray) : TestResult :=
     else
       -- Run extracted code through Kraken
       match runKraken testCode with
-      | .error e => .krakenError s!"Error running extracted code: {e}"
+      | .error e => .krakenError s!"Error running extracted code: {e}\n{testCode}"
       | .ok krakenState => compareStates krakenState actualRegs actualFlags
 
 /-- Format a TestResult for display. -/

--- a/Kraken/TestHarness.lean
+++ b/Kraken/TestHarness.lean
@@ -358,6 +358,8 @@ def runKraken (asmCode : String)
     : Except String MachineState := do
   let prog ← Parser.parse (startGadget ++ asmCode ++ endGadget)
   let initState: MachineState := ({}, prog.fakeLayout.labels.label "__start")
+  -- Kept in sync with asm-tests/prologue-*.S -- this is the effect of the
+  -- initial series of xor instructions.
   let initState := ({ initState.1 with status := { initState.1.status with zf := true, pf := true }}, initState.2)
   prog.fakeLayout.eval initState (finishCriterion prog)
 

--- a/asm-tests/epilogue-Darwin.S
+++ b/asm-tests/epilogue-Darwin.S
@@ -1,3 +1,4 @@
+jmp _kraken_capture
 
 # ====== KRAKEN CAPTURE EPILOGUE ======
 _kraken_capture:

--- a/asm-tests/epilogue-Darwin.S
+++ b/asm-tests/epilogue-Darwin.S
@@ -1,0 +1,32 @@
+
+# ====== KRAKEN CAPTURE EPILOGUE ======
+_kraken_capture:
+    movq %rax, final_rax(%rip)
+    movq %rbx, final_rbx(%rip)
+    movq %rcx, final_rcx(%rip)
+    movq %rdx, final_rdx(%rip)
+    movq %rsi, final_rsi(%rip)
+    movq %rdi, final_rdi(%rip)
+    movq %rsp, final_rsp(%rip)
+    movq %rbp, final_rbp(%rip)
+    movq %r8,  final_r8(%rip)
+    movq %r9,  final_r9(%rip)
+    movq %r10, final_r10(%rip)
+    movq %r11, final_r11(%rip)
+    movq %r12, final_r12(%rip)
+    movq %r13, final_r13(%rip)
+    movq %r14, final_r14(%rip)
+    movq %r15, final_r15(%rip)
+    pushfq
+    popq %rax
+    movq %rax, final_flags(%rip)
+
+    movq $0x2000004, %rax
+    movq $1, %rdi
+    leaq final_rax(%rip), %rsi
+    movq $136, %rdx
+    syscall
+
+    movq $0x2000001, %rax
+    xorq %rdi, %rdi
+    syscall

--- a/asm-tests/epilogue-Linux.S
+++ b/asm-tests/epilogue-Linux.S
@@ -1,3 +1,4 @@
+jmp _kraken_capture
 
 # ====== KRAKEN CAPTURE EPILOGUE ======
 _kraken_capture:

--- a/asm-tests/epilogue-Linux.S
+++ b/asm-tests/epilogue-Linux.S
@@ -1,0 +1,32 @@
+
+# ====== KRAKEN CAPTURE EPILOGUE ======
+_kraken_capture:
+    movq %rax, final_rax(%rip)
+    movq %rbx, final_rbx(%rip)
+    movq %rcx, final_rcx(%rip)
+    movq %rdx, final_rdx(%rip)
+    movq %rsi, final_rsi(%rip)
+    movq %rdi, final_rdi(%rip)
+    movq %rsp, final_rsp(%rip)
+    movq %rbp, final_rbp(%rip)
+    movq %r8,  final_r8(%rip)
+    movq %r9,  final_r9(%rip)
+    movq %r10, final_r10(%rip)
+    movq %r11, final_r11(%rip)
+    movq %r12, final_r12(%rip)
+    movq %r13, final_r13(%rip)
+    movq %r14, final_r14(%rip)
+    movq %r15, final_r15(%rip)
+    pushfq
+    popq %rax
+    movq %rax, final_flags(%rip)
+
+    movq $1, %rax
+    movq $1, %rdi
+    leaq final_rax(%rip), %rsi
+    movq $136, %rdx
+    syscall
+
+    movq $60, %rax
+    xorq %rdi, %rdi
+    syscall

--- a/asm-tests/prologue-Darwin.S
+++ b/asm-tests/prologue-Darwin.S
@@ -1,0 +1,39 @@
+.data
+.align 8
+final_rax: .quad 0
+final_rbx: .quad 0
+final_rcx: .quad 0
+final_rdx: .quad 0
+final_rsi: .quad 0
+final_rdi: .quad 0
+final_rsp: .quad 0
+final_rbp: .quad 0
+final_r8: .quad 0
+final_r9: .quad 0
+final_r10: .quad 0
+final_r11: .quad 0
+final_r12: .quad 0
+final_r13: .quad 0
+final_r14: .quad 0
+final_r15: .quad 0
+final_flags: .quad 0
+
+.text
+.globl _main
+
+_main:
+  xor %rax, %rax
+  xor %rbx, %rbx
+  xor %rcx, %rcx
+  xor %rdx, %rdx
+  xor %rsi, %rsi
+  xor %rdi, %rdi
+  xor %rbp, %rbp
+  xor %r8, %r8
+  xor %r9, %r9
+  xor %r10, %r10
+  xor %r11, %r11
+  xor %r12, %r12
+  xor %r13, %r13
+  xor %r14, %r14
+  xor %r15, %r15

--- a/asm-tests/prologue-Darwin.S
+++ b/asm-tests/prologue-Darwin.S
@@ -22,6 +22,7 @@ final_flags: .quad 0
 .globl _main
 
 _main:
+  add $1, %rax
   xor %rax, %rax
   xor %rbx, %rbx
   xor %rcx, %rcx

--- a/asm-tests/prologue-Linux.S
+++ b/asm-tests/prologue-Linux.S
@@ -22,3 +22,19 @@ final_flags: .quad 0
 .globl _start
 
 _start:
+  add $1, %rax
+  xor %rax, %rax
+  xor %rbx, %rbx
+  xor %rcx, %rcx
+  xor %rdx, %rdx
+  xor %rsi, %rsi
+  xor %rdi, %rdi
+  xor %rbp, %rbp
+  xor %r8, %r8
+  xor %r9, %r9
+  xor %r10, %r10
+  xor %r11, %r11
+  xor %r12, %r12
+  xor %r13, %r13
+  xor %r14, %r14
+  xor %r15, %r15

--- a/asm-tests/prologue-Linux.S
+++ b/asm-tests/prologue-Linux.S
@@ -1,0 +1,24 @@
+.data
+.align 8
+final_rax: .quad 0
+final_rbx: .quad 0
+final_rcx: .quad 0
+final_rdx: .quad 0
+final_rsi: .quad 0
+final_rdi: .quad 0
+final_rsp: .quad 0
+final_rbp: .quad 0
+final_r8: .quad 0
+final_r9: .quad 0
+final_r10: .quad 0
+final_r11: .quad 0
+final_r12: .quad 0
+final_r13: .quad 0
+final_r14: .quad 0
+final_r15: .quad 0
+final_flags: .quad 0
+
+.text
+.globl _start
+
+_start:

--- a/asm-tests/test_32bit_ops.S
+++ b/asm-tests/test_32bit_ops.S
@@ -6,30 +6,6 @@
 #   rbx: result of 32-bit ops
 #   rcx: 50 (from subl test)
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-
-_start:
     # ----- 32-bit addition (addl) -----
     movl $10, %eax
     movl $5, %ebx
@@ -95,37 +71,3 @@ _start:
     movl $1, %r15d
     shll $4, %r15d
     # Expected: r15d = 16
-
-    jmp _kraken_capture
-
-# ====== KRAKEN CAPTURE EPILOGUE ======
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_8bit_16bit.S
+++ b/asm-tests/test_8bit_16bit.S
@@ -5,30 +5,6 @@
 # - setc/setnc write a byte (0 or 1) to 8-bit register
 # - 16-bit writes (movw) preserve upper 48 bits
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-
-_start:
     # ----- 16-bit register writes preserve upper bits (movw) -----
     movq $0xFFFFFFFFFFFF0000, %rax
     movw $0x1234, %ax
@@ -56,37 +32,3 @@ _start:
     movq $100, %r8
     cmpb %r8b, %dil                  # Compare low bytes: 100 - 100 = 0, ZF=1
     # ZF should be set
-
-    jmp _kraken_capture
-
-# ====== KRAKEN CAPTURE EPILOGUE ======
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_arithmetic.S
+++ b/asm-tests/test_arithmetic.S
@@ -7,30 +7,6 @@
 #   rcx: 3 + 2 + CF(0) = 5, then + 1 + CF = 7
 #   rdx: result of negq
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-_start:
-    # Test addq
     movq $10, %rax
     addq $5, %rax           # rax = 15
 
@@ -78,37 +54,3 @@ _start:
     # Test cmpq (64-bit compare)
     movq $50, %r15
     cmpq $50, %r15          # Should set ZF=1
-
-    jmp _kraken_capture
-
-# ====== KRAKEN CAPTURE EPILOGUE ======
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_bswap.S
+++ b/asm-tests/test_bswap.S
@@ -6,30 +6,6 @@
 #   rbx: 0xBEBAFECAEFBEADDE (bswap of 0xDEADBEEFCAFEBABE)
 #   rcx: 0x00000000EFBEADDE (bswapl of 0xDEADBEEF)
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-
-_start:
     # ----- 64-bit byte swap -----
     movq $0x0102030405060708, %rax
     bswapq %rax
@@ -50,37 +26,3 @@ _start:
     movl $0x01020304, %edx           # Clears upper 32 bits
     bswapl %edx
     # Expected: rdx = 0x0000000004030201
-
-    jmp _kraken_capture
-
-# ====== KRAKEN CAPTURE EPILOGUE ======
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_conditionals.S
+++ b/asm-tests/test_conditionals.S
@@ -3,30 +3,6 @@
 #
 # Note: Avoiding cmov and push/pop which may need more parser support
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-
-_start:
     # ----- TEST instruction -----
     movq $0xFF, %rax
     testq %rax, %rax                 # Sets ZF=0 (non-zero)
@@ -62,37 +38,3 @@ _start:
     movq $700, %r13
     movq $800, %r14
     movq $42, %r15
-
-    jmp _kraken_capture
-
-# ====== KRAKEN CAPTURE EPILOGUE ======
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_displacement_whitespace.S
+++ b/asm-tests/test_displacement_whitespace.S
@@ -7,29 +7,6 @@
 # This test uses leaq to exercise the parser fix without requiring actual
 # memory access (Kraken has limited memory support).
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-_start:
     # Setup base values
     movq $1000, %rdi
     movq $2000, %rbx
@@ -60,37 +37,3 @@ _start:
     # rax = 1000, rbx = 2000, rcx = 3, rdx = 1008
     # rsi = 2028, rdi = 1000
     # r8 = 992, r9 = 2256, r10 = 1024, r11 = 42
-
-    jmp _kraken_capture
-
-# ====== KRAKEN CAPTURE EPILOGUE ======
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_flags.S
+++ b/asm-tests/test_flags.S
@@ -9,30 +9,6 @@
 # Instead of saving flags to registers (which needs pushfq),
 # we test flag effects via the final flag state and register values.
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-_start:
-    # Test 1: ZF set when result is zero
     movq $5, %rax
     subq $5, %rax           # rax = 0, ZF = 1
 
@@ -59,35 +35,3 @@ _start:
     # rsi = 0x8000000000000000 (MIN_INT64)
     # Flags from last instruction: OF = 1
 
-    jmp _kraken_capture
-
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_logic.S
+++ b/asm-tests/test_logic.S
@@ -7,29 +7,6 @@
 #   rcx: 0xFF00 OR 0x0F0F = 0xFF0F
 #   rdx: XOR with self = 0
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-_start:
     # Test xorq
     movq $0xFF00, %rax
     xorq $0x0F0F, %rax      # rax = 0xF00F
@@ -46,35 +23,3 @@ _start:
     movq $12345, %rdx
     xorq %rdx, %rdx         # rdx = 0, ZF = 1
 
-    jmp _kraken_capture
-
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_memory.S
+++ b/asm-tests/test_memory.S
@@ -4,30 +4,8 @@
 #
 # This is a simplified test that verifies register operations work correctly.
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-_start:
     # Test: Various register operations
+
     movq $100, %rax
     movq $200, %rbx
     movq $2, %rcx
@@ -43,35 +21,3 @@ _start:
     # Final state:
     # rax = 100, rbx = 200, rcx = 2, rdx = 116, rsi = 224, rdi = 8
 
-    jmp _kraken_capture
-
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_memory_whitespace.S
+++ b/asm-tests/test_memory_whitespace.S
@@ -8,30 +8,8 @@
 # This test ensures Kraken's parser also accepts this syntax.
 # Uses only register operations (no RIP-relative memory) for parser compatibility.
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-_start:
     # Setup base values
+
     movq $100, %rdi
     movq $200, %rbx
     movq $2, %rcx
@@ -56,36 +34,3 @@ _start:
     # rsi = 224 (from leaq 16 (%rbx, %rcx, 4), %rsi)
     # rdi = 100
     # r8 = 108 (from leaq 8 (%rdi), %r8)
-
-    jmp _kraken_capture
-
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_move.S
+++ b/asm-tests/test_move.S
@@ -10,29 +10,6 @@
 #   rdx: 999
 #   rsi: 142
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-_start:
     # Test movq (64-bit immediate)
     movq $42, %rax          # rax = 42
 
@@ -48,35 +25,3 @@ _start:
     # Test leaq with just displacement
     leaq 100(%rax), %rsi    # rsi = 42 + 100 = 142
 
-    jmp _kraken_capture
-
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_mul_suffixed.S
+++ b/asm-tests/test_mul_suffixed.S
@@ -6,29 +6,6 @@
 # `mulq %reg` performs unsigned rdx:rax = rax * reg (64-bit)
 # `mull %reg` performs unsigned edx:eax = eax * reg (32-bit)
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-_start:
     # ----- Test 1: mulq (64-bit, suffixed) -----
     movq $100, %rax
     movq $7, %rbx
@@ -74,37 +51,3 @@ _start:
     movq %r11, %rdx                  # rdx = 1   (test 2 high)
     # rsi = clobbered by mull, but we saved to r12
     # rdi = 4 (from test 4)
-
-    jmp _kraken_capture
-
-# ====== KRAKEN CAPTURE EPILOGUE ======
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_multiply.S
+++ b/asm-tests/test_multiply.S
@@ -5,29 +5,6 @@
 #   rdx:rax = 10 * 20 = 200 (mulq puts result in rdx:rax)
 #   r8 = 5 * 7 = 35 (imulq two-operand form)
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-_start:
     # Test mulq (unsigned multiply, result in rdx:rax)
     movq $10, %rax
     movq $20, %rbx
@@ -46,35 +23,3 @@ _start:
     # Restore rax for output
     movq %rcx, %rax
 
-    jmp _kraken_capture
-
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_shifts.S
+++ b/asm-tests/test_shifts.S
@@ -3,30 +3,6 @@
 #
 # Avoiding shld/shrd and 32-bit variants for now (parser may not support)
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-
-_start:
     # ----- Logical left shift (SHL) -----
     movq $0x00FF00FF00FF00FF, %rax
     shlq $4, %rax                    # rax << 4
@@ -79,36 +55,3 @@ _start:
     rorl $1, %r13d
     # Expected: r13d = 0xC0000000
 
-    jmp _kraken_capture
-
-# ====== KRAKEN CAPTURE EPILOGUE ======
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_single_arg_shift.S
+++ b/asm-tests/test_single_arg_shift.S
@@ -9,29 +9,6 @@
 # Note: The last flag-setting instruction is `addq $0` which sets AF
 # deterministically, avoiding the known AF-undefined issue with shifts.
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-_start:
     # ----- SHR single-arg (implicit $1) -----
     movq $0x8000000000000004, %rax
     shrq %rax                        # rax >>= 1
@@ -87,37 +64,3 @@ _start:
     # The test harness compares all flags including AF. Use addq $0 to reset
     # AF to a known state matching both hardware and Kraken.
     addq $0, %r11
-
-    jmp _kraken_capture
-
-# ====== KRAKEN CAPTURE EPILOGUE ======
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/asm-tests/test_zero_extend.S
+++ b/asm-tests/test_zero_extend.S
@@ -3,30 +3,6 @@
 #
 # Note: movz* require register sources in AT&T syntax, not immediates
 
-.data
-.align 8
-final_rax: .quad 0
-final_rbx: .quad 0
-final_rcx: .quad 0
-final_rdx: .quad 0
-final_rsi: .quad 0
-final_rdi: .quad 0
-final_rsp: .quad 0
-final_rbp: .quad 0
-final_r8: .quad 0
-final_r9: .quad 0
-final_r10: .quad 0
-final_r11: .quad 0
-final_r12: .quad 0
-final_r13: .quad 0
-final_r14: .quad 0
-final_r15: .quad 0
-final_flags: .quad 0
-
-.text
-.globl _start
-
-_start:
     # ----- movzbl with register source -----
     # Load a value into al, then zero-extend to 32/64-bit
     movq $0x00000000000000AB, %rax   # al = 0xAB
@@ -51,37 +27,3 @@ _start:
     movq $0xDEADBEEFDEADBEEF, %r9
     movzbl %r8b, %r9d                # r9 = 0x0000000000000042
     # Expected: r9 = 0x42
-
-    jmp _kraken_capture
-
-# ====== KRAKEN CAPTURE EPILOGUE ======
-_kraken_capture:
-    movq %rax, final_rax(%rip)
-    movq %rbx, final_rbx(%rip)
-    movq %rcx, final_rcx(%rip)
-    movq %rdx, final_rdx(%rip)
-    movq %rsi, final_rsi(%rip)
-    movq %rdi, final_rdi(%rip)
-    movq %rsp, final_rsp(%rip)
-    movq %rbp, final_rbp(%rip)
-    movq %r8,  final_r8(%rip)
-    movq %r9,  final_r9(%rip)
-    movq %r10, final_r10(%rip)
-    movq %r11, final_r11(%rip)
-    movq %r12, final_r12(%rip)
-    movq %r13, final_r13(%rip)
-    movq %r14, final_r14(%rip)
-    movq %r15, final_r15(%rip)
-    pushfq
-    popq %rax
-    movq %rax, final_flags(%rip)
-
-    movq $1, %rax
-    movq $1, %rdi
-    leaq final_rax(%rip), %rsi
-    movq $136, %rdx
-    syscall
-
-    movq $60, %rax
-    xorq %rdi, %rdi
-    syscall

--- a/scripts/run_all_asm_tests.sh
+++ b/scripts/run_all_asm_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run all assembly tests comparing AS execution against Kraken's eval
 # Usage: ./run_all_asm_tests.sh
 
@@ -11,6 +11,15 @@ PASSED=0
 FAILED=0
 FAILED_TESTS=""
 
+declare -A cpu_features
+cpu_features[test_arithmetic]="bmi2 adx"
+
+if [[ $(uname) == "Linux" ]]; then
+  CPUINFO=/proc/cpuinfo
+else
+  CPUINFO=/dev/null
+fi
+
 echo "========================================"
 echo "Kraken Assembly Test Suite"
 echo "========================================"
@@ -19,6 +28,15 @@ echo ""
 for test_file in "$ASM_TESTS_DIR"/test_*.S; do
     name=$(basename "${test_file%.S}")
     echo -n "Running $name... "
+
+    if [[ ${cpu_features[$name]} != "" ]]; then
+      for flag in ${cpu_features[$name]}; do
+        if ! grep -q $flag $CPUINFO; then
+          echo "skipped (missing flag: $flag)"
+          continue 2
+        fi
+      done
+    fi
 
     if "$SCRIPT_DIR/run_asm_test.sh" "$test_file" > /tmp/test_output.txt 2>&1; then
         if grep -q "^PASS" /tmp/test_output.txt; then

--- a/scripts/run_all_asm_tests.sh
+++ b/scripts/run_all_asm_tests.sh
@@ -21,8 +21,7 @@ for test_file in "$ASM_TESTS_DIR"/test_*.S; do
     echo -n "Running $name... "
 
     if "$SCRIPT_DIR/run_asm_test.sh" "$test_file" > /tmp/test_output.txt 2>&1; then
-        result=$(cat /tmp/test_output.txt)
-        if echo "$result" | grep -q "^PASS"; then
+        if grep -q "^PASS" /tmp/test_output.txt; then
             echo "✓"
             PASSED=$((PASSED + 1))
         else

--- a/scripts/run_asm_test.sh
+++ b/scripts/run_asm_test.sh
@@ -78,4 +78,5 @@ fi
   cp "$TMPDIR/output.bin" output.bin
   cp $TMP_ASM_FILE input.S
   echo "Left output.bin and input.S in the working directory to help debug"
+  exit 1
 }

--- a/scripts/run_asm_test.sh
+++ b/scripts/run_asm_test.sh
@@ -38,11 +38,13 @@ if [[ $(uname) == "Darwin" ]]; then
   ASFLAGS="-target x86_64-apple-darwin"
   LDFLAGS="-lSystem -L$(xcode-select -p)/SDKs/MacOSX.sdk/usr/lib"
   STAT=gstat
-  TMP_ASM_FILE="$TMPDIR"/$(basename $ASM_FILE)
-  touch $TMP_ASM_FILE
 else
   STAT=stat
 fi
+
+# Assemble the assembly
+TMP_ASM_FILE="$TMPDIR"/$(basename $ASM_FILE)
+touch $TMP_ASM_FILE
 
 PROLOGUE=$KRAKEN_ROOT/asm-tests/prologue-$(uname).S
 EPILOGUE=$KRAKEN_ROOT/asm-tests/epilogue-$(uname).S

--- a/scripts/run_asm_test.sh
+++ b/scripts/run_asm_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run a single assembly test comparing AS execution against Kraken's eval
 # Usage: ./run_asm_test.sh <test.S>
 #
@@ -29,25 +29,51 @@ if [ ! -x "$KRAKENTEST" ]; then
     exit 1
 fi
 
+# Cross-compile on ARM64 Apple
+if [[ $(uname) == "Darwin" ]]; then
+  if ! which gstat &>/dev/null; then
+    echo "Missing gstat; please run `brew install coreutils`"
+    exit 1
+  fi
+  ASFLAGS="-target x86_64-apple-darwin"
+  LDFLAGS="-lSystem -L$(xcode-select -p)/SDKs/MacOSX.sdk/usr/lib"
+  STAT=gstat
+  TMP_ASM_FILE="$TMPDIR"/$(basename $ASM_FILE)
+  touch $TMP_ASM_FILE
+else
+  STAT=stat
+fi
+
+PROLOGUE=$KRAKEN_ROOT/asm-tests/prologue-$(uname).S
+EPILOGUE=$KRAKEN_ROOT/asm-tests/epilogue-$(uname).S
+
+cat $PROLOGUE >> $TMP_ASM_FILE
+cat $ASM_FILE >> $TMP_ASM_FILE
+cat $EPILOGUE >> $TMP_ASM_FILE
+
 # Step 1: Assemble and link
-as -o "$TMPDIR/test.o" "$ASM_FILE" 2>/dev/null || {
-    echo "FAIL: Assembly failed for $ASM_FILE"
+as $ASFLAGS -o "$TMPDIR/test.o" "$TMP_ASM_FILE" || {
+    echo "FAIL: Assembly failed for $TMP_ASM_FILE"
     exit 1
 }
 
-ld -o "$TMPDIR/test" "$TMPDIR/test.o" 2>/dev/null || {
+ld -o "$TMPDIR/test" "$TMPDIR/test.o" $LDFLAGS || {
     echo "FAIL: Linking failed for $ASM_FILE"
     exit 1
 }
 
 # Step 2: Run and capture output (136 bytes: registers + flags)
-"$TMPDIR/test" > "$TMPDIR/output.bin" 2>/dev/null || true
+"$TMPDIR/test" > "$TMPDIR/output.bin"
 
 # Check we got enough output
-if [ ! -f "$TMPDIR/output.bin" ] || [ $(stat -c%s "$TMPDIR/output.bin") -lt 136 ]; then
+if [[ ! -f "$TMPDIR/output.bin" ]] || [[ $($STAT -c%s "$TMPDIR/output.bin") -lt 136 ]]; then
     echo "FAIL: Test execution didn't produce expected output"
     exit 1
 fi
 
 # Step 3: Run krakentest to compare AS vs Kraken
-"$KRAKENTEST" "$ASM_FILE" "$TMPDIR/output.bin"
+"$KRAKENTEST" "$ASM_FILE" "$TMPDIR/output.bin" || {
+  cp "$TMPDIR/output.bin" output.bin
+  cp $TMP_ASM_FILE input.S
+  echo "Left output.bin and input.S in the working directory to help debug"
+}


### PR DESCRIPTION
Prompted by https://github.com/AeneasVerif/kraken/pull/62 I started cleaning up the tests. 
- Add support for working on OSX via emulation
- Share prologue / epilogue in tests rather than copy-paste
- Make krakentest support both _start and _main in its test harness