### PR TITLE
Refactor effectful parse into separate file.

### DIFF
--- a/Kraken.lean
+++ b/Kraken.lean
@@ -9,6 +9,7 @@ For experimental features (SymM tactics), see kraken-experimental/.
 
 import Kraken.Semantics
 import Kraken.Parser
+import Kraken.ParseEffectful
 import Kraken.TestHarness
 import Kraken.Theorems
 import Kraken.Tactics

--- a/Kraken/Examples.lean
+++ b/Kraken/Examples.lean
@@ -9,7 +9,7 @@ For tactics, see Kraken/Tactics.lean.
 -/
 
 import Kraken.Tactics
-import Kraken.Parser
+import Kraken.ParseEffectful
 import Kraken.Eval
 
 open Kraken.Parser

--- a/Kraken/ParseEffectful.lean
+++ b/Kraken/ParseEffectful.lean
@@ -1,0 +1,16 @@
+/-
+Kraken - Effectful Parser Helpers
+
+Provides `parse!`, a panicking wrapper around `Parser.parse`
+for convenient use in `#eval` and `eval%` contexts.
+-/
+
+import Kraken.Parser
+
+open Kraken.Parser
+
+/-- Parse an assembly string, panicking on failure (for use in #eval). -/
+def parse! (input : String) : Program :=
+  match parse input with
+  | .ok prog => prog
+  | .error msg => panic! s!"parse error: {msg}"

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -844,10 +844,4 @@ def parse (input: String): Except String Program := do
   ) ((1 : Nat), [])
   pure lines.reverse.flatten
 
-/-- Parse an assembly string, panicking on failure (for use in #eval). -/
-def parse! (input : String) : Program :=
-  match parse input with
-  | .ok prog => prog
-  | .error msg => panic! s!"parse error: {msg}"
-
 end Kraken.Parser

--- a/Kraken/ParserTests.lean
+++ b/Kraken/ParserTests.lean
@@ -3,7 +3,7 @@
   Uses #guard_msgs to verify parser output against expected results.
 -/
 
-import Kraken.Parser
+import Kraken.ParseEffectful
 
 section Tests
 open Kraken.Parser


### PR DESCRIPTION
This is purely for compatibility with a downstream application that cannot handle lean files that contain effectful definitions with `!`.