### PR TITLE
Draft: Abstract state

### DIFF
--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -48,6 +48,23 @@ def offset {w} (r : Reg w) : Nat := match r with
   | .low _ _ => 0
   | .ah | .bh | .ch | .dh => 8
 
+def size {w} (r : Reg w) : Nat := match r with
+  | .low _ _ => w.bits
+  | .ah | .bh | .ch | .dh => 8
+
+def isL {w} (r : Reg w) : Bool := match r with
+  | .low _ .W8 => true
+  | _ => false
+
+def isH {w} (r : Reg w) : Bool := match r with
+  | .low _ _ => false
+  | .ah | .bh | .ch | .dh => true
+
+/-- Returns true iff the state modified by writing r1
+    is disjoint from the state modified by writing r2 -/
+def disjoint {w1 w2} (r1 : Reg w1) (r2 : Reg w2) : Bool :=
+  r1.base != r2.base || r1.isL && r2.isH || r2.isL && r1.isH
+
 @[match_pattern] abbrev rax := low .rax .W64
 @[match_pattern] abbrev rbx := low .rbx .W64
 @[match_pattern] abbrev rcx := low .rcx .W64
@@ -117,48 +134,70 @@ def offset {w} (r : Reg w) : Nat := match r with
 @[match_pattern] abbrev r15b := low .r15 .W8
 end Reg
 
-inductive Flag
+structure StatusFlags where
+  cf : Bool
+  pf : Bool
+  af : Bool
+  zf : Bool
+  sf : Bool
+  of : Bool
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
+
+inductive StatusFlag
   | cf | pf | af | zf | sf | of
 
--- State modification primitives: get/set/undefine for Reg/Flag/Mem
--- State argument goes last to make the functions compatible with pipeline syntax |>
+/-- State modification primitives: get/set/undefine for Reg/Flag/Mem -/
 class StateAccess σ where
-  getReg {w} (r : Reg w) (s : σ) : w.type
-  setReg {w} (r : Reg w) (v : w.type) (s : σ) : σ
-  undefineReg {w} (r : Reg w) (s : σ) : σ
-  getFlag (f : Flag) (s : σ) : Bool
-  setFlag (f : Flag) {w : Width} (v : Bool) (s : σ) : σ
-  undefineFlag (f : Flag) {w : Width} (s : σ) : σ
-  getMem (addr : BitVec 64) (w : Width) {α} (ret : w.type → α) (s : σ) : α
-  setMem (addr : BitVec 64) {w : Width} (v : w.type) {α} (ret : σ → α) (s : σ) : α
-  undefineMem (addr : BitVec 64) {w : Width} {α} (ret : σ → α) (s : σ) : α
+  getReg (s : σ) {w} (r : Reg w) : w.type
+  setReg (s : σ) {w} (r : Reg w) (v : w.type) : σ
+  undefineReg (s : σ) {w} (r : Reg w) : σ
+  getFlag (s : σ) (f : StatusFlag) : Bool
+  setFlag (s : σ) (f : StatusFlag) (v : Bool) : σ
+  undefineFlag (s : σ) (f : StatusFlag) {w : Width} : σ
+  getMem (s : σ) (addr : BitVec 64) (w : Width) {α} (ret : w.type → α) : α
+  setMem (s : σ) (addr : BitVec 64) {w : Width} (v : w.type) {α} (ret : σ → α) : α
+  undefineMem (s : σ) (addr : BitVec 64) {w : Width} {α} (ret : σ → α) : α
 
-def getReg {σ} [inst : StateAccess σ] {w} := @inst.getReg w
-def setReg {σ} [inst : StateAccess σ] {w} := @inst.setReg w
-def undefineReg {σ} [inst : StateAccess σ] {w} := @inst.undefineReg w
-def getFlag {σ} [inst : StateAccess σ] := inst.getFlag
-def setFlag {σ} [inst : StateAccess σ] := inst.setFlag
-def undefineFlag {σ} [inst : StateAccess σ] := inst.undefineFlag
-def getMem {σ} [inst : StateAccess σ] := inst.getMem
-def setMem {σ} [inst : StateAccess σ] := inst.setMem
-def undefineMem {σ} [inst : StateAccess σ] := inst.undefineMem
+-- We don't define shorthands to get rid of the StateAccess prefix.
+-- Instead, we use the following shorthands (defined later):
+-- * Reg.interp/.get/.set/.undefine for registers
+-- * Flag.get/.set/.undefine for flags
+-- * load/store for memory
+-- * RegOrMem.interp/.set/.undefine for operands
 
-/- sample usage:
-#check (fun σ (inst: StateAccess σ) (s: σ) => s |>
-  setReg .ah 42 |>
-  setReg .bh 43 |>
-  setMem 123 567 (fun sFinal =>
-    getReg .ah sFinal + getReg .bh sFinal))
--/
+def Reg.get {σ w} [StateAccess σ] (r : Reg w) (s : σ) : w.type :=
+  StateAccess.getReg s r
+
+def Reg.set {σ w} [StateAccess σ] (r : Reg w) (v : w.type) (s : σ) : σ :=
+  StateAccess.setReg s r v
+
+def StatusFlag.get {σ} [StateAccess σ] (f : StatusFlag) (s : σ) : Bool :=
+  StateAccess.getFlag s f
+
+def StatusFlag.set {σ} [StateAccess σ] (f : StatusFlag) (v : Bool) (s : σ) : σ :=
+  StateAccess.setFlag s f v
+
+def StatusFlags.set {σ} [StateAccess σ] (fs : StatusFlags) (s : σ) : σ :=
+  let { cf, pf, af, zf, sf, of } := fs
+  StatusFlag.cf.set cf $
+  StatusFlag.pf.set pf $
+  StatusFlag.af.set af $
+  StatusFlag.zf.set zf $
+  StatusFlag.sf.set sf $
+  StatusFlag.of.set of $ s
+
+-- TODO which .interp are in CPS vs non-CPS style?
+def Reg.interp {σ α w} [StateAccess σ] (r : Reg w) (s : σ) (ret : w.type → α) :=
+  r.get s |> ret
+
+def load {σ} [inst : StateAccess σ] := inst.getMem
+def store {σ} [inst : StateAccess σ] := inst.setMem
 
 class Throw α where
   throw: String → α
 
 def throw {α} [inst: Throw α] :=
   inst.throw
-
-def Reg.interp {σ α w} [StateAccess σ] (r : Reg w) (s : σ) (ret : w.type → α) :=
-  ret (getReg r s)
 
 abbrev Label := String
 
@@ -210,11 +249,11 @@ def address_size [inst: AddressSize] := inst.address_size
 def AddrExpr.interp [Labels] [address_size : AddressSize] {σ} [StateAccess σ]
     (a : AddrExpr) (s : σ) (p : Std.Rco Int64) :=
   let base := match a.base with
-              | .some (.ofRegW ⟨_, r⟩)  => (getReg r s).toInt
+              | .some (.ofRegW ⟨_, r⟩)  => (r.get s).toInt
               | .some .rip => p.upper.toInt
               | .none => 0
   let idx := match a.idx with
-             | .some ⟨⟨_, r⟩, c⟩ => (getReg r s).toInt * c.bytes
+             | .some ⟨⟨_, r⟩, c⟩ => (r.get s).toInt * c.bytes
              | .none => 0
   BitVec.ofInt address_size.address_size.bits (base + idx + (a.disp.interp p).toInt)
 
@@ -229,14 +268,14 @@ abbrev Dst := RegOrMem
 def RegOrMem.interp {σ α w} [Labels] [AddressSize] [Throw α] [StateAccess σ]
     (o : RegOrMem w) (s : σ) (p : Std.Rco Int64) (ret : w.type → α) :=
   match o with
-  | .Reg r => s |> getReg r |> ret
-  | .mem a => s |> getMem ((a.interp s p).zeroExtend _) w ret
+  | .Reg r => r.get s |> ret
+  | .mem a => load s ((a.interp s p).zeroExtend _) w ret
 
-def setDst {σ α w} [Labels] [AddressSize] [Throw α] [StateAccess σ]
-    (d : Dst w) (v : w.type) (p : Std.Rco Int64) (ret : σ → α) (s : σ) : α :=
+def RegOrMem.set {σ α w} [Labels] [AddressSize] [Throw α] [StateAccess σ]
+    (d : Dst w) (v : w.type) (s : σ) (p : Std.Rco Int64) (ret : σ → α) : α :=
   match d with
-  | .Reg r => s |> setReg r v |> ret
-  | .mem a => s |> setMem ((a.interp s p).zeroExtend _) v ret
+  | .Reg r => r.set v s |> ret
+  | .mem a => store s ((a.interp s p).zeroExtend _) v ret
 
 inductive Operand w | RegOrMem (_ : RegOrMem w) | imm (v : ConstExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
@@ -263,12 +302,12 @@ abbrev CondCode.ae := CondCode.nc
 
 def CondCode.interp {σ} [StateAccess σ] (cc : CondCode) (s : σ) : Bool :=
   match cc with
-  | .z => getFlag .zf s
-  | .nz => !(getFlag .zf s)
-  | .c => getFlag .cf s
-  | .nc => !(getFlag .cf s)
-  | .a => !(getFlag .cf s) && !(getFlag .zf s)
-  | .be => getFlag .cf s || getFlag .zf s
+  | .z => StatusFlag.zf.get s
+  | .nz => ! StatusFlag.zf.get s
+  | .c => StatusFlag.cf.get s
+  | .nc => ! StatusFlag.cf.get s
+  | .a => ! StatusFlag.cf.get s && ! StatusFlag.zf.get s
+  | .be => StatusFlag.cf.get s || StatusFlag.zf.get s
 
 inductive ShiftCountExpr | cl | imm8 (v : ConstExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
@@ -276,7 +315,7 @@ inductive ShiftCountExpr | cl | imm8 (v : ConstExpr)
 def ShiftCountExpr.interp {σ} [Labels] [StateAccess σ]
     (c : ShiftCountExpr) (s : σ) (p : Std.Rco Int64) :=
   match c with
-  | .cl => (getReg .rcx s).take 8
+  | .cl => (Reg.rcx.get s).take 8
   | .imm8 v => (v.interp p).toBitVec.truncate _
 
 def ShiftCountExpr.interpMasked {σ} [Labels] [StateAccess σ]
@@ -290,8 +329,8 @@ def RelRegOrMem.interp {σ α} [Labels] [AddressSize] [Throw α] [StateAccess σ
     (o : RelRegOrMem) (s : σ) (p : Std.Rco Int64) (ret : BitVec 64 → α) :=
   match o with
   | .Rel c => ret (p.upper + c.interp p).toBitVec
-  | .Reg r => s |> getReg r |> ret
-  | .mem a => s |> getMem ((a.interp s p).zeroExtend _) .W64 ret
+  | .Reg r => r.get s |> ret
+  | .mem a => load s ((a.interp s p).zeroExtend _) .W64 ret
 
 inductive Operation (w : Width)
   -- Data movement
@@ -361,55 +400,54 @@ def cpopNatRec_ {w} (x : BitVec w) (pos acc : Nat) : Nat :=
 def cpop_ {w} (x : BitVec w) : BitVec w := BitVec.ofNat w (cpopNatRec_ x w 0)
 end BitVec
 
+def StatusFlags.from_result {w} (result : BitVec w) (f : from_result.Remaining) : StatusFlags :=
+  { pf := (result.truncate 8).cpop_ % 2 == BitVec.zero _
+    zf := result == BitVec.zero _
+    sf := result.msb, cf := f.cf, af := f.af, of := f.of }
+
 set_option maxHeartbeats 1000000
 def Operation.interp {α σ} [Throw α] [Labels] [address_size : AddressSize] [StateAccess σ] {w}
     (i : Operation w) (p : Std.Rco Int64) (s : σ) (next : σ → α) (jmp : Int64 → σ → α) : α :=
   match (generalizing := false) (motive := Operation w → α) i with
-  | .mov dst src => src.interp s p (fun val => s |> setDst dst val p next)
-  | .movsx dst src => src.interp s p (fun val => s |> setDst dst (val.signExtend _) p next)
-  | .movzx dst src => src.interp s p (fun val => s |> setDst dst (val.zeroExtend _) p next)
+  | .mov dst src => src.interp s p (fun val => dst.set val s p next)
+  | .movsx dst src => src.interp s p (fun val => dst.set (val.signExtend _) s p next)
+  | .movzx dst src => src.interp s p (fun val => dst.set (val.zeroExtend _) s p next)
   | .push src =>
     src.interp s p (fun v =>
-    let rsp := s.regs.get64 .rsp - w.bytesv
-    { s with regs := s.regs.set64 .rsp rsp }.store rsp v next)
+    let rsp := Reg.rsp.get s - w.bytesv
+    store (Reg.rsp.set rsp s) rsp v next)
   | .pop dst =>
-    let rsp := s.regs.get64 .rsp
-    s.load rsp w (fun val =>
-    s.set dst val p (fun s =>
-    next { s with regs := s.regs.set64 .rsp (rsp + w.bytesv) }))
-  | .pop dst =>
-    let rsp := getReg .rsp s; s |>
-    getMem rsp w (fun val => s |>
-    setDst dst val p (fun s => s |>
-    setReg .rsp (rsp + w.bytesv) |>
-    next))
+    let rsp := Reg.rsp.get s
+    load s rsp w (fun val =>
+    dst.set val s p (fun s =>
+    Reg.rsp.set (rsp + w.bytesv) s |> next))
   | .setcc cc dst =>
-    s.set dst (cc.interp s.status) p next
+    dst.set (cc.interp s) s p next
   | .cmovcc cc dst src =>
     src.interp s p (fun src =>
-    let v := if cc.interp s.status then src else s.regs.get dst
-    next (s.setReg dst v))
+    let v := if cc.interp s then src else dst.get s
+    dst.set v s |> next)
 -- Arithmetic
-  | .lea dst src => next (s.setReg dst ((src.interp s.regs p).zeroExtend _))
+  | .lea dst src => dst.set ((src.interp s p).zeroExtend _) s |> next
   | .add dst src =>
     src.interp s p (fun a =>
     dst.interp s p (fun b =>
     let v := a + b
-    let status := .from_result v {
+    let status := StatusFlags.from_result v {
       cf := v.toNat != a.toNat + b.toNat
       af := (v.truncate 4).toNat != (a.truncate 4).toNat + (b.truncate 4).toNat,
       of := v.toInt != a.toInt + b.toInt }
-    { s with status }.set dst v p next))
+    dst.set v (status.set s) p next))
   | .adc dst src =>
     src.interp s p (fun a =>
     dst.interp s p (fun b =>
-    let c := s.status.cf
-    let v := a + b + s.status.cf + c
-    let status := .from_result v {
+    let c := StatusFlag.cf.get s
+    let v := a + b + c
+    let status := StatusFlags.from_result v {
       cf := v.toNat != a.toNat + b.toNat + c
       af := (v.truncate 4).toNat != (a.truncate 4).toNat + (b.truncate 4).toNat + c,
       of := v.toInt != a.toInt + b.toInt + c }
-    { s with status }.set dst v p next))
+    dst.set v (status.set s) p next))
   | .adcx dst src =>
     src.interp s p (fun a =>
     dst.interp s p (fun b =>

--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -47,72 +47,109 @@ def base {w} (r : Reg w) : Reg64 := match r with
 def offset {w} (r : Reg w) : Nat := match r with
   | .low _ _ => 0
   | .ah | .bh | .ch | .dh => 8
+
+@[match_pattern] abbrev rax := low .rax .W64
+@[match_pattern] abbrev rbx := low .rbx .W64
+@[match_pattern] abbrev rcx := low .rcx .W64
+@[match_pattern] abbrev rdx := low .rdx .W64
+@[match_pattern] abbrev rsi := low .rsi .W64
+@[match_pattern] abbrev rdi := low .rdi .W64
+@[match_pattern] abbrev rsp := low .rsp .W64
+@[match_pattern] abbrev rbp := low .rbp .W64
+@[match_pattern] abbrev r8  := low .r8  .W64
+@[match_pattern] abbrev r9  := low .r9  .W64
+@[match_pattern] abbrev r10 := low .r10 .W64
+@[match_pattern] abbrev r11 := low .r11 .W64
+@[match_pattern] abbrev r12 := low .r12 .W64
+@[match_pattern] abbrev r13 := low .r13 .W64
+@[match_pattern] abbrev r14 := low .r14 .W64
+@[match_pattern] abbrev r15 := low .r15 .W64
+
+@[match_pattern] abbrev eax  := low .rax .W32
+@[match_pattern] abbrev ebx  := low .rbx .W32
+@[match_pattern] abbrev ecx  := low .rcx .W32
+@[match_pattern] abbrev edx  := low .rdx .W32
+@[match_pattern] abbrev esi  := low .rsi .W32
+@[match_pattern] abbrev edi  := low .rdi .W32
+@[match_pattern] abbrev esp  := low .rsp .W32
+@[match_pattern] abbrev ebp  := low .rbp .W32
+@[match_pattern] abbrev r8d  := low .r8  .W32
+@[match_pattern] abbrev r9d  := low .r9  .W32
+@[match_pattern] abbrev r10d := low .r10 .W32
+@[match_pattern] abbrev r11d := low .r11 .W32
+@[match_pattern] abbrev r12d := low .r12 .W32
+@[match_pattern] abbrev r13d := low .r13 .W32
+@[match_pattern] abbrev r14d := low .r14 .W32
+@[match_pattern] abbrev r15d := low .r15 .W32
+
+@[match_pattern] abbrev ax   := low .rax .W16
+@[match_pattern] abbrev bx   := low .rbx .W16
+@[match_pattern] abbrev cx   := low .rcx .W16
+@[match_pattern] abbrev dx   := low .rdx .W16
+@[match_pattern] abbrev si   := low .rsi .W16
+@[match_pattern] abbrev di   := low .rdi .W16
+@[match_pattern] abbrev sp   := low .rsp .W16
+@[match_pattern] abbrev bp   := low .rbp .W16
+@[match_pattern] abbrev r8w  := low .r8  .W16
+@[match_pattern] abbrev r9w  := low .r9  .W16
+@[match_pattern] abbrev r10w := low .r10 .W16
+@[match_pattern] abbrev r11w := low .r11 .W16
+@[match_pattern] abbrev r12w := low .r12 .W16
+@[match_pattern] abbrev r13w := low .r13 .W16
+@[match_pattern] abbrev r14w := low .r14 .W16
+@[match_pattern] abbrev r15w := low .r15 .W16
+
+@[match_pattern] abbrev al   := low .rax .W8
+@[match_pattern] abbrev bl   := low .rbx .W8
+@[match_pattern] abbrev cl   := low .rcx .W8
+@[match_pattern] abbrev dl   := low .rdx .W8
+@[match_pattern] abbrev sil  := low .rsi .W8
+@[match_pattern] abbrev dil  := low .rdi .W8
+@[match_pattern] abbrev spl  := low .rsp .W8
+@[match_pattern] abbrev bpl  := low .rbp .W8
+@[match_pattern] abbrev r8b  := low .r8  .W8
+@[match_pattern] abbrev r9b  := low .r9  .W8
+@[match_pattern] abbrev r10b := low .r10 .W8
+@[match_pattern] abbrev r11b := low .r11 .W8
+@[match_pattern] abbrev r12b := low .r12 .W8
+@[match_pattern] abbrev r13b := low .r13 .W8
+@[match_pattern] abbrev r14b := low .r14 .W8
+@[match_pattern] abbrev r15b := low .r15 .W8
 end Reg
 
-structure Reg64s where
-  rax : UInt64 := 0
-  rbx : UInt64 := 0
-  rcx : UInt64 := 0
-  rdx : UInt64 := 0
-  rsi : UInt64 := 0
-  rdi : UInt64 := 0
-  rsp : UInt64 := 0
-  rbp : UInt64 := 0
-  r8  : UInt64 := 0
-  r9  : UInt64 := 0
-  r10 : UInt64 := 0
-  r11 : UInt64 := 0
-  r12 : UInt64 := 0
-  r13 : UInt64 := 0
-  r14 : UInt64 := 0
-  r15 : UInt64 := 0
-  deriving Repr, BEq, DecidableEq, Hashable, Hashable, Lean.ToExpr
+inductive Flag
+  | cf | pf | af | zf | sf | of
 
-def Reg64s.get64 (s : Reg64s) (r : Reg64) : Width.W64.type := UInt64.toBitVec (match r with
-  | .rax => s.rax | .rbx => s.rbx | .rcx => s.rcx | .rdx => s.rdx
-  | .rsi => s.rsi | .rdi => s.rdi | .rsp => s.rsp | .rbp => s.rbp
-  | .r8  => s.r8  | .r9  => s.r9  | .r10 => s.r10 | .r11 => s.r11
-  | .r12 => s.r12 | .r13 => s.r13 | .r14 => s.r14 | .r15 => s.r15)
+-- State modification primitives: get/set/undefine for Reg/Flag/Mem
+-- State argument goes last to make the functions compatible with pipeline syntax |>
+class StateAccess σ where
+  getReg {w} (r : Reg w) (s : σ) : w.type
+  setReg {w} (r : Reg w) (v : w.type) (s : σ) : σ
+  undefineReg {w} (r : Reg w) (s : σ) : σ
+  getFlag (f : Flag) (s : σ) : Bool
+  setFlag (f : Flag) {w : Width} (v : Bool) (s : σ) : σ
+  undefineFlag (f : Flag) {w : Width} (s : σ) : σ
+  getMem (addr : BitVec 64) (w : Width) {α} (ret : w.type → α) (s : σ) : α
+  setMem (addr : BitVec 64) {w : Width} (v : w.type) {α} (ret : σ → α) (s : σ) : α
+  undefineMem (addr : BitVec 64) {w : Width} {α} (ret : σ → α) (s : σ) : α
 
-def Reg64s.set64 (regs : Reg64s) (r : Reg64) (v : Width.W64.type) : Reg64s :=
-  let  v := UInt64.ofBitVec v
-  match r with
-  | .rax => { regs with rax := v } | .rbx => { regs with rbx := v }
-  | .rcx => { regs with rcx := v } | .rdx => { regs with rdx := v }
-  | .rsi => { regs with rsi := v } | .rdi => { regs with rdi := v }
-  | .rsp => { regs with rsp := v } | .rbp => { regs with rbp := v }
-  | .r8  => { regs with r8  := v } | .r9  => { regs with r9  := v }
-  | .r10 => { regs with r10 := v } | .r11 => { regs with r11 := v }
-  | .r12 => { regs with r12 := v } | .r13 => { regs with r13 := v }
-  | .r14 => { regs with r14 := v } | .r15 => { regs with r15 := v }
+def getReg {σ} [inst : StateAccess σ] {w} := @inst.getReg w
+def setReg {σ} [inst : StateAccess σ] {w} := @inst.setReg w
+def undefineReg {σ} [inst : StateAccess σ] {w} := @inst.undefineReg w
+def getFlag {σ} [inst : StateAccess σ] := inst.getFlag
+def setFlag {σ} [inst : StateAccess σ] := inst.setFlag
+def undefineFlag {σ} [inst : StateAccess σ] := inst.undefineFlag
+def getMem {σ} [inst : StateAccess σ] := inst.getMem
+def setMem {σ} [inst : StateAccess σ] := inst.setMem
+def undefineMem {σ} [inst : StateAccess σ] := inst.undefineMem
 
-def Reg64s.get (s : Reg64s) {w} (r : Reg w) : w.type :=
-  ((s.get64 r.base).drop r.offset).take w.bits
-  -- BitVec because it may be signed or unsigned depending on context
-
-def Reg64s.set (s : Reg64s) {w} (r : Reg w) (v : w.type) : Reg64s := match r with
-  | .low r .W64 => s.set64 r v
-  | .low r .W32 => s.set64 r (v.zeroExtend _)
-  | .low r w => s.set64 r ((s.get64 r).replaceLow v)
-  | .ah | .bh | .ch | .dh => let old := s.get64 r.base;
-    s.set64 r.base (old.replaceLow (BitVec.append v (s.get (.low r.base .W8))))
-
-structure StatusFlags where
-  cf : Bool
-  pf : Bool
-  af : Bool
-  zf : Bool
-  sf : Bool
-  of : Bool
-  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
-
-abbrev DataMem := Std.ExtHashMap UInt64 UInt64 -- 8-byte-aligned acceses only now
-instance : Repr DataMem where reprPrec _ _ := "<opaque memory>"
-structure MachineData where -- does not include code or program position
-  regs : Reg64s := {}
-  status : StatusFlags := .mk false false false false false false
-  dmem : DataMem := ∅
-  deriving Repr, BEq, DecidableEq
+/- sample usage:
+#check (fun σ (inst: StateAccess σ) (s: σ) => s |>
+  setReg .ah 42 |>
+  setReg .bh 43 |>
+  setMem 123 567 (fun sFinal =>
+    getReg .ah sFinal + getReg .bh sFinal))
+-/
 
 class Throw α where
   throw: String → α
@@ -120,18 +157,8 @@ class Throw α where
 def throw {α} [inst: Throw α] :=
   inst.throw
 
-def Reg.interp {α w} (r : Reg w) (s : MachineData) (_ : Std.Rco Int64) (ret : w.type → α) :=
-  ret (s.regs.get r) -- the unused argument is present ^ for uniformity with RegOrMem.interp
-
-def MachineData.load {α} [Throw α] (s : MachineData) (addr : BitVec 64) (w : Width) (ret : w.type → α): α :=
-  if addr % 8 != 0 then throw (s!"Unimplemented: only 8-byte-aligned memory access is supported")
-  else match s.dmem[UInt64.ofBitVec addr]? with
-  | .some v => ret (v.toBitVec.truncate _)
-  | .none => throw (s!"Memory accessed but not mapped (addr={repr addr})")
-
-def MachineData.store {α} [Throw α] (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.type) (ret: MachineData → α) : α :=
-  s.load addr .W64 (fun old =>
-  ret { s with dmem := s.dmem.insert (.ofBitVec addr) (.ofBitVec (old.replaceLow v)) })
+def Reg.interp {σ α w} [StateAccess σ] (r : Reg w) (s : σ) (ret : w.type → α) :=
+  ret (getReg r s)
 
 abbrev Label := String
 
@@ -180,13 +207,14 @@ structure AddrExpr where
 class AddressSize where address_size : Width
 def address_size [inst: AddressSize] := inst.address_size
 
-def AddrExpr.interp [Labels] [address_size : AddressSize] (a : AddrExpr) (s : Reg64s) (p : Std.Rco Int64) :=
+def AddrExpr.interp [Labels] [address_size : AddressSize] {σ} [StateAccess σ]
+    (a : AddrExpr) (s : σ) (p : Std.Rco Int64) :=
   let base := match a.base with
-              | .some (.ofRegW ⟨_, r⟩)  => (s.get r).toInt
+              | .some (.ofRegW ⟨_, r⟩)  => (getReg r s).toInt
               | .some .rip => p.upper.toInt
               | .none => 0
   let idx := match a.idx with
-             | .some ⟨⟨_, r⟩, c⟩ => (s.get r).toInt * c.bytes
+             | .some ⟨⟨_, r⟩, c⟩ => (getReg r s).toInt * c.bytes
              | .none => 0
   BitVec.ofInt address_size.address_size.bits (base + idx + (a.disp.interp p).toInt)
 
@@ -198,18 +226,17 @@ instance {w} : Coe (Reg w) (RegOrMem w) where coe := RegOrMem.Reg
 attribute [coe] RegOrMem.Reg
 abbrev Dst := RegOrMem
 
-def RegOrMem.interp {α w} [Labels] [AddressSize] [Throw α] (o : RegOrMem w) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → α) :=
+def RegOrMem.interp {σ α w} [Labels] [AddressSize] [Throw α] [StateAccess σ]
+    (o : RegOrMem w) (s : σ) (p : Std.Rco Int64) (ret : w.type → α) :=
   match o with
-  | .Reg r => ret (s.regs.get r)
-  | .mem a => s.load ((a.interp s.regs p).zeroExtend _) w ret
+  | .Reg r => s |> getReg r |> ret
+  | .mem a => s |> getMem ((a.interp s p).zeroExtend _) w ret
 
-def MachineData.setReg (s : MachineData) {w} (r : Reg w) (v : w.type) : MachineData :=
-  { s with regs := s.regs.set r v }
-
-def MachineData.set {α w} [Labels] [AddressSize] [Throw α] (s : MachineData) (d : Dst w) (v : w.type) (p : Std.Rco Int64) (ret : MachineData → α) : α :=
+def setDst {σ α w} [Labels] [AddressSize] [Throw α] [StateAccess σ]
+    (d : Dst w) (v : w.type) (p : Std.Rco Int64) (ret : σ → α) (s : σ) : α :=
   match d with
-  | .Reg r => ret (s.setReg r v)
-  | .mem a => s.store ((a.interp s.regs p).zeroExtend _) v ret
+  | .Reg r => s |> setReg r v |> ret
+  | .mem a => s |> setMem ((a.interp s p).zeroExtend _) v ret
 
 inductive Operand w | RegOrMem (_ : RegOrMem w) | imm (v : ConstExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
@@ -220,7 +247,8 @@ attribute [coe] Operand.imm
 abbrev Operand.reg {w} (r : Reg w) : Operand w := .RegOrMem (.Reg r)
 abbrev Operand.mem {w} (m : AddrExpr) : Operand w := .RegOrMem (.mem m)
 
-def Operand.interp {α w} [Labels] [AddressSize] [Throw α] (o : Operand w) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → α) :=
+def Operand.interp {σ α w} [Labels] [AddressSize] [Throw α] [StateAccess σ]
+    (o : Operand w) (s : σ) (p : Std.Rco Int64) (ret : w.type → α) :=
   match o with
   | .RegOrMem rm => rm.interp s p ret
   | .imm v => ret ((v.interp p).toBitVec.truncate _)
@@ -233,27 +261,37 @@ abbrev CondCode.ne := CondCode.nz
 abbrev CondCode.b := CondCode.c
 abbrev CondCode.ae := CondCode.nc
 
-def CondCode.interp (cc : CondCode) (s : StatusFlags) : Bool := match cc with
-  | .z  => s.zf | .nz => !s.zf | .c  => s.cf | .nc => !s.cf
-  | .a  => !s.cf && !s.zf | .be => s.cf || s.zf
+def CondCode.interp {σ} [StateAccess σ] (cc : CondCode) (s : σ) : Bool :=
+  match cc with
+  | .z => getFlag .zf s
+  | .nz => !(getFlag .zf s)
+  | .c => getFlag .cf s
+  | .nc => !(getFlag .cf s)
+  | .a => !(getFlag .cf s) && !(getFlag .zf s)
+  | .be => getFlag .cf s || getFlag .zf s
 
 inductive ShiftCountExpr | cl | imm8 (v : ConstExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
-def ShiftCountExpr.interp [Labels] (c : ShiftCountExpr) (s : MachineData) (p : Std.Rco Int64) := match c with
-  | .cl => s.regs.rcx.toBitVec.take 8
+def ShiftCountExpr.interp {σ} [Labels] [StateAccess σ]
+    (c : ShiftCountExpr) (s : σ) (p : Std.Rco Int64) :=
+  match c with
+  | .cl => (getReg .rcx s).take 8
   | .imm8 v => (v.interp p).toBitVec.truncate _
-def ShiftCountExpr.interpMasked [Labels] (c : ShiftCountExpr) (s : MachineData) (p : Std.Rco Int64) (w : Width) : Nat :=
+
+def ShiftCountExpr.interpMasked {σ} [Labels] [StateAccess σ]
+    (c : ShiftCountExpr) (s : σ) (p : Std.Rco Int64) (w : Width) : Nat :=
   (c.interp s p).toNat &&& match w with | .W64 => 0x1f | _ => 0x0f -- "masked to 5 bits (or 6 bits with a 64-bit operand)"
 
 inductive RelRegOrMem | Rel (_ : ConstExpr) | Reg (r : Reg .W64) | mem (_ : AddrExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
-def RelRegOrMem.interp {α} [Labels] [AddressSize] [Throw α] (o : RelRegOrMem) (s : MachineData) (p : Std.Rco Int64) (ret : BitVec 64 → α) :=
+def RelRegOrMem.interp {σ α} [Labels] [AddressSize] [Throw α] [StateAccess σ]
+    (o : RelRegOrMem) (s : σ) (p : Std.Rco Int64) (ret : BitVec 64 → α) :=
   match o with
   | .Rel c => ret (p.upper + c.interp p).toBitVec
-  | .Reg r => ret (s.regs.get r)
-  | .mem a => s.load ((a.interp s.regs p).zeroExtend _) .W64 ret
+  | .Reg r => s |> getReg r |> ret
+  | .mem a => s |> getMem ((a.interp s p).zeroExtend _) .W64 ret
 
 inductive Operation (w : Width)
   -- Data movement
@@ -323,22 +361,13 @@ def cpopNatRec_ {w} (x : BitVec w) (pos acc : Nat) : Nat :=
 def cpop_ {w} (x : BitVec w) : BitVec w := BitVec.ofNat w (cpopNatRec_ x w 0)
 end BitVec
 
-def StatusFlags.from_result {w} (result : BitVec w) (f : from_result.Remaining) : StatusFlags :=
-  { pf := (result.truncate 8).cpop_ % 2 == BitVec.zero _
-    zf := result == BitVec.zero _
-    sf := result.msb, cf := f.cf, af := f.af, of := f.of }
-
-class Undefined (T R) where undefined : (T → R) → R
-def undefined {T R} [inst: Undefined T R] := inst.undefined
-
 set_option maxHeartbeats 1000000
-def Operation.interp {α} [∀ w : Width, Undefined w.type α] [Undefined StatusFlags α] [Undefined Bool α] [Throw α]
-  [Labels] [address_size : AddressSize] {w} (i : Operation w) (p : Std.Rco Int64) (s : MachineData)
-  (next : MachineData → α) (jmp : Int64 → MachineData → α) : α :=
+def Operation.interp {α σ} [Throw α] [Labels] [address_size : AddressSize] [StateAccess σ] {w}
+    (i : Operation w) (p : Std.Rco Int64) (s : σ) (next : σ → α) (jmp : Int64 → σ → α) : α :=
   match (generalizing := false) (motive := Operation w → α) i with
-  | .mov dst src => src.interp s p (fun val => s.set dst val p next)
-  | .movsx dst src => src.interp s p (fun val => s.set dst (val.signExtend _) p next)
-  | .movzx dst src => src.interp s p (fun val => s.set dst (val.zeroExtend _) p next)
+  | .mov dst src => src.interp s p (fun val => s |> setDst dst val p next)
+  | .movsx dst src => src.interp s p (fun val => s |> setDst dst (val.signExtend _) p next)
+  | .movzx dst src => src.interp s p (fun val => s |> setDst dst (val.zeroExtend _) p next)
   | .push src =>
     src.interp s p (fun v =>
     let rsp := s.regs.get64 .rsp - w.bytesv
@@ -348,6 +377,12 @@ def Operation.interp {α} [∀ w : Width, Undefined w.type α] [Undefined Status
     s.load rsp w (fun val =>
     s.set dst val p (fun s =>
     next { s with regs := s.regs.set64 .rsp (rsp + w.bytesv) }))
+  | .pop dst =>
+    let rsp := getReg .rsp s; s |>
+    getMem rsp w (fun val => s |>
+    setDst dst val p (fun s => s |>
+    setReg .rsp (rsp + w.bytesv) |>
+    next))
   | .setcc cc dst =>
     s.set dst (cc.interp s.status) p next
   | .cmovcc cc dst src =>
@@ -726,73 +761,3 @@ abbrev eval [layout : Layout] (prog : Program) := (layout prog).eval
   let start := exe.labels.label "main"
   let data := { dmem := .ofList [(0x100, 0x1337)], regs := {rsp := 0x100} }
   (exe.eval (data, start) (fun (_, pc) => pc = 0x1337)).bind (fun s => .ok s.1.regs.rax)
-
-namespace Reg
-@[match_pattern] abbrev rax := low .rax .W64
-@[match_pattern] abbrev rbx := low .rbx .W64
-@[match_pattern] abbrev rcx := low .rcx .W64
-@[match_pattern] abbrev rdx := low .rdx .W64
-@[match_pattern] abbrev rsi := low .rsi .W64
-@[match_pattern] abbrev rdi := low .rdi .W64
-@[match_pattern] abbrev rsp := low .rsp .W64
-@[match_pattern] abbrev rbp := low .rbp .W64
-@[match_pattern] abbrev r8  := low .r8  .W64
-@[match_pattern] abbrev r9  := low .r9  .W64
-@[match_pattern] abbrev r10 := low .r10 .W64
-@[match_pattern] abbrev r11 := low .r11 .W64
-@[match_pattern] abbrev r12 := low .r12 .W64
-@[match_pattern] abbrev r13 := low .r13 .W64
-@[match_pattern] abbrev r14 := low .r14 .W64
-@[match_pattern] abbrev r15 := low .r15 .W64
-
-@[match_pattern] abbrev eax  := low .rax .W32
-@[match_pattern] abbrev ebx  := low .rbx .W32
-@[match_pattern] abbrev ecx  := low .rcx .W32
-@[match_pattern] abbrev edx  := low .rdx .W32
-@[match_pattern] abbrev esi  := low .rsi .W32
-@[match_pattern] abbrev edi  := low .rdi .W32
-@[match_pattern] abbrev esp  := low .rsp .W32
-@[match_pattern] abbrev ebp  := low .rbp .W32
-@[match_pattern] abbrev r8d  := low .r8  .W32
-@[match_pattern] abbrev r9d  := low .r9  .W32
-@[match_pattern] abbrev r10d := low .r10 .W32
-@[match_pattern] abbrev r11d := low .r11 .W32
-@[match_pattern] abbrev r12d := low .r12 .W32
-@[match_pattern] abbrev r13d := low .r13 .W32
-@[match_pattern] abbrev r14d := low .r14 .W32
-@[match_pattern] abbrev r15d := low .r15 .W32
-
-@[match_pattern] abbrev ax   := low .rax .W16
-@[match_pattern] abbrev bx   := low .rbx .W16
-@[match_pattern] abbrev cx   := low .rcx .W16
-@[match_pattern] abbrev dx   := low .rdx .W16
-@[match_pattern] abbrev si   := low .rsi .W16
-@[match_pattern] abbrev di   := low .rdi .W16
-@[match_pattern] abbrev sp   := low .rsp .W16
-@[match_pattern] abbrev bp   := low .rbp .W16
-@[match_pattern] abbrev r8w  := low .r8  .W16
-@[match_pattern] abbrev r9w  := low .r9  .W16
-@[match_pattern] abbrev r10w := low .r10 .W16
-@[match_pattern] abbrev r11w := low .r11 .W16
-@[match_pattern] abbrev r12w := low .r12 .W16
-@[match_pattern] abbrev r13w := low .r13 .W16
-@[match_pattern] abbrev r14w := low .r14 .W16
-@[match_pattern] abbrev r15w := low .r15 .W16
-
-@[match_pattern] abbrev al   := low .rax .W8
-@[match_pattern] abbrev bl   := low .rbx .W8
-@[match_pattern] abbrev cl   := low .rcx .W8
-@[match_pattern] abbrev dl   := low .rdx .W8
-@[match_pattern] abbrev sil  := low .rsi .W8
-@[match_pattern] abbrev dil  := low .rdi .W8
-@[match_pattern] abbrev spl  := low .rsp .W8
-@[match_pattern] abbrev bpl  := low .rbp .W8
-@[match_pattern] abbrev r8b  := low .r8  .W8
-@[match_pattern] abbrev r9b  := low .r9  .W8
-@[match_pattern] abbrev r10b := low .r10 .W8
-@[match_pattern] abbrev r11b := low .r11 .W8
-@[match_pattern] abbrev r12b := low .r12 .W8
-@[match_pattern] abbrev r13b := low .r13 .W8
-@[match_pattern] abbrev r14b := low .r14 .W8
-@[match_pattern] abbrev r15b := low .r15 .W8
-end Reg

--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -153,7 +153,7 @@ class StateAccess σ where
   undefineReg (s : σ) {w} (r : Reg w) : σ
   getFlag (s : σ) (f : StatusFlag) : Bool
   setFlag (s : σ) (f : StatusFlag) (v : Bool) : σ
-  undefineFlag (s : σ) (f : StatusFlag) {w : Width} : σ
+  undefineFlag (s : σ) (f : StatusFlag) : σ
   getMem (s : σ) (addr : BitVec 64) (w : Width) {α} (ret : w.type → α) : α
   setMem (s : σ) (addr : BitVec 64) {w : Width} (v : w.type) {α} (ret : σ → α) : α
   undefineMem (s : σ) (addr : BitVec 64) {w : Width} {α} (ret : σ → α) : α
@@ -177,7 +177,10 @@ def StatusFlag.get {σ} [StateAccess σ] (f : StatusFlag) (s : σ) : Bool :=
 def StatusFlag.set {σ} [StateAccess σ] (f : StatusFlag) (v : Bool) (s : σ) : σ :=
   StateAccess.setFlag s f v
 
-def StatusFlags.set {σ} [StateAccess σ] (fs : StatusFlags) (s : σ) : σ :=
+def StatusFlag.undefine {σ} [StateAccess σ] (f : StatusFlag) (s : σ) : σ :=
+  StateAccess.undefineFlag s f
+
+def setFlags {σ} [StateAccess σ] (fs : StatusFlags) (s : σ) : σ :=
   let { cf, pf, af, zf, sf, of } := fs
   StatusFlag.cf.set cf $
   StatusFlag.pf.set pf $
@@ -186,9 +189,16 @@ def StatusFlags.set {σ} [StateAccess σ] (fs : StatusFlags) (s : σ) : σ :=
   StatusFlag.sf.set sf $
   StatusFlag.of.set of $ s
 
--- TODO which .interp are in CPS vs non-CPS style?
-def Reg.interp {σ α w} [StateAccess σ] (r : Reg w) (s : σ) (ret : w.type → α) :=
-  r.get s |> ret
+def undefineFlags {σ} [StateAccess σ] (s : σ) : σ :=
+  StatusFlag.cf.undefine $
+  StatusFlag.pf.undefine $
+  StatusFlag.af.undefine $
+  StatusFlag.zf.undefine $
+  StatusFlag.sf.undefine $
+  StatusFlag.of.undefine $ s
+
+def Reg.interp {σ α w} [StateAccess σ] (r : Reg w) (s : σ) (_ : Std.Rco Int64) (ret : w.type → α) :=
+  r.get s |> ret -- the unused argument is for uniformity with RegOrMem.interp
 
 def load {σ} [inst : StateAccess σ] := inst.getMem
 def store {σ} [inst : StateAccess σ] := inst.setMem
@@ -383,6 +393,12 @@ inductive Operation (w : Width)
   | nopalign (alignment : Nat) (pad : Option Nat)
   deriving Repr, DecidableEq, Hashable, Lean.ToExpr
 
+structure StatusFlags.from_result.Defined where
+  pf : Bool
+  zf : Bool
+  sf : Bool
+  deriving Repr, BEq, DecidableEq
+
 structure StatusFlags.from_result.Remaining where
   cf : Bool
   af : Bool
@@ -400,12 +416,23 @@ def cpopNatRec_ {w} (x : BitVec w) (pos acc : Nat) : Nat :=
 def cpop_ {w} (x : BitVec w) : BitVec w := BitVec.ofNat w (cpopNatRec_ x w 0)
 end BitVec
 
-def StatusFlags.from_result {w} (result : BitVec w) (f : from_result.Remaining) : StatusFlags :=
+def StatusFlags.defined_from_result {w} (result : BitVec w) : StatusFlags.from_result.Defined :=
   { pf := (result.truncate 8).cpop_ % 2 == BitVec.zero _
     zf := result == BitVec.zero _
-    sf := result.msb, cf := f.cf, af := f.af, of := f.of }
+    sf := result.msb }
 
-set_option maxHeartbeats 1000000
+-- TODO replace by setFlagsFromResult?
+def StatusFlags.from_result {w} (result : BitVec w) (r : from_result.Remaining) : StatusFlags :=
+  let d := StatusFlags.defined_from_result result
+  { pf := d.pf, zf := d.zf, sf := d.sf, cf := r.cf, af := r.af, of := r.of }
+
+def setFlagsFromResult {σ} [StateAccess σ] {w} (result : BitVec w) (s : σ) : σ :=
+  let { pf, zf, sf } := StatusFlags.defined_from_result result
+  StatusFlag.pf.set pf $
+  StatusFlag.zf.set zf $
+  StatusFlag.sf.set sf $ s
+
+-- set_option maxHeartbeats 1000000
 def Operation.interp {α σ} [Throw α] [Labels] [address_size : AddressSize] [StateAccess σ] {w}
     (i : Operation w) (p : Std.Rco Int64) (s : σ) (next : σ → α) (jmp : Int64 → σ → α) : α :=
   match (generalizing := false) (motive := Operation w → α) i with
@@ -433,49 +460,49 @@ def Operation.interp {α σ} [Throw α] [Labels] [address_size : AddressSize] [S
     src.interp s p (fun a =>
     dst.interp s p (fun b =>
     let v := a + b
-    let status := StatusFlags.from_result v {
+    let status := .from_result v {
       cf := v.toNat != a.toNat + b.toNat
       af := (v.truncate 4).toNat != (a.truncate 4).toNat + (b.truncate 4).toNat,
       of := v.toInt != a.toInt + b.toInt }
-    dst.set v (status.set s) p next))
+    dst.set v (setFlags status s) p next))
   | .adc dst src =>
     src.interp s p (fun a =>
     dst.interp s p (fun b =>
     let c := StatusFlag.cf.get s
     let v := a + b + c
-    let status := StatusFlags.from_result v {
+    let status := .from_result v {
       cf := v.toNat != a.toNat + b.toNat + c
       af := (v.truncate 4).toNat != (a.truncate 4).toNat + (b.truncate 4).toNat + c,
       of := v.toInt != a.toInt + b.toInt + c }
-    dst.set v (status.set s) p next))
+    dst.set v (setFlags status s) p next))
   | .adcx dst src =>
     src.interp s p (fun a =>
     dst.interp s p (fun b =>
-    let v := a + b + s.status.cf
-    let cf := v.toNat != a.toNat + b.toNat + s.status.cf.toNat
-    next { s with regs := s.regs.set dst v, status := { s.status with cf := cf }}))
+    let v := a + b + StatusFlag.cf.get s
+    let cf := v.toNat != a.toNat + b.toNat + (StatusFlag.cf.get s).toNat
+    dst.set v (StatusFlag.cf.set cf s) |> next))
   | .adox dst src =>
     src.interp s p (fun a =>
     dst.interp s p (fun b =>
-    let v := a + b + s.status.of
-    let of := v.toNat != a.toNat + b.toNat + s.status.of.toNat
-    next { s with regs := s.regs.set dst v, status := { s.status with of := of }}))
+    let v := a + b + StatusFlag.of.get s
+    let of := v.toNat != a.toNat + b.toNat + (StatusFlag.of.get s).toNat
+    dst.set v (StatusFlag.of.set of s) |> next))
   | .inc dst =>
     dst.interp s p (fun a =>
     let v := a + 1
     let status := .from_result v {
-      cf := s.status.cf
+      cf := StatusFlag.cf.get s
       af := (v.truncate 4).toNat != (a.truncate 4).toNat + 1,
       of := v.toInt != a.toInt + 1 }
-    { s with status }.set dst v p next)
+    dst.set v (setFlags status s) p next)
   | .dec dst =>
     dst.interp s p (fun a =>
     let v := a - 1
     let status := .from_result v {
-      cf := s.status.cf
+      cf := StatusFlag.cf.get s
       af := (v.truncate 4).toNat != (a.truncate 4).toNat - 1,
       of := v.toInt != a.toInt - 1 }
-    { s with status }.set dst v p next)
+    dst.set v (setFlags status s) p next)
   | .neg dst =>
     dst.interp s p (fun b =>
     let v := -b
@@ -483,7 +510,7 @@ def Operation.interp {α σ} [Throw α] [Labels] [address_size : AddressSize] [S
       cf := b != 0
       af := (b.truncate 4) != 0,
       of := v.toInt != - b.toInt }
-    { s with status }.set dst v p next)
+    dst.set v (setFlags status s) p next)
   | .sub dst src =>
     src.interp s p (fun a =>
     dst.interp s p (fun b =>
@@ -492,17 +519,17 @@ def Operation.interp {α σ} [Throw α] [Labels] [address_size : AddressSize] [S
       cf := v.toNat != b.toNat - a.toNat
       af := (v.truncate 4).toNat != (b.truncate 4).toNat - (a.truncate 4).toNat,
       of := v.toInt != b.toInt - a.toInt }
-    { s with status }.set dst v p next))
+    dst.set v (setFlags status s) p next))
   | .sbb dst src =>
     src.interp s p (fun a =>
     dst.interp s p (fun b =>
-    let c := s.status.cf
+    let c := StatusFlag.cf.get s
     let v := b - a - c
     let status := .from_result v {
       cf := v.toNat != b.toNat - a.toNat - c.toNat
       af := (v.truncate 4).toNat != (b.truncate 4).toNat - (a.truncate 4).toNat - c.toNat,
       of := v.toInt != b.toInt - a.toInt - c.toInt }
-    { s with status }.set dst v p next))
+    dst.set v (setFlags status s) p next))
   | .cmp a b =>
     a.interp s p (fun a =>
     b.interp s p (fun b =>
@@ -511,107 +538,111 @@ def Operation.interp {α σ} [Throw α] [Labels] [address_size : AddressSize] [S
       cf := v.toNat != b.toNat - a.toNat
       af := (v.truncate 4).toNat != (b.truncate 4).toNat - (a.truncate 4).toNat,
       of := v.toInt != b.toInt - a.toInt }
-    next { s with status }))
+    setFlags status s |> next))
   | .mul src =>
-    let a := s.regs.get (Reg.low .rax w)
+    let a := (Reg.low .rax w).get s
     src.interp s p (fun b =>
     let v := a * b
     let vn := a.toNat * b.toNat
     let s := if w == .W8
-      then s.setReg (.low .rax .W16) (.ofNat _ vn)
-      else (s.setReg (.low .rax w) v).setReg (.low .rdx w) (.ofNat _ (vn >>> w.bits))
-    undefined (λ sf => undefined (λ zf => undefined (λ af => undefined (λ pf =>
-    next { s with status := { cf := v.toNat != vn, pf, af, zf, sf, of := v.toNat != vn }})))))
+      then (Reg.low .rax .W16).set (.ofNat _ vn) s
+      else (Reg.low .rdx w).set (.ofNat _ (vn >>> w.bits)) ((Reg.low .rax w).set v s)
+    StatusFlag.cf.set (v.toNat != vn) (StatusFlag.of.set (v.toNat != vn) (undefineFlags s)) |> next)
   | .mulx r_hi r_lo src1 =>
     src1.interp s p (fun a =>
-    let b := s.regs.get (.low .rdx w)
+    let b := (Reg.low .rdx w).get s
     let v := a.toNat * b.toNat
-    let s := s.setReg r_lo (.ofNat _ v) -- if r_hi = r_li, hi is written:
-    let s := s.setReg r_hi (.ofNat _ (v >>> w.bits))
+    let s := r_lo.set (.ofNat _ v) s -- if r_hi = r_li, hi is written:
+    let s := r_hi.set (.ofNat _ (v >>> w.bits)) s
     next s)
   | .imul dst src1 src2 =>
     src1.interp s p (fun a =>
     src2.interp s p (fun b =>
     let v := a * b
-    s.set (match (generalizing := false) (motive := Option (RegOrMem w) → RegOrMem w)
-             dst with | .some dst => dst | _ => src1) v p (fun s =>
+    (match (generalizing := false) (motive := Option (RegOrMem w) → RegOrMem w)
+             dst with | .some dst => dst | _ => src1).set v s p (fun s =>
     let cf := v.toInt != a.toInt * b.toInt
-    undefined (λ sf => undefined (λ zf => undefined (λ af => undefined (λ pf =>
-    next { s with status := { cf := cf, pf, af, zf, sf, of := cf }})))))))
+    StatusFlag.cf.set cf (StatusFlag.of.set cf (undefineFlags s)) |> next)))
 -- Bitwise
   | .test a b =>
     a.interp s p (fun a =>
     b.interp s p (fun b =>
     let v := a &&& b
-    undefined (fun af =>
-    let status := .from_result v { cf := false, af, of := false}
-    next { s with status})))
+    setFlagsFromResult v s |>
+    StatusFlag.cf.set false |>
+    StatusFlag.of.set false |>
+    StatusFlag.af.undefine |> next))
   | .and dst src | .or dst src | .xor dst src =>
     dst.interp s p (fun a =>
     src.interp s p (fun b =>
     let v := match i with | .and _ _ => a &&& b | .or _ _ => a ||| b | _ => a ^^^ b
-    undefined (fun af =>
-    let status := .from_result v { cf := false, of := false, af }
-    { s with status }.set dst v p next)))
+    let s := setFlagsFromResult v s |>
+      StatusFlag.cf.set false |>
+      StatusFlag.of.set false |>
+      StatusFlag.af.undefine
+    dst.set v s p next))
   | .shl dst count =>
     dst.interp s p (fun a =>
     let count := count.interpMasked s p w
     if count == 0 then next s else
     let v := a <<< count
-    undefined (λ af =>
-    (λ setcf => if count < w.bits then setcf (a <<< (count-1)).msb else undefined setcf) (λ cf =>
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
-    { s with status := .from_result v { s.status with cf, af, of } }.set dst v p next))))
+    let s := setFlagsFromResult v s |>
+      (if count < w.bits then StatusFlag.cf.set (a <<< (count-1)).msb else StatusFlag.cf.undefine) |>
+      (if count == 1 then StatusFlag.of.set (v.msb != a.msb) else StatusFlag.of.undefine) |>
+      StatusFlag.af.undefine
+    dst.set v s p next)
   | .shr dst count =>
     dst.interp s p (fun a =>
     let count := count.interpMasked s p w
     if count == 0 then next s else
     let v := a.ushiftRight count
-    undefined (λ af =>
-    (λ setcf => if count < w.bits then setcf (a.getLsbD (count-1)) else undefined setcf) (λ cf =>
-    (λ setof => if count == 1 then setof a.msb else undefined setof) (λ of =>
-    { s with status := .from_result v { s.status with cf, af, of } }.set dst v p next))))
+    let s := setFlagsFromResult v s |>
+      (if count < w.bits then StatusFlag.cf.set (a.getLsbD (count-1)) else StatusFlag.cf.undefine) |>
+      (if count == 1 then StatusFlag.of.set a.msb else StatusFlag.of.undefine) |>
+      StatusFlag.af.undefine
+    dst.set v s p next)
   | .sar dst count =>
     dst.interp s p (fun a =>
     let count := count.interpMasked s p w
     if count == 0 then next s else
     let v := a.sshiftRight count
-    undefined (λ af =>
-    (λ setcf => if count < w.bits then setcf (a.getLsbD (count-1)) else undefined setcf) (λ cf =>
-    (λ setof => if count == 1 then setof false else undefined setof) (λ of =>
-    { s with status := .from_result v { s.status with cf, af, of } }.set dst v p next))))
+    let s := setFlagsFromResult v s |>
+      (if count < w.bits then StatusFlag.cf.set (a.getLsbD (count-1)) else StatusFlag.cf.undefine) |>
+      (if count == 1 then StatusFlag.of.set false else StatusFlag.of.undefine) |>
+      StatusFlag.af.undefine
+    dst.set v s p next)
   | .shrd dst src count =>
     dst.interp s p (fun a =>
     src.interp s p (fun b =>
     let count := count.interpMasked s p w
     if count == 0 then next s else
     let v := (((b.append a) >>> count).take w.bits).setWidth _
-    (λ setstatus => if count >= w.bits then undefined setstatus else
-      let cf := a.getLsbD (count-1)
-      undefined (λ af =>
-      (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
-      setstatus (.from_result v { cf, af, of})))) (λ status =>
-    { s with status }.set dst v p next)))
+    let s := if count >= w.bits then undefineFlags s else
+      (setFlagsFromResult v s |>
+       StatusFlag.cf.set (a.getLsbD (count-1)) |>
+       (if count == 1 then StatusFlag.of.set (v.msb != a.msb) else StatusFlag.of.undefine) |>
+       StatusFlag.af.undefine)
+    dst.set v s p next))
   | .shld dst src count =>
     dst.interp s p (fun a =>
     src.interp s p (fun b =>
     let count := count.interpMasked s p w
     if count == 0 then next s else
     let v := (((a.append b) <<< count).drop w.bits).setWidth _
-    (λ setstatus => if count >= w.bits then undefined setstatus else
-      let cf := (a <<< (count-1)).msb
-      undefined (λ af =>
-      (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
-      setstatus (.from_result v { cf, af, of})))) (λ status =>
-    { s with status }.set dst v p next)))
+    let s := if count >= w.bits then undefineFlags s else
+      (setFlagsFromResult v s |>
+       StatusFlag.cf.set (a <<< (count-1)).msb |>
+       (if count == 1 then StatusFlag.of.set (v.msb != a.msb) else StatusFlag.of.undefine) |>
+       StatusFlag.af.undefine)
+    dst.set v s p next))
   | .rol dst count =>
     dst.interp s p (fun a =>
     let count := count.interpMasked s p w
     if count == 0 then next s else
     let v := a.rotateLeft count
-    let cf := v.getLsbD 0
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
-    { s with status := { s.status with cf, of } }.set dst v p next))
+    let s := StatusFlag.cf.set (v.getLsbD 0) s |>
+      (if count == 1 then StatusFlag.of.set (v.msb != a.msb) else StatusFlag.of.undefine)
+    dst.set v s p next)
   | .ror dst count =>
     dst.interp s p (fun a =>
     let count := count.interpMasked s p w
@@ -624,7 +655,7 @@ def Operation.interp {α σ} [Throw α] [Labels] [address_size : AddressSize] [S
     dst.interp s p (fun a =>
     let count := count.interpMasked s p w
     if count == 0 then next s else
-    let t := (BitVec.ofBool s.status.cf ++ a).rotateRight count
+    let t := (BitVec.ofBool (StatusFlag.cf.get s) ++ a).rotateRight count
     let (cf, v) := (t.msb, t.take w.bits)
     (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
     { s with status := { s.status with cf, of } }.set dst v p next))
@@ -632,7 +663,7 @@ def Operation.interp {α σ} [Throw α] [Labels] [address_size : AddressSize] [S
     dst.interp s p (fun a =>
     let count := count.interpMasked s p w
     if count == 0 then next s else
-    let t := (BitVec.ofBool s.status.cf ++ a).rotateLeft count
+    let t := (BitVec.ofBool (StatusFlag.cf.get s) ++ a).rotateLeft count
     let (cf, v) := (t.msb, t.take w.bits)
     (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
     { s with status := { s.status with cf, of } }.set dst v p next))

--- a/Kraken/SemanticsWithRecords.lean
+++ b/Kraken/SemanticsWithRecords.lean
@@ -48,15 +48,6 @@ def Reg64s.set (s : Reg64s) {w} (r : Reg w) (v : w.type) : Reg64s := match r wit
   | .ah | .bh | .ch | .dh => let old := s.get64 r.base;
     s.set64 r.base (old.replaceLow (BitVec.append v (s.get (.low r.base .W8))))
 
-structure StatusFlags where
-  cf : Bool
-  pf : Bool
-  af : Bool
-  zf : Bool
-  sf : Bool
-  of : Bool
-  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
-
 abbrev DataMem := Std.ExtHashMap UInt64 UInt64 -- 8-byte-aligned acceses only now
 instance : Repr DataMem where reprPrec _ _ := "<opaque memory>"
 structure MachineData where -- does not include code or program position
@@ -77,8 +68,3 @@ def MachineData.store {α} [Throw α] (s : MachineData) (addr : BitVec 64) {w : 
 
 def MachineData.setReg (s : MachineData) {w} (r : Reg w) (v : w.type) : MachineData :=
   { s with regs := s.regs.set r v }
-
-def StatusFlags.from_result {w} (result : BitVec w) (f : from_result.Remaining) : StatusFlags :=
-  { pf := (result.truncate 8).cpop_ % 2 == BitVec.zero _
-    zf := result == BitVec.zero _
-    sf := result.msb, cf := f.cf, af := f.af, of := f.of }

--- a/Kraken/SemanticsWithRecords.lean
+++ b/Kraken/SemanticsWithRecords.lean
@@ -1,0 +1,84 @@
+import Kraken.Semantics
+
+structure Reg64s where
+  rax : UInt64 := 0
+  rbx : UInt64 := 0
+  rcx : UInt64 := 0
+  rdx : UInt64 := 0
+  rsi : UInt64 := 0
+  rdi : UInt64 := 0
+  rsp : UInt64 := 0
+  rbp : UInt64 := 0
+  r8  : UInt64 := 0
+  r9  : UInt64 := 0
+  r10 : UInt64 := 0
+  r11 : UInt64 := 0
+  r12 : UInt64 := 0
+  r13 : UInt64 := 0
+  r14 : UInt64 := 0
+  r15 : UInt64 := 0
+  deriving Repr, BEq, DecidableEq, Hashable, Hashable, Lean.ToExpr
+
+def Reg64s.get64 (s : Reg64s) (r : Reg64) : Width.W64.type := UInt64.toBitVec (match r with
+  | .rax => s.rax | .rbx => s.rbx | .rcx => s.rcx | .rdx => s.rdx
+  | .rsi => s.rsi | .rdi => s.rdi | .rsp => s.rsp | .rbp => s.rbp
+  | .r8  => s.r8  | .r9  => s.r9  | .r10 => s.r10 | .r11 => s.r11
+  | .r12 => s.r12 | .r13 => s.r13 | .r14 => s.r14 | .r15 => s.r15)
+
+def Reg64s.set64 (regs : Reg64s) (r : Reg64) (v : Width.W64.type) : Reg64s :=
+  let  v := UInt64.ofBitVec v
+  match r with
+  | .rax => { regs with rax := v } | .rbx => { regs with rbx := v }
+  | .rcx => { regs with rcx := v } | .rdx => { regs with rdx := v }
+  | .rsi => { regs with rsi := v } | .rdi => { regs with rdi := v }
+  | .rsp => { regs with rsp := v } | .rbp => { regs with rbp := v }
+  | .r8  => { regs with r8  := v } | .r9  => { regs with r9  := v }
+  | .r10 => { regs with r10 := v } | .r11 => { regs with r11 := v }
+  | .r12 => { regs with r12 := v } | .r13 => { regs with r13 := v }
+  | .r14 => { regs with r14 := v } | .r15 => { regs with r15 := v }
+
+def Reg64s.get (s : Reg64s) {w} (r : Reg w) : w.type :=
+  ((s.get64 r.base).drop r.offset).take w.bits
+  -- BitVec because it may be signed or unsigned depending on context
+
+def Reg64s.set (s : Reg64s) {w} (r : Reg w) (v : w.type) : Reg64s := match r with
+  | .low r .W64 => s.set64 r v
+  | .low r .W32 => s.set64 r (v.zeroExtend _)
+  | .low r w => s.set64 r ((s.get64 r).replaceLow v)
+  | .ah | .bh | .ch | .dh => let old := s.get64 r.base;
+    s.set64 r.base (old.replaceLow (BitVec.append v (s.get (.low r.base .W8))))
+
+structure StatusFlags where
+  cf : Bool
+  pf : Bool
+  af : Bool
+  zf : Bool
+  sf : Bool
+  of : Bool
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
+
+abbrev DataMem := Std.ExtHashMap UInt64 UInt64 -- 8-byte-aligned acceses only now
+instance : Repr DataMem where reprPrec _ _ := "<opaque memory>"
+structure MachineData where -- does not include code or program position
+  regs : Reg64s := {}
+  status : StatusFlags := .mk false false false false false false
+  dmem : DataMem := ∅
+  deriving Repr, BEq, DecidableEq
+
+def MachineData.load {α} [Throw α] (s : MachineData) (addr : BitVec 64) (w : Width) (ret : w.type → α): α :=
+  if addr % 8 != 0 then throw (s!"Unimplemented: only 8-byte-aligned memory access is supported")
+  else match s.dmem[UInt64.ofBitVec addr]? with
+  | .some v => ret (v.toBitVec.truncate _)
+  | .none => throw (s!"Memory accessed but not mapped (addr={repr addr})")
+
+def MachineData.store {α} [Throw α] (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.type) (ret: MachineData → α) : α :=
+  s.load addr .W64 (fun old =>
+  ret { s with dmem := s.dmem.insert (.ofBitVec addr) (.ofBitVec (old.replaceLow v)) })
+
+def MachineData.setReg (s : MachineData) {w} (r : Reg w) (v : w.type) : MachineData :=
+  { s with regs := s.regs.set r v }
+
+def StatusFlags.from_result {w} (result : BitVec w) (f : from_result.Remaining) : StatusFlags :=
+  { pf := (result.truncate 8).cpop_ % 2 == BitVec.zero _
+    zf := result == BitVec.zero _
+    sf := result.msb, cf := f.cf, af := f.af, of := f.of }


### PR DESCRIPTION
This is my first attempt at sketching how I'd like to abstract over state as proposed in https://github.com/AeneasVerif/kraken/issues/60.

This code does not compile yet. This PR is meant as a request for early feedback on whether I should continue in this direction.

A few notes:
* To make sure getters and setters can still use dot notation, I flipped the order of their first (state) and second (destination or register) argument, because the type of the self (first) argument in dot notation cannot be an abstract type.
* To make sure the execution order is as close as possible to left-to-right, I replaced `next newStateExpression` by `newStateExpression |> next`. The pipeline operator is defined in the Lean standard library and I didn't have to add any import or notation-scope-opening to activate it.
* The `StatusFlags` record could be removed by using setters for the individual flags, but I kept it because it seems to me that the code tries to defend against accidential omission of a flag, and keeping the `StatusFlags` record seems to helps towards that goal, but I'm not sure if it's worth keeping these records.
* Before this PR, all lambdas starting with `(λ setcf => ...)` invoke `setcf` twice, so after a beta reduction, the whole body of `setcf` is duplicated. With this PR, the duplication should be gone, but it now uses a different setter to set specific values than to set an undefined value. I believe it would be best to push the `if` as far down as possible, all the way into the argument of the setter, like `StatusFlag.cf.set (if cond then specificValue else undefinedValue)`. As far as I can tell, neither the code before this PR nor this PR achieves this. If someone comes up with a solution that achieves this using the `Undefined` typeclass instead of `undefineX` methods on `StateAccess`, I'll be happy to accept this as an indicator that my `undefineX` methods on `StateAccess` were a bad idea ;)
* I don't have strong opinions on argument order, naming, and namespacing. I just picked something that looks reasonable to me and leads to code that gets executed (mostly) from left to right. If/once consensus for abstracting over the state has been reached, I'll be happy to fine-tune argument order and naming etc.
