### PR TITLE
Add not, fix partial writes, parser corrections

### DIFF
--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -503,13 +503,13 @@ def parseInstr : Parser Instr := do
   | "imulq" | "imull" | "imulw" | "imulb" =>
     let w ← instrWidth mn
     let src1 ← parseOperandWithType w; parseComma
-    (do
+    (attempt do
       let src2 ← parseRegOrMemWithType w; parseComma
       let dst ← parseRegWithType w
       pure ⟨ .W64, w, .imul (.some dst) src2 src1 ⟩
     ) <|>
     (do
-      let src2 ← parseRegOrMemWithType w; parseComma
+      let src2 ← parseRegOrMemWithType w
       pure ⟨ .W64, w, .imul none src2 src1 ⟩
     )
 
@@ -557,7 +557,7 @@ def parseInstr : Parser Instr := do
     let w_dst ← instrWidth mn
     let c_src ← String.Pos.Raw.get? mn (.mk (mn.length - 2))
     let w_src ← Char.toWidth c_src
-    let src ← parseRegWithType w_src
+    let src ← parseRegWithType w_src; parseComma
     let dst ← parseRegWithType w_dst
     pure ⟨ .W64, w_dst, .movzx dst (.Reg src) ⟩
 
@@ -565,7 +565,7 @@ def parseInstr : Parser Instr := do
     let w_dst ← instrWidth mn
     let c_src ← String.Pos.Raw.get? mn (.mk (mn.length - 2))
     let w_src ← Char.toWidth c_src
-    let src ← parseRegWithType w_src
+    let src ← parseRegWithType w_src; parseComma
     let dst ← parseRegWithType w_dst
     pure ⟨ .W64, w_dst, .movzx dst (.Reg src) ⟩
 
@@ -597,6 +597,16 @@ def parseInstr : Parser Instr := do
   | "andq" | "andl" | "andw" | "andb" =>
     let w ← instrWidth mn
     commaSeparated w parseOperand parseRegOrMem .and
+
+  | "not" =>
+    let dst ← parseRegOrMem
+    let ⟨ w, dst ⟩ ← assertW dst
+    pure ⟨ .W64, w, .not dst ⟩
+
+  | "notq" | "notl" | "notw" | "notb" =>
+    let w ← instrWidth mn
+    let dst ← parseRegOrMemWithType w
+    pure ⟨ .W64, w, .not dst ⟩
 
   | "or" =>
     commaSeparated .none parseOperand parseRegOrMem .or

--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -12,7 +12,7 @@ instance : Coe Bool Nat where coe := Bool.toNat
 def BitVec.take {w} (x : BitVec w) (n : Nat) : BitVec n := x.extractLsb' 0 n
 def BitVec.drop {w} (x : BitVec w) (n : Nat) : BitVec (w - n) := x.extractLsb' n (w-n)
 def BitVec.replaceLow {w n} (old : BitVec w) (new : BitVec n) : BitVec w :=
-  (BitVec.append (old.drop w) new).setWidth _
+  (BitVec.append (old.drop n) new).setWidth _
 
 inductive Width | W8 | W16 | W32 | W64 deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
@@ -123,15 +123,32 @@ def throw {α} [inst: Throw α] :=
 def Reg.interp {α w} (r : Reg w) (s : MachineData) (_ : Std.Rco Int64) (ret : w.type → α) :=
   ret (s.regs.get r) -- the unused argument is present ^ for uniformity with RegOrMem.interp
 
+def MachineData.loadOpt {α} [Throw α] (s : MachineData) (addr : BitVec 64) (ret : Option UInt64 → α): α :=
+  if addr % 8 != 0 then
+    throw (s!"Unimplemented: only 8-byte-aligned memory access is supported")
+  else
+    ret (s.dmem[UInt64.ofBitVec addr]?)
+
 def MachineData.load {α} [Throw α] (s : MachineData) (addr : BitVec 64) (w : Width) (ret : w.type → α): α :=
-  if addr % 8 != 0 then throw (s!"Unimplemented: only 8-byte-aligned memory access is supported")
-  else match s.dmem[UInt64.ofBitVec addr]? with
-  | .some v => ret (v.toBitVec.truncate _)
-  | .none => throw (s!"Memory accessed but not mapped (addr={repr addr})")
+    loadOpt s addr (fun v =>
+    match v with
+    | .some v => ret (v.toBitVec.truncate _)
+    | .none => throw (s!"Memory accessed but not mapped (addr={repr addr})"))
 
 def MachineData.store {α} [Throw α] (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.type) (ret: MachineData → α) : α :=
-  s.load addr .W64 (fun old =>
-  ret { s with dmem := s.dmem.insert (.ofBitVec addr) (.ofBitVec (old.replaceLow v)) })
+    s.loadOpt addr (fun old =>
+    match old with
+    | .some old =>
+      ret { s with dmem := s.dmem.insert (.ofBitVec addr) (.ofBitVec (old.toBitVec.replaceLow v)) }
+    | .none =>
+      if h: w = .W64 then
+        -- We know how to perform full writes even though there is not previous
+        -- value
+        have : w.type = BitVec 64 := by simp [h,Width.type,Width.bits]
+        ret { s with dmem := s.dmem.insert (.ofBitVec addr) (UInt64.ofBitVec (this ▸ v)) }
+      else
+        throw (s!"Cannot perform a partial write at {addr} because there is no previous value")
+  )
 
 abbrev Label := String
 
@@ -283,6 +300,7 @@ inductive Operation (w : Width)
   -- Bitwise
   | test (a : RegOrMem w) (b : Operand w)
   | and  (_ : Dst w) (src : Operand w)
+  | not  (_ : Dst w)
   | or   (_ : Dst w) (src : Operand w)
   | xor  (_ : Dst w) (src : Operand w)
   | shl  (_ : Dst w) (_ : ShiftCountExpr)
@@ -480,6 +498,10 @@ def Operation.interp {α} [∀ w : Width, Undefined w.type α] [Undefined Status
     undefined (fun af =>
     let status := .from_result v { cf := false, of := false, af }
     { s with status }.set dst v p next)))
+  | .not dst =>
+    dst.interp s p (fun a =>
+    let v := ~~~a
+    s.set dst v p next)
   | .shl dst count =>
     dst.interp s p (fun a =>
     let count := count.interpMasked s p w


### PR DESCRIPTION
This is an unchanged copy of the part of https://github.com/AeneasVerif/kraken/pull/65/ that fixed tests. Locally, they are all passing for me now, but as mentioned in the PR there will probably still be some failures in the CI / on other architectures regarding flags that are undefined after the test.

@protz are you happy with these as they are, or would like me to do some changes before merging?