### PR TITLE
fix: report rsp in the state summary

### DIFF
--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -66,7 +66,7 @@ structure Reg64s where
   r13 : UInt64 := 0
   r14 : UInt64 := 0
   r15 : UInt64 := 0
-  deriving Repr, BEq, DecidableEq, Hashable, Hashable, Lean.ToExpr
+  deriving Repr, BEq, DecidableEq, Hashable, Hashable, Lean.ToExpr, Lean.ToJson
 
 def Reg64s.get64 (s : Reg64s) (r : Reg64) : Width.W64.type := UInt64.toBitVec (match r with
   | .rax => s.rax | .rbx => s.rbx | .rcx => s.rcx | .rdx => s.rdx
@@ -104,7 +104,7 @@ structure StatusFlags where
   zf : Bool
   sf : Bool
   of : Bool
-  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr, Lean.ToJson
 
 abbrev DataMem := Std.ExtHashMap UInt64 UInt64 -- 8-byte-aligned acceses only now
 instance : Repr DataMem where reprPrec _ _ := "<opaque memory>"

--- a/Kraken/Test/asm_tests.py
+++ b/Kraken/Test/asm_tests.py
@@ -102,7 +102,10 @@ def run_kraken(path: Path) -> Tuple[Optional[ExecutionState], Optional[str]]:
     try:
         res = subprocess.run([KRAKEN_RUNNER, path], capture_output=True, check=True, timeout=TIMEOUT_SECONDS)
         data = json.loads(res.stdout)
-        return ExecutionState(regs=data["regs"], flags=data["flags"]), None
+        return ExecutionState(
+            # Lean serializes big integers as strings so as not to confuse javascript
+            regs={k: int(v) for k, v in data["regs"].items()},
+            flags=data["flags"]), None
     except subprocess.CalledProcessError as e:
         return None, f"Kraken Error:\n{(e.stderr or b"").decode(errors="replace").strip()}"
     except Exception as e:

--- a/KrakenRunner.lean
+++ b/KrakenRunner.lean
@@ -21,28 +21,12 @@ open Lean
 
 -- TODO Add memory, for now we only track registers and flags.
 structure StateSummary where
-  regs : List (String × UInt64)
-  flags : List (String × Bool)
-
--- Custom json serialization for the state summary.
-instance : ToJson StateSummary where
-  toJson s :=
-    let regs := s.regs.map (fun (k, v) => (k, Json.num v.toNat))
-    let flags := s.flags.map (fun (k, v) => (k, toJson v))
-    Json.mkObj [
-      ("regs", Json.mkObj regs),
-      ("flags", Json.mkObj flags)
-    ]
+  regs : Reg64s
+  flags : StatusFlags
+deriving Lean.ToJson
 
 def summarize (s : MachineData) : StateSummary :=
-  let r := s.regs
-  let f := s.status
-  { regs := [("rax", r.rax), ("rbx", r.rbx), ("rcx", r.rcx), ("rdx", r.rdx),
-             ("rsi", r.rsi), ("rdi", r.rdi), ("rbp", r.rbp), ("r8", r.r8),
-             ("r9", r.r9), ("r10", r.r10), ("r11", r.r11), ("r12", r.r12),
-             ("r13", r.r13), ("r14", r.r14), ("r15", r.r15)],
-    flags := [("cf", f.cf), ("pf", f.pf), ("af", f.af),
-              ("zf", f.zf), ("sf", f.sf), ("of", f.of)] }
+  { regs := s.regs, flags := s.status }
 
 abbrev MachineState := MachineData × Int64
 


### PR DESCRIPTION
Rather than manually converting to JSON, we can ask Lean to do it for us.

It's not clear to me whether in https://github.com/AeneasVerif/kraken/pull/70/changes#r3096719019, the omission of `rsp` was deliberate.