### PR TITLE
Add pycache to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # Build artifacts from test runs
 *.o
 asm-tests/test
+__pycache__/


### PR DESCRIPTION
I keep accidentally adding Test/__pycache__ into my commits with `git add -a` and then needing to unstage and I imagine I am not the only one.