### PR TITLE
refactor: rename inductive constructors to follow the naming convention

### DIFF
--- a/Kraken/Examples.lean
+++ b/Kraken/Examples.lean
@@ -65,11 +65,11 @@ theorem swap_correct [layout : Layout] (d : MachineData) :
 
 -- Stepping demo. Ideally, this demo should be without the first .mov
 def p2 : Program := eval% [
-  .Label "start",
-  .Instr ⟨ .W64, .W64, .mov Reg.rax (.imm (.Int64 1)) ⟩,
-  .Instr ⟨ .W64, .W64, .xor Reg.rax Reg.rax ⟩,
-  .Instr ⟨ .W64, .W64, .jcc .nz "start" ⟩,
-  .Instr ⟨ .W64, .W64, .mov Reg.rax (.imm (.Int64 2)) ⟩,
+  .label "start",
+  .instr ⟨ .W64, .W64, .mov Reg.rax (.imm (.int64 1)) ⟩,
+  .instr ⟨ .W64, .W64, .xor Reg.rax Reg.rax ⟩,
+  .instr ⟨ .W64, .W64, .jcc .nz "start" ⟩,
+  .instr ⟨ .W64, .W64, .mov Reg.rax (.imm (.int64 2)) ⟩,
 ]
 def p2' : Program := eval% parse! "
 start:

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -163,20 +163,20 @@ def parseInt64 : Parser ConstExpr := do
     Int64.ofInt (v - 18446744073709551616)
   else
     Int64.ofInt v
-  pure (.Int64 i64)
+  pure (.int64 i64)
 
 -- parseName allows for dots
 def parseLabelRaw : Parser Label := parseName
 
 def parseLabel : Parser ConstExpr := do
   let n ← parseLabelRaw
-  pure (.Label n)
+  pure (.label n)
 
 /-- Parse a memory operand (a.k.a. "address expression"): disp(%base), (%base,%idx,scale), etc. -/
 def parseMemory : Parser AddrExpr := do
   skipHWs
   -- Optional displacement; TODO: parse ConstExpr generally
-  let disp ← (do let i ← parseInt; pure (.Int64 (Int64.ofInt i))) <|> parseLabel <|> pure (.Int64 0)
+  let disp ← (do let i ← parseInt; pure (.int64 (Int64.ofInt i))) <|> parseLabel <|> pure (.int64 0)
   skipHWs
   let _ ← pchar '('
 
@@ -253,7 +253,7 @@ def parseRegOrMem: Parser (MaybeTyped RegOrMem) := do
   let c ← peek!
   if c == '%' then
     let ⟨ w, r ⟩ ← parseRegW
-    pure ⟨ .some w, (.Reg r) ⟩
+    pure ⟨ .some w, .reg r ⟩
   else if c == '(' || c == '-' || c.isDigit then
     let m ← parseMemory
     pure ⟨ .none, .mem m ⟩
@@ -265,7 +265,7 @@ def parseRelRegOrMem: Parser RelRegOrMem := do
   (do
     let ⟨ w, r ⟩ ← parseRegW
     if h: w = .W64 then
-      pure (.Reg (h ▸ r))
+      pure (.reg (h ▸ r))
     else
       fail "expected a 64-bit register in relative addressing position"
   ) <|> (do
@@ -273,7 +273,7 @@ def parseRelRegOrMem: Parser RelRegOrMem := do
     -- assume that all jumps are relative, in that this seems to be the behavior
     -- of the assembler
     let e ← parseLabel
-    pure (.Rel (.sub e .after_current_instruction))
+    pure (.rel (.sub e .after_current_instruction))
   ) <|> (do
     let m ← parseMemory
     pure (.mem m)
@@ -318,7 +318,7 @@ def parseComma : Parser Unit := do
 
 /-- Try to parse a shift count followed by a comma; if that fails, default to 1. -/
 def parseOptionalShiftAndComma : Parser ShiftCountExpr :=
-  (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.Int64 1))
+  (attempt do let cnt ← parseShiftExpr; parseComma; pure cnt) <|> pure (.imm8 (.int64 1))
 
 def ascribe {T: Width → Type} (w: Width) (v: MaybeTyped T): Parser (T w) := do
   match v with
@@ -545,13 +545,13 @@ def parseInstr : Parser Instr := do
     -- Must be a register otherwise lacking type info
     let ⟨ _w_src, src ⟩ ← parseRegW
     let ⟨ w_dst, dst ⟩ ← parseRegW
-    pure ⟨ .W64, w_dst, .movsx dst (.Reg src) ⟩
+    pure ⟨ .W64, w_dst, .movsx dst (.reg src) ⟩
 
   | "movzx" =>
     -- Must be a register otherwise lacking type info
     let ⟨ _w_src, src ⟩ ← parseRegW
     let ⟨ w_dst, dst ⟩ ← parseRegW
-    pure ⟨ .W64, w_dst, .movzx dst (.Reg src) ⟩
+    pure ⟨ .W64, w_dst, .movzx dst (.reg src) ⟩
 
   | "movsbw" | "movsbl" | "movsbq" | "movswl" | "movswq" =>
     let w_dst ← instrWidth mn
@@ -559,7 +559,7 @@ def parseInstr : Parser Instr := do
     let w_src ← Char.toWidth c_src
     let src ← parseRegWithType w_src; parseComma
     let dst ← parseRegWithType w_dst
-    pure ⟨ .W64, w_dst, .movzx dst (.Reg src) ⟩
+    pure ⟨ .W64, w_dst, .movzx dst (.reg src) ⟩
 
   | "movzbw" | "movzbl" | "movzbq" | "movzwl" | "movzwq" =>
     let w_dst ← instrWidth mn
@@ -567,7 +567,7 @@ def parseInstr : Parser Instr := do
     let w_src ← Char.toWidth c_src
     let src ← parseRegWithType w_src; parseComma
     let dst ← parseRegWithType w_dst
-    pure ⟨ .W64, w_dst, .movzx dst (.Reg src) ⟩
+    pure ⟨ .W64, w_dst, .movzx dst (.reg src) ⟩
 
   | "lea" =>
     let src ← parseMemory; parseComma
@@ -817,7 +817,7 @@ def parseLine : Parser (List Directive) := do
   else
     let label ← (attempt do
       let l ← parseLabelDecl
-      pure (some (Directive.Label l))) <|> pure none
+      pure (some (Directive.label l))) <|> pure none
     skipHWs
     let instr ← (do
       let c ← peek!
@@ -836,10 +836,10 @@ def parseLine : Parser (List Directive) := do
             let pad ← parseHexOrDec
             pure (some pad.toNat)
           ) <|> pure none
-          pure (some (Directive.Instr ⟨ .W64, .W64, .nopalign alignment.toNat pad ⟩))
+          pure (some (Directive.instr ⟨ .W64, .W64, .nopalign alignment.toNat pad ⟩))
         ) <|> (do
           let instr ← parseInstr
-          pure (some (Directive.Instr instr)))
+          pure (some (Directive.instr instr)))
     ) <|> pure none
     match label, instr with
     | some l, some i => pure [l, i]

--- a/Kraken/ParserTests.lean
+++ b/Kraken/ParserTests.lean
@@ -12,7 +12,7 @@ open Instr Operand Reg
 
 -- Test: Simple instruction
 /--
-info: [Directive.Instr
+info: [Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation := Operation.add ↑(low Reg64.rbx Width.W64) ↑↑(low Reg64.rax Width.W64) }]
 -/
@@ -21,7 +21,7 @@ info: [Directive.Instr
 
 -- Test: Immediate operand
 /--
-info: [Directive.Instr
+info: [Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation := Operation.mov ↑(low Reg64.rax Width.W64) ↑↑42 }]
 -/
@@ -31,7 +31,7 @@ info: [Directive.Instr
 
 -- Test: Memory operand with displacement
 /--
-info: [Directive.Instr
+info: [Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation :=
         Operation.mov ↑(low Reg64.rax Width.W64)
@@ -43,7 +43,7 @@ info: [Directive.Instr
 
 -- Test: Memory operand with index and scale
 /--
-info: [Directive.Instr
+info: [Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation :=
         Operation.mov ↑(low Reg64.rax Width.W64)
@@ -56,8 +56,8 @@ info: [Directive.Instr
 
 -- Test: Labeled instruction
 /--
-info: [Directive.Label "loop",
-  Directive.Instr
+info: [Directive.label "loop",
+  Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation := Operation.add ↑(low Reg64.rcx Width.W64) ↑↑1 }]
 -/
@@ -67,7 +67,7 @@ info: [Directive.Label "loop",
 
 -- Test: Conditional jump
 /--
-info: [Directive.Instr
+info: [Directive.instr
     { address_size := Width.W64, operation_size := Width.W64, operation := Operation.jcc CondCode.nz "loop" }]
 -/
 #guard_msgs in
@@ -76,17 +76,17 @@ info: [Directive.Instr
 
 -- Test: Multi-line program
 /--
-info: [Directive.Instr
+info: [Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation := Operation.mov ↑(low Reg64.rax Width.W64) ↑↑0 },
-  Directive.Label "loop",
-  Directive.Instr
+  Directive.label "loop",
+  Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation := Operation.add ↑(low Reg64.rax Width.W64) ↑↑1 },
-  Directive.Instr
+  Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation := Operation.cmp ↑(low Reg64.rax Width.W64) ↑↑10 },
-  Directive.Instr
+  Directive.instr
     { address_size := Width.W64, operation_size := Width.W64, operation := Operation.jcc CondCode.nz "loop" }]
 -/
 #guard_msgs in
@@ -100,7 +100,7 @@ loop:
 
 -- Test: Negative immediate
 /--
-info: [Directive.Instr
+info: [Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation := Operation.add ↑(low Reg64.rax Width.W64) ↑↑(-1) }]
 -/
@@ -109,7 +109,7 @@ info: [Directive.Instr
 
 -- Test: Hex immediate
 /--
-info: [Directive.Instr
+info: [Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation := Operation.mov ↑(low Reg64.rax Width.W64) ↑↑255 }]
 -/
@@ -118,7 +118,7 @@ info: [Directive.Instr
 
 -- Test: mulx instruction
 /--
-info: [Directive.Instr
+info: [Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation := Operation.mulx (low Reg64.r10 Width.W64) (low Reg64.r9 Width.W64) ↑(low Reg64.r8 Width.W64) }]
 -/
@@ -127,7 +127,7 @@ info: [Directive.Instr
 
 -- Test: xor for zeroing
 /--
-info: [Directive.Instr
+info: [Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation := Operation.xor ↑(low Reg64.rax Width.W64) ↑↑(low Reg64.rax Width.W64) }]
 -/
@@ -136,7 +136,7 @@ info: [Directive.Instr
 
 -- Test: lea with complex addressing
 /--
-info: [Directive.Instr
+info: [Directive.instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation :=
         Operation.lea (low Reg64.rax Width.W64)

--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -153,25 +153,25 @@ def MachineData.store {α} [Throw α] (s : MachineData) (addr : BitVec 64) {w : 
 abbrev Label := String
 
 class Labels where label : Label → Int64
-def label [inst: Labels] := inst.label
+export Labels (label)
 
 inductive ConstExpr
-  | Label (_ : Label)
-  | Int64 (_ : Int64)
+  | label (_ : Label)
+  | int64 (_ : Int64)
   | before_current_instruction | after_current_instruction
   | add (_ _ : ConstExpr) | sub (_ _ : ConstExpr)
   -- Careful adding operations here! Need to match overflow behavior of all
   -- assemblers we want compatibility with. We assume oversized literals error;
   -- clang and gcc seem to always use 64-bit arithmetic (MCValue has an int64).
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
-instance : Coe Label ConstExpr where coe := ConstExpr.Label
-instance : Coe Int64 ConstExpr where coe := ConstExpr.Int64
-attribute [coe] ConstExpr.Label
-attribute [coe] ConstExpr.Int64
+instance : Coe Label ConstExpr where coe := .label
+instance : Coe Int64 ConstExpr where coe := .int64
+attribute [coe] ConstExpr.label
+attribute [coe] ConstExpr.int64
 
 def ConstExpr.interp [Labels] : ConstExpr → Std.Rco _root_.Int64 → _root_.Int64
-  | .Label l, _ => label l
-  | .Int64 i, _ => i
+  | .label l, _ => Labels.label l
+  | .int64 i, _ => i
   | .before_current_instruction, r => r.lower
   | .after_current_instruction, r => r.upper
   | .add e1 e2, p => e1.interp p + e2.interp p
@@ -191,7 +191,7 @@ structure AddrIndex where
 structure AddrExpr where
   base : Option RegOrRip
   idx : Option AddrIndex
-  disp : ConstExpr := .Int64 0
+  disp : ConstExpr := .int64 0
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 class AddressSize where address_size : Width
@@ -207,17 +207,17 @@ def AddrExpr.interp [Labels] [address_size : AddressSize] (a : AddrExpr) (s : Re
              | .none => 0
   BitVec.ofInt address_size.address_size.bits (base + idx + (a.disp.interp p).toInt)
 
-inductive RegOrMem w | Reg (r : Reg w) | mem (_ : AddrExpr)
+inductive RegOrMem w | reg (r : Reg w) | mem (_ : AddrExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 instance {w} : Coe AddrExpr (RegOrMem w) where coe := RegOrMem.mem
 attribute [coe] RegOrMem.mem
-instance {w} : Coe (Reg w) (RegOrMem w) where coe := RegOrMem.Reg
-attribute [coe] RegOrMem.Reg
+instance {w} : Coe (Reg w) (RegOrMem w) where coe := .reg
+attribute [coe] RegOrMem.reg
 abbrev Dst := RegOrMem
 
 def RegOrMem.interp {α w} [Labels] [AddressSize] [Throw α] (o : RegOrMem w) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → α) :=
   match o with
-  | .Reg r => ret (s.regs.get r)
+  | .reg r => ret (s.regs.get r)
   | .mem a => s.load ((a.interp s.regs p).zeroExtend _) w ret
 
 def MachineData.setReg (s : MachineData) {w} (r : Reg w) (v : w.type) : MachineData :=
@@ -225,21 +225,21 @@ def MachineData.setReg (s : MachineData) {w} (r : Reg w) (v : w.type) : MachineD
 
 def MachineData.set {α w} [Labels] [AddressSize] [Throw α] (s : MachineData) (d : Dst w) (v : w.type) (p : Std.Rco Int64) (ret : MachineData → α) : α :=
   match d with
-  | .Reg r => ret (s.setReg r v)
+  | .reg r => ret (s.setReg r v)
   | .mem a => s.store ((a.interp s.regs p).zeroExtend _) v ret
 
-inductive Operand w | RegOrMem (_ : RegOrMem w) | imm (v : ConstExpr)
+inductive Operand w | regOrMem (_ : RegOrMem w) | imm (v : ConstExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
-instance {w} : Coe (RegOrMem w) (Operand w) where coe := Operand.RegOrMem
-attribute [coe] Operand.RegOrMem
+instance {w} : Coe (RegOrMem w) (Operand w) where coe := .regOrMem
+attribute [coe] Operand.regOrMem
 instance {w} : Coe ConstExpr (Operand w) where coe := Operand.imm
 attribute [coe] Operand.imm
-abbrev Operand.reg {w} (r : Reg w) : Operand w := .RegOrMem (.Reg r)
-abbrev Operand.mem {w} (m : AddrExpr) : Operand w := .RegOrMem (.mem m)
+abbrev Operand.reg {w} (r : Reg w) : Operand w := regOrMem (.reg r)
+abbrev Operand.mem {w} (m : AddrExpr) : Operand w := regOrMem (.mem m)
 
 def Operand.interp {α w} [Labels] [AddressSize] [Throw α] (o : Operand w) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → α) :=
   match o with
-  | .RegOrMem rm => rm.interp s p ret
+  | regOrMem rm => rm.interp s p ret
   | .imm v => ret ((v.interp p).toBitVec.truncate _)
   -- we rely on assemblers erroring out on too-large immediates in uniform ops
 
@@ -263,13 +263,13 @@ def ShiftCountExpr.interp [Labels] (c : ShiftCountExpr) (s : MachineData) (p : S
 def ShiftCountExpr.interpMasked [Labels] (c : ShiftCountExpr) (s : MachineData) (p : Std.Rco Int64) (w : Width) : Nat :=
   (c.interp s p).toNat &&& match w with | .W64 => 0x1f | _ => 0x0f -- "masked to 5 bits (or 6 bits with a 64-bit operand)"
 
-inductive RelRegOrMem | Rel (_ : ConstExpr) | Reg (r : Reg .W64) | mem (_ : AddrExpr)
+inductive RelRegOrMem | rel (_ : ConstExpr) | reg (r : Reg .W64) | mem (_ : AddrExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 def RelRegOrMem.interp {α} [Labels] [AddressSize] [Throw α] (o : RelRegOrMem) (s : MachineData) (p : Std.Rco Int64) (ret : BitVec 64 → α) :=
   match o with
-  | .Rel c => ret (p.upper + c.interp p).toBitVec
-  | .Reg r => ret (s.regs.get r)
+  | .rel c => ret (p.upper + c.interp p).toBitVec
+  | .reg r => ret (s.regs.get r)
   | .mem a => s.load ((a.interp s.regs p).zeroExtend _) .W64 ret
 
 inductive Operation (w : Width)
@@ -628,9 +628,9 @@ instance : Repr ByteArray where reprPrec _ _ := "<opaque byte array>"
 
 deriving instance Lean.ToExpr for ByteArray
 inductive Directive
-  | Instr (_ : Instr)
-  | Label (_ : Label)
-  | ByteArray (_ : ByteArray)
+  | instr (_ : Instr)
+  | label (_ : Label)
+  | byteArray (_ : ByteArray)
   deriving BEq, DecidableEq, Repr, Hashable, Lean.ToExpr
 
 def Directive.interp {α} [Undefined Bool α] [Throw α] [Labels]
@@ -638,9 +638,9 @@ def Directive.interp {α} [Undefined Bool α] [Throw α] [Labels]
   (d : Directive) (s : MachineData) (p : Std.Rco Int64)
   (next : MachineData → α) (jmp : Int64 → MachineData → α) : α :=
   match d with
-  | .Label _ => next s
-  | .Instr i => i.interp s p next jmp
-  | .ByteArray _ => throw s!"Unimplemented: execution reached data block at {p.1}"
+  | .label _ => next s
+  | .instr i => i.interp s p next jmp
+  | .byteArray _ => throw s!"Unimplemented: execution reached data block at {p.1}"
 
 def Directives.interp {α} [Undefined Bool α] [Throw α] [Labels]
   [∀ w : Width, Undefined w.type α] [Undefined StatusFlags α]
@@ -681,11 +681,11 @@ def scanl {α β} (f : β → α → β) (init : β) (as : List α) : List β :=
 end Kraken.Compat
 
 def Executable.withAddresses (e : Executable)  : List (Int64 × Directive × Nat) :=
-  (Kraken.Compat.scanl (fun (p, _, _) (d, z) => (p+.ofNat z, d, z)) (e.1, .ByteArray (.mk #[]), 0) e.2)
+  (Kraken.Compat.scanl (fun (p, _, _) (d, z) => (p+.ofNat z, d, z)) (e.1, .byteArray (.mk #[]), 0) e.2)
 
 def Executable.labels (e : Executable) : Labels :=
   { label l := (e.withAddresses.findSome?
-      (fun (p, d, _) => if d = .Label l then .some p else .none)).getD (-1) }
+      (fun (p, d, _) => if d = .label l then .some p else .none)).getD (-1) }
 
 def Executable.directivesAtAddress (e : Executable) (a : Int64) : List (Directive × Nat) :=
   (e.withAddresses.filter (·.1 = a)).map (·.2)
@@ -694,7 +694,7 @@ def Executable.directivesFromAddress (e : Executable) (a : Int64) : List (Direct
   e.2.drop (((e.withAddresses).map (·.1)).idxOf a)
 
 def Executable.directivesFromLabel (e : Executable) (l : Label) : List (Directive × Nat) :=
-  e.2.dropWhile (·.1 != .Label l)
+  e.2.dropWhile (·.1 != .label l)
 
 def Executable.step {α} [∀ w : Width, Undefined w.type α] [Undefined StatusFlags α] [Undefined Bool α]
   [Throw α]
@@ -724,13 +724,13 @@ partial_fixpoint
 
 def Directive.fakeSize (hashOfProgram : UInt64) (d : Directive) : Nat :=
   match d with
-  | .Label _ => 0
-  | .Instr (.mk _ _ (.nop sz)) => sz -- may be zero
-  | .Instr i => (1 + hash (hashOfProgram, i) % 15).toNat
-  | .ByteArray bs => bs.size
+  | .label _ => 0
+  | .instr (.mk _ _ (.nop sz)) => sz -- may be zero
+  | .instr i => (1 + hash (hashOfProgram, i) % 15).toNat
+  | .byteArray bs => bs.size
 
 def Program.fakeLayout (prog : Program) : Executable :=
-  let : Inhabited Directive := .mk (.ByteArray (.mk #[]))
+  let : Inhabited Directive := .mk (.byteArray (.mk #[]))
   let h := hash prog;
   let layout : Layout := { start := h.toInt64<<<16, size i := prog[i]!.fakeSize h }
   layout prog
@@ -741,10 +741,10 @@ abbrev eval [layout : Layout] (prog : Program) := (layout prog).eval
 #guard_msgs in
 #eval
   let exe := Program.fakeLayout [
-    .Label "main",
-    .Instr (.mk .W64 .W64 (.lea (.low .rax .W64) (.mk .none .none (.Int64 41)))),
-    .Instr (.mk .W64 .W64 (.inc (.Reg (.low .rax .W64)))),
-    .Instr (.mk .W64 .W64 .ret) ]
+    .label "main",
+    .instr (.mk .W64 .W64 (.lea (.low .rax .W64) (.mk .none .none (.int64 41)))),
+    .instr (.mk .W64 .W64 (.inc (.reg (.low .rax .W64)))),
+    .instr (.mk .W64 .W64 .ret) ]
   let start := exe.labels.label "main"
   let data := { dmem := .ofList [(0x100, 0x1337)], regs := {rsp := 0x100} }
   (exe.eval (data, start) (fun (_, pc) => pc = 0x1337)).bind (fun s => .ok s.1.regs.rax)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -8,6 +8,7 @@ relaxedAutoImplicit = false
 
 [[lean_lib]]
 name = "Kraken"
+globs = ["Kraken.*"]  # TODO: move the tests out of `Kraken`
 
 [[lean_exe]]
 name = "krakenrunner"


### PR DESCRIPTION
Only types should be in `PascalCase`, everything else (that is not a proof) should be `lowerCamel`.

I've left the width `.W64` ones alone, since there are often exceptions allowed for single-letter identifiers.