### PR TITLE
Enable parser errors and consecutive labels

### DIFF
--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -885,47 +885,58 @@ def parseLabelDecl : Parser Label := do
 -- Line and Program Parsing
 -- ============================================================================
 
+def parseAlign : Parser Instr := do
+  let _ ← pstring ".align"
+  skipHWs
+  let alignment ← parseHexOrDec
+  let pad ← (do
+    skipHWs
+    let _ ← parseComma
+    skipHWs
+    let pad ← parseHexOrDec
+    pure (some pad.toNat)
+  ) <|> pure none
+  pure ⟨ .W64, .W64, .nopalign alignment.toNat pad ⟩
+
+def skipSpaceAndCheckLineEnd : Parser Bool := do
+  skipHWs
+  let c? ← peek?
+  match c? with
+  | none
+  | some '\n' =>
+    pure true
+  | some '#' =>
+    skipLineComment
+    pure true
+  | some _ =>
+    pure false
+
+def parseOptionalInstr : Parser (Option Directive) := do
+  if (← skipSpaceAndCheckLineEnd) then
+    pure none
+  else
+    let i ← parseAlign <|> parseInstr
+    pure (some (Directive.instr i))
+
+def checkLineEnd : Parser Unit := do
+  if (← skipSpaceAndCheckLineEnd) then
+    pure ()
+  else
+    fail "unexpected trailing characters on line"
+
 /-- Parse a single line: optional label, followed by optional instruction or directive.
     Returns a list of directives found on the line. -/
 def parseLine : Parser (List Directive) := do
   skipHWs
-  let c ← peek!
-  -- Skip empty lines and comment-only lines
-  if c == '\n' || c == '#' then
-    if c == '#' then skipLineComment
-    pure []
-  else
-    let label ← (attempt do
-      let l ← parseLabelDecl
-      pure (some (Directive.label l))) <|> pure none
-    skipHWs
-    let instr ← (do
-      let c ← peek!
-      if c == '\n' || c == '#' then
-        pure none
-      else
-        -- Try to parse a .align directive
-        (do
-          let _ ← pstring ".align"
-          skipHWs
-          let alignment ← parseHexOrDec
-          let pad ← (do
-            skipHWs
-            let _ ← parseComma
-            skipHWs
-            let pad ← parseHexOrDec
-            pure (some pad.toNat)
-          ) <|> pure none
-          pure (some (Directive.instr ⟨ .W64, .W64, .nopalign alignment.toNat pad ⟩))
-        ) <|> (do
-          let instr ← parseInstr
-          pure (some (Directive.instr instr)))
-    ) <|> pure none
-    match label, instr with
-    | some l, some i => pure [l, i]
-    | some l, none   => pure [l]
-    | none,   some i => pure [i]
-    | none,   none   => pure []
+  let labels ← many (attempt do
+    let l ← parseLabelDecl
+    pure (Directive.label l))
+  let instr ← parseOptionalInstr
+  checkLineEnd
+  let labelsList := labels.toList
+  match instr with
+  | some i => pure (labelsList ++ [i])
+  | none   => pure labelsList
 
 -- ============================================================================
 -- Public API
@@ -934,7 +945,7 @@ def parseLine : Parser (List Directive) := do
 instance {T1} : Coe (ParseResult (List T1) (Sigma String.Pos)) (Except String (List T1)) where coe :=
   fun r => match r with
   | .success _ v => .ok v
-  | .error _ .eof => .ok []
+  | .error _ .eof => .error "unexpected end of input"
   | .error _ (.other msg) => .error msg
 
 def parse (input: String) : Except String Program := do

--- a/Kraken/ParserTests.lean
+++ b/Kraken/ParserTests.lean
@@ -180,25 +180,36 @@ error: line 1: type mismatch in memory addressing operands: base ({w1}) and inde
 #guard_msgs in
 #check parse("mov $2, (%ah)")
 
-end error_reporting
+/-- error: line 1: unexpected end of input -/
+#guard_msgs in
+#check parse("addq %rax")
 
-/-! Behavior which is wrong. -/
-section broken
-
-/-- info: [] : List Directive -/
+/-- error: line 1: unexpected end of input -/
 #guard_msgs in
 #check parse("xorq %rax, 1")
 
-/-- info: [] : List Directive -/
+/-- error: line 1: unexpected end of input -/
 #guard_msgs in
 #check parse("addq")
 
-/-- error: line 2: unsupported instruction: loop -/
+/-- error: line 2: unexpected end of input -/
 #guard_msgs in
 #check parse("
-loop: loop: addq %rax, %rbx
+  addq %rax
+  cmpq $10, %rax
 ")
 
-end broken
+/-- error: line 1: type error: w64 != w32 -/
+#guard_msgs in
+#check parse("movq %eax, %rbx")
 
+/-- error: line 1: invalid scale 3, must be 1, 2, 4, or 8 -/
+#guard_msgs in
+#check parse("movq (%rax, %rcx, 3), %rbx")
+
+/-- error: line 1: unexpected trailing characters on line -/
+#guard_msgs in
+#check parse("movq %rax, %rbx garbage")
+
+end error_reporting
 end Tests

--- a/Kraken/ParserTests.lean
+++ b/Kraken/ParserTests.lean
@@ -212,4 +212,16 @@ error: line 1: type mismatch in memory addressing operands: base ({w1}) and inde
 #check parse("movq %rax, %rbx garbage")
 
 end error_reporting
+
+section broken
+
+-- TODO: Support absolute memory addressing (bare displacements) and add reliable integration tests for it.
+-- Currently, the parser requires '(' after displacement, so this fails to parse with "expected: '('".
+-- Also, testing this on real x86 is tricky because we need a guaranteed mapped addresses.
+/-- error: line 1: expected: '(' -/
+#guard_msgs in
+#check parse("movq 1, %rax")
+
+end broken
+
 end Tests

--- a/Kraken/Test/asm/test_double_label.S
+++ b/Kraken/Test/asm/test_double_label.S
@@ -1,0 +1,3 @@
+# Undefined flags: cf, pf, af, zf, sf, of
+loop: loop:
+  addq %rax, %rbx


### PR DESCRIPTION
Propagate parser errors to output instead of silently swallowing them. Parse multiple labels in one line correctly.