### PR TITLE
correct the capitalization of Effects.all and step1

### DIFF
--- a/Kraken/Examples/Examples.lean
+++ b/Kraken/Examples/Examples.lean
@@ -21,15 +21,15 @@ theorem Executable.directivesFromStart [layout : Layout] prog :
   sorry
 
 -- Super-simple example to debug tactics
-example [layout : Layout] s : step1 (layout p1) (s, layout.start) (fun s => s.1.regs.rax = 1) := by
+example [layout : Layout] s : Step1 (layout p1) (s, layout.start) (fun s => s.1.regs.rax = 1) := by
   dsimp only [p1]
-  dsimp only [step1,Executable.straightline]
+  dsimp only [Step1,Executable.straightline]
   rw [Executable.directivesFromStart]
   simp [List.mapIdx,List.mapIdx.go]
   dsimp only [Directives.interp,Directive.interp,Instr.interp,Operation.interp,Operand.interp,RegOrMem.interp]
   dsimp only [MachineData.set,Reg64s.set,MachineData.setReg,Reg64s.set64,ConstExpr.interp,require_exec_access]
   simp (ground:=True)
-  dsimp only [Effects.all]
+  dsimp only [Effects.All]
 
   /- simp [Instr.interp,Operation.interp,Operand.interp,MachineData.set] -/
   /- simp [MachineData.setReg,Reg64s.set,Reg64s.set64,ConstExpr.interp] -/
@@ -50,12 +50,12 @@ theorem swap_correct [layout : Layout] (d : MachineData) :
       (d, layout.start) := by
   dsimp [swap]
   apply step_cps
-  dsimp only [step1, Executable.straightline, Directives.interp]
+  dsimp only [Step1, Executable.straightline, Directives.interp]
   rw [Executable.directivesFromStart]
   simp [List.mapIdx, List.mapIdx.go]
   -- TODO It would be nice to progress instruction by instruction instead of all at once, like below.
   dsimp only [Directives.interp, Directive.interp, Instr.interp, Operation.interp, Operand.interp, RegOrMem.interp]
-  dsimp [MachineData.set, MachineData.setReg, Reg64s.set, Reg64s.set64, Effects.all]
+  dsimp [MachineData.set, MachineData.setReg, Reg64s.set, Reg64s.set64, Effects.All]
   intros _af1 _af2 _af3
   apply Eventually.done
   simp (ground:=True)
@@ -82,11 +82,11 @@ start:
 example [layout : Layout] (s : MachineData): Eventually (layout p2) (fun s => s.1.regs.rax = 2) (s, layout.start) := by
   dsimp [p2]
   apply step_cps
-  dsimp only [step1,Executable.straightline]
+  dsimp only [Step1,Executable.straightline]
   rw [Executable.directivesFromStart]
   simp [List.mapIdx,List.mapIdx.go]
   dsimp only [Directives.interp,Directive.interp,Instr.interp,Operation.interp,Operand.interp,RegOrMem.interp]
-  dsimp only [MachineData.set,Reg64s.set,MachineData.setReg,Reg64s.set64,ConstExpr.interp,CondCode.interp,StatusFlags.from_result, Effects.all]
+  dsimp only [MachineData.set,Reg64s.set,MachineData.setReg,Reg64s.set64,ConstExpr.interp,CondCode.interp,StatusFlags.from_result, Effects.All]
   simp only [Int64.toBitVec_ofNat, BitVec.ofNat_eq_ofNat, BitVec.truncate_eq_setWidth, BitVec.xor_self, BitVec.zero_eq,
     BEq.rfl, Bool.not_true, Bool.false_eq_true, ↓reduceIte, BitVec.msb_zero]
   intros _af
@@ -211,18 +211,18 @@ def p4 := eval% parse("start: mov $2, %rax
 dec %rax")
 
 -- Super-simple example to debug tactics
-example [layout : Layout] s : step1 (layout p4) (s, layout.start) (fun s => s.1.regs.rax = 1) := by
+example [layout : Layout] s : Step1 (layout p4) (s, layout.start) (fun s => s.1.regs.rax = 1) := by
   let ss := s
-  change (step1 _ (ss, _) _)
+  change (Step1 _ (ss, _) _)
   cases s with | mk regs flags mem =>
   cases regs with | mk rax =>
   delta p4
-  dsimp only [step1,Executable.straightline]
+  dsimp only [Step1,Executable.straightline]
   rw [Executable.directivesFromStart]
   simp [List.mapIdx,List.mapIdx.go]
-  dsimp (zeta:=false)(iota:=true) only [Directives.interp,Directive.interp,Instr.interp,Operation.interp,Operand.interp,ConstExpr.interp,RegOrMem.interp,Reg.interp,Reg64s.get,Reg.base,Reg.offset,MachineData.set,MachineData.setReg,Reg64s.set,Width.type,Width.bits,Effects.all]
+  dsimp (zeta:=false)(iota:=true) only [Directives.interp,Directive.interp,Instr.interp,Operation.interp,Operand.interp,ConstExpr.interp,RegOrMem.interp,Reg.interp,Reg64s.get,Reg.base,Reg.offset,MachineData.set,MachineData.setReg,Reg64s.set,Width.type,Width.bits,Effects.All]
   lift_lets
-  dsimp (zeta:=false)(beta:=true)(eta:=false)(iota:=true)(proj:=true) only [Reg64s.get64,Reg64s.set64,BitVec.drop,BitVec.take,ss,Effects.all] -- reduces UInt64.toBitVec but leaves let binders behind and gets stuck confused on it
+  dsimp (zeta:=false)(beta:=true)(eta:=false)(iota:=true)(proj:=true) only [Reg64s.get64,Reg64s.set64,BitVec.drop,BitVec.take,ss,Effects.All] -- reduces UInt64.toBitVec but leaves let binders behind and gets stuck confused on it
   intros rax1
   lift_lets; intros t -- unfortunately a separte tactic rather than a simp flag
   -- simp [MachineData.regs,Reg64s.set64,Reg64s.get64,ss] at t -- made no progress for some reason

--- a/Kraken/Examples/IncrementDMA.lean
+++ b/Kraken/Examples/IncrementDMA.lean
@@ -64,5 +64,5 @@ structure SystemState where
   machineState : MachineState
   deviceState : IncrementerState
 
-def Effects.all (s : Effects) (ds : IncrementerState) (post : SystemState → Prop) : Prop
+def Effects.All (s : Effects) (ds : IncrementerState) (post : SystemState → Prop) : Prop
   := by sorry

--- a/Kraken/Tactics.lean
+++ b/Kraken/Tactics.lean
@@ -14,19 +14,18 @@ import Kraken.Theorems
 
 abbrev Post := MachineState → Prop
 
-def Effects.all (s : Effects) (post : MachineState → Prop) : Prop :=
-  match s with
+def Effects.All (post : MachineState → Prop) : Effects → Prop
   | .done a => post a
   | .unimplemented _ => False
   | .nonmem_load .. => False
   | .nonmem_store .. => False
-  | @Effects.undefined α _ cont => ∀ v: α, (cont v).all post
-  | .require_read_access _ _ cont => (cont ()).all post
-  | .require_write_access _ _ cont => (cont ()).all post
-  | .require_exec_access _ cont => (cont ()).all post
+  | @Effects.undefined α _ cont => ∀ v: α, (cont v).All post
+  | .require_read_access _ _ cont => (cont ()).All post
+  | .require_write_access _ _ cont => (cont ()).All post
+  | .require_exec_access _ cont => (cont ()).All post
 
-def step1 [Layout] (p: Executable) (s: MachineState) : Post → Prop :=
-  (Executable.straightline p s .done).all
+def Step1 [Layout] (p: Executable) (s: MachineState) : Post → Prop :=
+  (Executable.straightline p s .done).All
 
 inductive Eventually [Layout] (prog: Executable) (p: MachineState → Prop): MachineState -> Prop
   | done (initial: MachineState):
@@ -34,14 +33,14 @@ inductive Eventually [Layout] (prog: Executable) (p: MachineState → Prop): Mac
       Eventually _ p initial
   | step (initial: MachineState):
       (mid_p: Post) ->
-      step1 prog initial mid_p →
+      Step1 prog initial mid_p →
       (forall (mid: MachineState), mid_p mid → Eventually _ p mid) →
       Eventually _ p initial
 
 -- THEOREMS
 
 theorem step_cps {p : Executable} [Layout] (post: Post) (initial: MachineState):
-  step1 p initial (fun mid => Eventually p post mid) → Eventually p post initial :=
+  Step1 p initial (fun mid => Eventually p post mid) → Eventually p post initial :=
   by
     intro
     apply Eventually.step
@@ -117,7 +116,7 @@ syntax "step_instr" : tactic
 macro_rules
   | `(tactic|step_instr) =>
   `(tactic|
-    delta step1 eval1 fetch;
+    delta Step1 eval1 fetch;
     dsimp only [List.findIdx?,List.findIdx,getElem?,List.get?Internal];
     dsimp only [Instr.is_ctrl];
     dsimp only [Bool.false_eq_true, ↓dreduceIte]; -- special simproc for if https://github.com/leanprover/lean4/blob/master/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Core.lean#L25-L40
@@ -140,7 +139,7 @@ macro_rules
   | `(tactic|step_one) =>
   `(tactic|
     simp [
-      step1,Program.straightline,
+      Step1,Program.straightline,
       Program.position_of_addr,Program.positions,Program.positions',layout,List.filter,Position.Label,
       List.dropWhile,bne,BEq.beq,instBEqDirective.beq,dropInstrs,Program.straightline',Instr.interp,Operation.interp,Operand.interp];
     simp (ground:=True);


### PR DESCRIPTION
These are propositions, so should be `Effects.All` and `Step1` respectively.

Also swaps the argument order such that `Effects.All p` is itself a predicate on `Effects`, though this doesn't impact any other code.