### PR TITLE
Move Fixes (with tests against GNU as):

### DIFF
--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -621,15 +621,15 @@ def parseInstr : Parser Instr := do
     let w ← instrWidth mn
     commaSeparated w parseOperand parseRegOrMem .mov
 
-  | "moszx" =>
+  | "movsx" =>
     -- Must be a register otherwise lacking type info
-    let ⟨ _w_src, src ⟩ ← parseRegW
+    let ⟨ _w_src, src ⟩ ← parseRegW; parseComma
     let ⟨ w_dst, dst ⟩ ← parseRegW
     pure ⟨ .W64, w_dst, .movsx dst (.reg src) ⟩
 
   | "movzx" =>
     -- Must be a register otherwise lacking type info
-    let ⟨ _w_src, src ⟩ ← parseRegW
+    let ⟨ _w_src, src ⟩ ← parseRegW; parseComma
     let ⟨ w_dst, dst ⟩ ← parseRegW
     pure ⟨ .W64, w_dst, .movzx dst (.reg src) ⟩
 
@@ -639,7 +639,7 @@ def parseInstr : Parser Instr := do
     let w_src ← Char.toWidth c_src
     let src ← parseRegO w_src; parseComma
     let dst ← parseRegO w_dst
-    pure ⟨ .W64, w_dst, .movzx dst (.reg src) ⟩
+    pure ⟨ .W64, w_dst, .movsx dst (.reg src) ⟩
 
   | "movzbw" | "movzbl" | "movzbq" | "movzwl" | "movzwq" =>
     let w_dst ← instrWidth mn

--- a/Kraken/Test/asm/test_movsx.S
+++ b/Kraken/Test/asm/test_movsx.S
@@ -1,0 +1,10 @@
+# Undefined flags: 
+
+movq $128, %rax
+movsx %al, %bx
+movsx %al, %ecx
+movsx %al, %rdx
+
+movq $32768, %rax
+movsx %ax, %esi
+movsx %ax, %rdi

--- a/Kraken/Test/asm/test_sign_extend.S
+++ b/Kraken/Test/asm/test_sign_extend.S
@@ -1,0 +1,10 @@
+# Undefined flags: 
+
+movq $128, %rax
+movsbw %al, %bx
+movsbl %al, %ecx
+movsbq %al, %rdx
+
+movq $32768, %rax
+movswl %ax, %esi
+movswq %ax, %rdi


### PR DESCRIPTION
These are the fixes
1) The parser incorrectly mapped suffix-sized sign-extension instructions to the zero extension versions of these.
2) There appeared to be a typo mapping boszx to movsx. 
3) Missing parseCommas for movsx and movzx

The tests should fail if you checkout Parser.lean from main and run these tests against them.