### PR TITLE
Prove missing lemma from Examples

### DIFF
--- a/Kraken/Examples.lean
+++ b/Kraken/Examples.lean
@@ -17,8 +17,11 @@ open Kraken.Parser
 def p1 := parse("start: mov $1, %rax")
 
 theorem Executable.directivesFromStart [layout : Layout] prog :
-    (layout prog).directivesFromAddress layout.start = prog.mapIdx (fun i d => (d, layout.size i)) :=
-  sorry
+    (layout prog).directivesFromAddress layout.start = prog.mapIdx (fun i d => (d, layout.size i)) := by
+  induction prog with
+  | nil => simp [Executable.directivesFromAddress,Layout.apply]
+  | cons p ps =>
+    simp [Executable.directivesFromAddress,Layout.apply,Executable.withAddresses]
 
 -- Super-simple example to debug tactics
 example [layout : Layout] s : step1 (layout p1) (s, layout.start) (fun s => s.1.regs.rax = 1) := by
@@ -28,8 +31,7 @@ example [layout : Layout] s : step1 (layout p1) (s, layout.start) (fun s => s.1.
   simp [List.mapIdx,List.mapIdx.go]
   dsimp only [Directives.interp,Directive.interp,Instr.interp,Operation.interp,Operand.interp]
   dsimp only [MachineData.set,Reg64s.set,MachineData.setReg,Reg64s.set64,ConstExpr.interp]
-  simp (ground:=True)
-  simp
+  simp (ground:=True) (decide:=True)
 
   /- simp [Instr.interp,Operation.interp,Operand.interp,MachineData.set] -/
   /- simp [MachineData.setReg,Reg64s.set,Reg64s.set64,ConstExpr.interp] -/
@@ -60,7 +62,8 @@ theorem swap_correct [layout : Layout] (d : MachineData) :
   apply Eventually.done
   simp (ground:=True)
   dsimp only [Reg64s.get, Reg64s.get64, Reg.base, Reg.offset]
-  dsimp only [BitVec.drop, BitVec.take, Width.bits]
+  dsimp only [BitVec.drop, BitVec.take, Width.bits,BitVec.extractLsb'_eq_self]
+  simp only [BitVec.extractLsb'_eq_self]
   bv_decide
 
 -- Stepping demo. Ideally, this demo should be without the first .mov
@@ -92,6 +95,7 @@ example [layout : Layout] (s : MachineData): Eventually (layout p2) (fun s => s.
   dsimp [undefined,Undefined.undefined]; intros _af
   apply Eventually.done
   simp (ground:=True)
+  rfl
 
 -- Example 3 commented out until we figure out how to parse concrete syntax.
 /- def p3: Program := parse("

--- a/Kraken/Examples.lean
+++ b/Kraken/Examples.lean
@@ -18,10 +18,7 @@ def p1 := parse("start: mov $1, %rax")
 
 theorem Executable.directivesFromStart [layout : Layout] prog :
     (layout prog).directivesFromAddress layout.start = prog.mapIdx (fun i d => (d, layout.size i)) := by
-  induction prog with
-  | nil => simp [Executable.directivesFromAddress,Layout.apply]
-  | cons p ps =>
-    simp [Executable.directivesFromAddress,Layout.apply,Executable.withAddresses]
+  induction prog <;> simp [Executable.directivesFromAddress,Layout.apply,Executable.withAddresses]
 
 -- Super-simple example to debug tactics
 example [layout : Layout] s : step1 (layout p1) (s, layout.start) (fun s => s.1.regs.rax = 1) := by

--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -655,34 +655,19 @@ def Directives.interp {α} [Undefined Bool α] [Throw α] [Labels]
 abbrev Program := List Directive
 abbrev Executable := Int64 × List (Directive × Nat) -- start and sizes
 
-class Layout where (start : Int64) (size : Nat → Nat)
+class Layout where
+  start : Int64
+  size : Nat → Nat
+
 def Layout.apply (l : Layout) (prog : Program) : Executable :=
   (l.start, prog.mapIdx (fun i d => (d, l.size i)))
+
 instance : CoeFun Layout (fun _ => Program → Executable) where coe := Layout.apply
 
--- TEMPORARY: delete when dropping support for Lean <= 4.28
--- (above which Init.Data.List.scan.Basic is supported).
--- This namespace permits use of Mathlib 4.27 which also implements its own
--- `scanl` which differs from the one here.
-namespace Kraken.Compat
-@[inline]
-private def scanAuxM {α β m} [Monad m] (f : β → α → m β) (init : β) (l : List α) : m (List β) :=
-  go l init []
-where
-  @[specialize] go : List α → β → List β → m (List β)
-    | [], last, acc => pure <| last :: acc
-    | x :: xs, last, acc => do go xs (← f last x) (last :: acc)
-@[inline]
-def scanlM {α β m} [Monad m] (f : β → α → m β) (init : β) (l : List α) : m (List β) :=
-  List.reverse <$> scanAuxM f init l
-@[inline]
-def scanl {α β} (f : β → α → β) (init : β) (as : List α) : List β :=
-  Id.run <| Kraken.Compat.scanlM (pure <| f · ·) init as
-end Kraken.Compat
-
 def Executable.withAddresses (e : Executable)  : List (Int64 × Directive × Nat) :=
-  (Kraken.Compat.scanl (fun (p, _, _) (d, z) => (p+.ofNat z, d, z)) (e.1, .byteArray (.mk #[]), 0) e.2)
+  (List.scanl (fun (p, _, _) (d, z) => (p+.ofNat z, d, z)) (e.1, .byteArray (.mk #[]), 0) e.2)
 
+@[reducible]
 def Executable.labels (e : Executable) : Labels :=
   { label l := (e.withAddresses.findSome?
       (fun (p, d, _) => if d = .label l then .some p else .none)).getD (-1) }

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.27.0
+leanprover/lean4:v4.29.0


### PR DESCRIPTION
Not intending to merge this immediately, but I felt slightly annoyed that there was this blatant sorry in Examples.

Turns out, with the proper lemmas in scope (which are available in 4.29 but not earlier) about `scanl`, this went throught automatically.

Let's merge once we feel comfortable upgrading the toolchain. At least now we know the lemma is true :-)