### PR TITLE
refactor: replace `eval% parse! "asm"` with `parse("asm")`

### DIFF
--- a/Kraken/Examples.lean
+++ b/Kraken/Examples.lean
@@ -14,7 +14,7 @@ import Kraken.Eval
 
 open Kraken.Parser
 
-def p1 := eval% parse! "start: mov $1, %rax"
+def p1 := parse("start: mov $1, %rax")
 
 theorem Executable.directivesFromStart [layout : Layout] prog :
     (layout prog).directivesFromAddress layout.start = prog.mapIdx (fun i d => (d, layout.size i)) :=
@@ -37,10 +37,10 @@ example [layout : Layout] s : step1 (layout p1) (s, layout.start) (fun s => s.1.
 
   /- simp [p1,step1,eval1,fetch,Instr.is_ctrl,strt1,eval_operand,eval_imm,set_reg_or_mem,next,MachineState.setReg,Registers.set] -/
 
-def swap : Program := eval% parse! "
+def swap : Program := parse("
   xor %rbx, %rax
   xor %rax, %rbx
-  xor %rbx, %rax"
+  xor %rbx, %rax")
 
 theorem swap_correct [layout : Layout] (d : MachineData) :
       eventually (layout swap)
@@ -71,12 +71,12 @@ def p2 : Program := eval% [
   .Instr ⟨ .W64, .W64, .jcc .nz "start" ⟩,
   .Instr ⟨ .W64, .W64, .mov Reg.rax (.imm (.Int64 2)) ⟩,
 ]
-def p2' : Program := eval% parse! "
+def p2' : Program := parse("
 start:
   mov $1, %rax
   xor %rax, %rax
   jnz start
-  mov $2, %rax"
+  mov $2, %rax")
 
 -- Example 2: stepping through both straightline and control instructions
 example [layout : Layout] (s : MachineData): eventually (layout p2) (fun s => s.1.regs.rax = 2) (s, layout.start) := by
@@ -94,7 +94,7 @@ example [layout : Layout] (s : MachineData): eventually (layout p2) (fun s => s.
   simp (ground:=True)
 
 -- Example 3 commented out until we figure out how to parse concrete syntax.
-/- def p3: Program := parse! "
+/- def p3: Program := parse("
 init:
   mov $2 %rdx             # rdx: current result = 2
 start:
@@ -105,7 +105,7 @@ start:
   jmp start               # go back to test & loop body
 _end:
   nop
-"
+")
 
 def p3_spec (s: MachineState): Nat := 2^(2^s.1.regs.rbx.toNat)
 

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -857,7 +857,7 @@ instance {T1} : Coe (ParseResult (List T1) (Sigma String.Pos)) (Except String (L
   | .error _ .eof => .ok []
   | .error _ (.other msg) => .error msg
 
-def parse (input: String): Except String Program := do
+def parse (input: String) : Except String Program := do
   let rawLines := (input.splitOn "\n")
   let (_, lines) ← rawLines.foldlM (fun (lineNum, acc) x => do
     match (parseLine ⟨ x, x.startPos ⟩ : Except String (List Directive)) with
@@ -866,10 +866,10 @@ def parse (input: String): Except String Program := do
   ) ((1 : Nat), [])
   pure lines.reverse.flatten
 
-/-- Parse an assembly string, panicking on failure (for use in #eval). -/
-def parse! (input : String) : Program :=
-  match parse input with
-  | .ok prog => prog
-  | .error msg => panic! s!"parse error: {msg}"
+/-- A version of `parse` that runs at compile-time. -/
+elab "parse(" s:str ")" : term => do
+  match parse s.getString with
+  | .ok p => return Lean.toExpr p
+  | .error e => throwErrorAt s e
 
 end Kraken.Parser

--- a/Kraken/ParserTests.lean
+++ b/Kraken/ParserTests.lean
@@ -14,19 +14,19 @@ open Instr Operand Reg
 /--
 info: [Directive.Instr
     { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.add ↑(low Reg64.rbx Width.W64) ↑↑(low Reg64.rax Width.W64) }]
+      operation := Operation.add ↑(low Reg64.rbx Width.W64) ↑↑(low Reg64.rax Width.W64) }] : List Directive
 -/
 #guard_msgs in
-#eval parse! "addq %rax, %rbx"
+#check parse("addq %rax, %rbx")
 
 -- Test: Immediate operand
 /--
 info: [Directive.Instr
     { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.mov ↑(low Reg64.rax Width.W64) ↑↑42 }]
+      operation := Operation.mov ↑(low Reg64.rax Width.W64) ↑↑42 }] : List Directive
 -/
 #guard_msgs in
-#eval parse! "movq $42, %rax"
+#check parse("movq $42, %rax")
 -- Expected: [.Instr { address_size := .W64, operation_size := .W64, operation := .mov (.Reg (.low .rax .W64)) (.imm 42) }]
 
 -- Test: Memory operand with displacement
@@ -36,9 +36,10 @@ info: [Directive.Instr
       operation :=
         Operation.mov ↑(low Reg64.rax Width.W64)
           ↑↑{ base := some (RegOrRip.ofRegW { w := Width.W64, reg := low Reg64.rsp Width.W64 }), idx := none,
-                disp := ↑8 } }]-/
+                disp := ↑8 } }] : List Directive
+-/
 #guard_msgs in
-#eval parse! "movq 8(%rsp), %rax"
+#check parse("movq 8(%rsp), %rax")
 -- Expected: [.Instr { address_size := .W64, operation_size := .W64, operation := .mov (.Reg (.low .rax .W64)) (.mem .rsp .none 1 8) }]
 
 -- Test: Memory operand with index and scale
@@ -48,10 +49,13 @@ info: [Directive.Instr
       operation :=
         Operation.mov ↑(low Reg64.rax Width.W64)
           ↑↑{ base := some (RegOrRip.ofRegW { w := Width.W64, reg := low Reg64.rsi Width.W64 }),
-                idx := some { reg := { w := Width.W64, reg := low Reg64.r15 Width.W64 }, scale := Width.W64 } } }]
+                idx :=
+                  some
+                    { reg := { w := Width.W64, reg := low Reg64.r15 Width.W64 },
+                      scale := Width.W64 } } }] : List Directive
 -/
 #guard_msgs in
-#eval parse! "movq (%rsi, %r15, 8), %rax"
+#check parse("movq (%rsi, %r15, 8), %rax")
 -- Expected: [.Instr { address_size := .W64, operation_size := .W64, operation := .mov (.Reg (.low .rax .W64)) (.mem .rsi (some .r15) 8 0) }]
 
 -- Test: Labeled instruction
@@ -59,19 +63,20 @@ info: [Directive.Instr
 info: [Directive.Label "loop",
   Directive.Instr
     { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.add ↑(low Reg64.rcx Width.W64) ↑↑1 }]
+      operation := Operation.add ↑(low Reg64.rcx Width.W64) ↑↑1 }] : List Directive
 -/
 #guard_msgs in
-#eval parse! "loop: addq $1, %rcx"
+#check parse("loop: addq $1, %rcx")
 -- Expected: [.Label "loop", .Instr { address_size := .W64, operation_size := .W64, operation := .add (.Reg (.low .rcx .W64)) (.imm 1) }]
 
 -- Test: Conditional jump
 /--
 info: [Directive.Instr
-    { address_size := Width.W64, operation_size := Width.W64, operation := Operation.jcc CondCode.nz "loop" }]
+    { address_size := Width.W64, operation_size := Width.W64,
+      operation := Operation.jcc CondCode.nz "loop" }] : List Directive
 -/
 #guard_msgs in
-#eval parse! "jnz loop"
+#check parse("jnz loop")
 -- Expected: [.Instr { address_size := .W64, operation_size := .W64, operation := .jcc .nz "loop" }]
 
 -- Test: Multi-line program
@@ -87,52 +92,54 @@ info: [Directive.Instr
     { address_size := Width.W64, operation_size := Width.W64,
       operation := Operation.cmp ↑(low Reg64.rax Width.W64) ↑↑10 },
   Directive.Instr
-    { address_size := Width.W64, operation_size := Width.W64, operation := Operation.jcc CondCode.nz "loop" }]
+    { address_size := Width.W64, operation_size := Width.W64,
+      operation := Operation.jcc CondCode.nz "loop" }] : List Directive
 -/
 #guard_msgs in
-#eval parse! "
+#check parse("
   movq $0, %rax
 loop:
   addq $1, %rax
   cmpq $10, %rax
   jne loop
-"
+")
 
 -- Test: Negative immediate
 /--
 info: [Directive.Instr
     { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.add ↑(low Reg64.rax Width.W64) ↑↑(-1) }]
+      operation := Operation.add ↑(low Reg64.rax Width.W64) ↑↑(-1) }] : List Directive
 -/
 #guard_msgs in
-#eval parse! "addq $-1, %rax"
+#check parse("addq $-1, %rax")
 
 -- Test: Hex immediate
 /--
 info: [Directive.Instr
     { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.mov ↑(low Reg64.rax Width.W64) ↑↑255 }]
+      operation := Operation.mov ↑(low Reg64.rax Width.W64) ↑↑255 }] : List Directive
 -/
 #guard_msgs in
-#eval parse! "movq $0xff, %rax"
+#check parse("movq $0xff, %rax")
 
 -- Test: mulx instruction
 /--
 info: [Directive.Instr
     { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.mulx (low Reg64.r10 Width.W64) (low Reg64.r9 Width.W64) ↑(low Reg64.r8 Width.W64) }]
+      operation :=
+        Operation.mulx (low Reg64.r10 Width.W64) (low Reg64.r9 Width.W64) ↑(low Reg64.r8 Width.W64) }] : List Directive
 -/
 #guard_msgs in
-#eval parse! "mulxq %r8, %r9, %r10"
+#check parse("mulxq %r8, %r9, %r10")
 
 -- Test: xor for zeroing
 /--
 info: [Directive.Instr
     { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.xor ↑(low Reg64.rax Width.W64) ↑↑(low Reg64.rax Width.W64) }]
+      operation := Operation.xor ↑(low Reg64.rax Width.W64) ↑↑(low Reg64.rax Width.W64) }] : List Directive
 -/
 #guard_msgs in
-#eval parse! "xorq %rax, %rax"
+#check parse("xorq %rax, %rax")
 
 -- Test: lea with complex addressing
 /--
@@ -142,9 +149,37 @@ info: [Directive.Instr
         Operation.lea (low Reg64.rax Width.W64)
           { base := some (RegOrRip.ofRegW { w := Width.W64, reg := low Reg64.rbp Width.W64 }),
             idx := some { reg := { w := Width.W64, reg := low Reg64.rcx Width.W64 }, scale := Width.W32 },
-            disp := ↑16 } }]
+            disp := ↑16 } }] : List Directive
 -/
 #guard_msgs in
-#eval parse! "leaq 16(%rbp, %rcx, 4), %rax"
+#check parse("leaq 16(%rbp, %rcx, 4), %rax")
+
+section error_reporting
+
+/-- error: line 1: unknown register: unlikely -/
+#guard_msgs in
+#check parse("xorq %rax, %unlikely")
+
+
+end error_reporting
+
+/-! Behavior which is wrong. -/
+section broken
+
+/-- info: [] : List Directive -/
+#guard_msgs in
+#check parse("xorq %rax, 1")
+
+/-- info: [] : List Directive -/
+#guard_msgs in
+#check parse("addq")
+
+/-- error: line 2: unsupported instruction: loop -/
+#guard_msgs in
+#check parse("
+loop: loop: addq %rax, %rbx
+")
+
+end broken
 
 end Tests


### PR DESCRIPTION
The latter better surfaces errors at compile-time, without resorting to panics. Actually emitting the error on the exact token would require dropping the quoting, which would require tighter integration with Lean's parsing machinery. This also adds some tests which identify that the current parser is suboptimal.