### PR TITLE
Make krakenrunner a default target.

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "Kraken"
 version = "0.1.0"
-defaultTargets = ["Kraken"]
+defaultTargets = ["Kraken", "krakenrunner"]
 
 [leanOptions]
 autoImplicit = false


### PR DESCRIPTION
I'm not sure about anyone else, but I often go:
```
lake build
... attempt to run tests...
... Oh no!! tests broken.. why?
... Oh... the krakenrunner is stale ;(
```
This change just adds krakenrunner to the default targets to avoid this mistake.