### PR TITLE
Remove uses of native_decide

### DIFF
--- a/Kraken/Tactics.lean
+++ b/Kraken/Tactics.lean
@@ -143,4 +143,4 @@ macro_rules
     simp (ground:=True);
     simp [MachineData.set,Reg64s.set,MachineData.setReg,Reg64s.set64,ConstExpr.interp];
     simp (ground:=True)
-       <;> try native_decide)
+       <;> try decide)

--- a/Kraken/Theorems.lean
+++ b/Kraken/Theorems.lean
@@ -7,14 +7,6 @@ Used by tactics and examples for simplification.
 
 import Kraken.Semantics
 
--- Immediate conversion simp lemmas
-@[simp] theorem Int64_toUInt64_zero : Int64.toUInt64 0 = 0 := by native_decide
-@[simp] theorem Int64_toUInt64_one : Int64.toUInt64 1 = 1 := by native_decide
-@[simp] theorem Int64_toUInt64_two : Int64.toUInt64 2 = 2 := by native_decide
-@[simp] theorem Int64_toUInt64_zero_toNat : (Int64.toUInt64 0).toNat = 0 := by native_decide
-@[simp] theorem Int64_toUInt64_one_toNat : (Int64.toUInt64 1).toNat = 1 := by native_decide
-@[simp] theorem Int64_toUInt64_two_toNat : (Int64.toUInt64 2).toNat = 2 := by native_decide
-
 -- UInt64.ofInt (k : Int) ≠ 0 when k is a natural number with k < 2^64 and k ≠ 0
 -- This proof uses only core Lean lemmas (no Batteries/Mathlib)
 theorem UInt64_ofInt_natCast_ne_zero (k : Nat) (h_lt : k < 2^64) (h_ne : k ≠ 0) :

--- a/Kraken/Theorems.lean
+++ b/Kraken/Theorems.lean
@@ -1,8 +1,5 @@
 /-
 Kraken - Helper Theorems
-
-Small helper theorems for working with integer types.
-Used by tactics and examples for simplification.
 -/
 
 import Kraken.Semantics


### PR DESCRIPTION
These require greater trust in the Lean compiler than decide so it is best to avoid these. The uses of it that we had are also not necessary. The theorems proposed for deletion are ones that I added while previously trying to restore examples, but these are so simple that they are likely solvable by other tactics. They will work with regular decide, but I think deleting these is better.