### PR TITLE
Add stack to testing, revert write to undef memory

### DIFF
--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -123,32 +123,15 @@ def throw {α} [inst: Throw α] :=
 def Reg.interp {α w} (r : Reg w) (s : MachineData) (_ : Std.Rco Int64) (ret : w.type → α) :=
   ret (s.regs.get r) -- the unused argument is present ^ for uniformity with RegOrMem.interp
 
-def MachineData.loadOpt {α} [Throw α] (s : MachineData) (addr : BitVec 64) (ret : Option UInt64 → α): α :=
-  if addr % 8 != 0 then
-    throw (s!"Unimplemented: only 8-byte-aligned memory access is supported")
-  else
-    ret (s.dmem[UInt64.ofBitVec addr]?)
-
 def MachineData.load {α} [Throw α] (s : MachineData) (addr : BitVec 64) (w : Width) (ret : w.type → α): α :=
-    loadOpt s addr (fun v =>
-    match v with
-    | .some v => ret (v.toBitVec.truncate _)
-    | .none => throw (s!"Memory accessed but not mapped (addr={repr addr})"))
+  if addr % 8 != 0 then throw (s!"Unimplemented: only 8-byte-aligned memory access is supported")
+  else match s.dmem[UInt64.ofBitVec addr]? with
+  | .some v => ret (v.toBitVec.truncate _)
+  | .none => throw (s!"Memory accessed but not mapped (addr={repr addr})")
 
 def MachineData.store {α} [Throw α] (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.type) (ret: MachineData → α) : α :=
-    s.loadOpt addr (fun old =>
-    match old with
-    | .some old =>
-      ret { s with dmem := s.dmem.insert (.ofBitVec addr) (.ofBitVec (old.toBitVec.replaceLow v)) }
-    | .none =>
-      if h: w = .W64 then
-        -- We know how to perform full writes even though there is not previous
-        -- value
-        have : w.type = BitVec 64 := by simp [h,Width.type,Width.bits]
-        ret { s with dmem := s.dmem.insert (.ofBitVec addr) (UInt64.ofBitVec (this ▸ v)) }
-      else
-        throw (s!"Cannot perform a partial write at {addr} because there is no previous value")
-  )
+  s.load addr .W64 (fun old =>
+  ret { s with dmem := s.dmem.insert (.ofBitVec addr) (.ofBitVec (old.replaceLow v)) })
 
 abbrev Label := String
 

--- a/Kraken/Test/asm/stack/test_push_pop.S
+++ b/Kraken/Test/asm/stack/test_push_pop.S
@@ -1,0 +1,6 @@
+movq $0x1234, %rdi
+push %rdi
+movq $0x4567, %rdi
+push %rdi
+pop %r10
+pop %r8

--- a/Kraken/Test/asm/test_conditionals.S
+++ b/Kraken/Test/asm/test_conditionals.S
@@ -24,12 +24,6 @@ movq $0, %rsi
 setnc %sil                       # sil = 1 (CF not set after last addq)
 # Expected: rsi = 1
 
-# ----- PUSH / POP -----
-movq $0x1234567890ABCDEF, %rdi
-push %rdi
-pop %r8
-# Expected: r8 = 0x1234567890ABCDEF
-
 # Initialize remaining registers
 movq $300, %r9
 movq $400, %r10

--- a/Kraken/Test/asm_tests.py
+++ b/Kraken/Test/asm_tests.py
@@ -150,7 +150,7 @@ if __name__ == "__main__":
         sys.exit(1)
         
     target = Path(sys.argv[1]).resolve()
-    files = sorted(target.glob("*.S")) if target.is_dir() else ([target] if target.exists() else [])
+    files = sorted(target.rglob("*.S")) if target.is_dir() else ([target] if target.exists() else [])
     
     if not files:
         print(f"Error: No .S files found at {target}")

--- a/KrakenRunner.lean
+++ b/KrakenRunner.lean
@@ -19,7 +19,7 @@ import Lean.Data.Json
 
 open Lean
 
--- TODO Add memory, for now we only track registers and flags.
+-- TODO Add memory, for now we only track and compare registers and flags.
 structure StateSummary where
   regs : List (String × UInt64)
   flags : List (String × Bool)
@@ -49,13 +49,18 @@ abbrev MachineState := MachineData × Int64
 def _start: String := "_start"
 def _end: String := "_end"
 
+-- Give the program a stack of 100B initially.
+def stackSize := 100
+def initStack : List (UInt64 × UInt64) :=
+  (List.range stackSize).map (λ i => (0xfffffffffffffff8 - (i.toUInt64 * 8), 0))
+
 def finishCriterion (p: Program) (s: MachineState): Bool :=
   s.2 = p.fakeLayout.labels.label _end
 
 def runKraken (asmCode : String)
     : Except String MachineState := do
   let prog ← Kraken.Parser.parse (_start ++ ":" ++ asmCode ++ "\n" ++ _end ++ ":")
-  let initState: MachineState := ({}, prog.fakeLayout.labels.label _start)
+  let initState: MachineState := ({dmem := .ofList initStack}, prog.fakeLayout.labels.label _start)
   prog.fakeLayout.eval initState (finishCriterion prog)
 
 def main (args : List String) : IO UInt32 := do


### PR DESCRIPTION
Revert the change that allowed writes to memory not already mapped in dmem. As far as I understood the conversation, we consider only memory mapped in dmem accesible to the Program.

For proofs this means if we want to argue about memory that may be uninitialized, we put it in dmem and quantify universally over the content.

For tests we cannot do quantification, but we can just give the program a stack frame (and later also heap space - tbd). For now I added 100B of stack, and separated out the stack part of the test that was failing, as the test was running various unrelated things.

Also add support for subfolders in tests. We have strictly one test per file and we want to write small tests, so we will need subfolders to keep tests in order.