### PR TITLE
Fix test with two labels

### DIFF
--- a/Kraken/Test/asm/test_double_label.S
+++ b/Kraken/Test/asm/test_double_label.S
@@ -1,3 +1,3 @@
 # Undefined flags: cf, pf, af, zf, sf, of
-loop: loop:
+loop1: loop2:
   addq %rax, %rbx


### PR DESCRIPTION
This should have been in #116, I forgot to add it. On Jonathan's machine, the test doesn't pass with two labels with the same name.