### PR TITLE
Add initial support for SSE/AVX registers ({x,y,z}mm)s, {v,}movups

### DIFF
--- a/Kraken/Examples/Examples.lean
+++ b/Kraken/Examples/Examples.lean
@@ -271,7 +271,7 @@ theorem p6_correct [layout : Layout] (s₀ : MachineData)
   apply step_cps
   let ss := s₀
   change (straightlineStep _ (ss, _) _)
-  cases s₀ with | mk regs flags mem =>
+  cases s₀ with | mk regs zmms flags mem =>
   cases regs with | mk rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15 =>
   have h_bs : stack.length = 8 := h_len
   -- Rewrite the program to make layout, addresses, etc. apparent
@@ -420,7 +420,7 @@ theorem move_2_regs_to_heap_correct [layout : Layout] (s₀ : MachineData)
         s'.1.regs.rdi = s₀.regs.rdi)
       (s₀, layout.start) := by
   apply step_cps
-  cases s₀ with | mk regs flags mem =>
+  cases s₀ with | mk regs zmms flags mem =>
   cases regs with | mk rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15 =>
   have h_bs1 : v1.toBytes.length = 8 := UInt64.toBytes_length v1
   have h_bs2 : v2.toBytes.length = 8 := UInt64.toBytes_length v2
@@ -473,7 +473,7 @@ theorem sib_example_correct [layout : Layout] (s₀ : MachineData)
       (fun s' => s'.1.regs.rax = 42)
       (s₀, layout.start) := by
   apply step_cps
-  cases s₀ with | mk regs flags mem =>
+  cases s₀ with | mk regs zmms flags mem =>
   cases regs with | mk rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15 =>
   have h_bs : v.toBytes.length = 8 := UInt64.toBytes_length v
   dsimp only [straightlineStep, Executable.straightline]
@@ -510,7 +510,7 @@ theorem alu_mem_example_correct [layout : Layout] (s₀ : MachineData)
       (fun s' => s'.1.regs.rcx = 142)
       (s₀, layout.start) := by
   apply step_cps
-  cases s₀ with | mk regs flags mem =>
+  cases s₀ with | mk regs zmms flags mem =>
   cases regs with | mk rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15 =>
   have h_bs : v.toBytes.length = 8 := UInt64.toBytes_length v
   dsimp only [straightlineStep, Executable.straightline]
@@ -557,7 +557,7 @@ theorem dynamic_stack_example_correct [layout : Layout] (s₀ : MachineData)
   apply step_cps
   let ss := s₀
   change (straightlineStep _ (ss, _) _)
-  cases s₀ with | mk regs flags mem =>
+  cases s₀ with | mk regs zmms flags mem =>
   cases regs with | mk rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15 =>
   have h_bs : stack.length = 1024 := lstack
   have h_take_drop : stack = stack.take 1016 ++ stack.drop 1016 := by exact (List.take_append_drop 1016 stack).symm

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -137,6 +137,11 @@ def parseInt : Parser Int := do
   let val ← parseHexOrDec
   pure (if neg then -val else val)
 
+/-- Helper to parse a standard natural number. -/
+def parseNat : Parser Nat := do
+  let digits ← many1 digit
+  pure (digits.foldl (fun acc d => acc * 10 + (d.toNat - '0'.toNat)) 0)
+
 /-- Parse a name (identifier or label). -/
 def parseName : Parser String := do
   let first ← satisfy fun c => c.isAlpha || c == '_' || c == '.'
@@ -183,6 +188,36 @@ def parseRegNameW : Parser RegW := do
   | "ah" => pure ⟨ .W8, ah ⟩ | "bh" => pure ⟨ .W8, bh ⟩ | "ch" => pure ⟨ .W8, ch ⟩ | "dh" => pure ⟨ .W8, dh ⟩
   | _ => fail s!"unknown register: {name}"
 
+/-- Safely map a natural number index to its corresponding RegMm constructor. -/
+def toRegMm (idx : Nat) : Option RegMm :=
+  match idx with
+  | 0  => some .mm0  | 1  => some .mm1  | 2  => some .mm2  | 3  => some .mm3
+  | 4  => some .mm4  | 5  => some .mm5  | 6  => some .mm6  | 7  => some .mm7
+  | 8  => some .mm8  | 9  => some .mm9  | 10 => some .mm10 | 11 => some .mm11
+  | 12 => some .mm12 | 13 => some .mm13 | 14 => some .mm14 | 15 => some .mm15
+  | 16 => some .mm16 | 17 => some .mm17 | 18 => some .mm18 | 19 => some .mm19
+  | 20 => some .mm20 | 21 => some .mm21 | 22 => some .mm22 | 23 => some .mm23
+  | 24 => some .mm24 | 25 => some .mm25 | 26 => some .mm26 | 27 => some .mm27
+  | 28 => some .mm28 | 29 => some .mm29 | 30 => some .mm30 | 31 => some .mm31
+  | _ => none
+
+/-- Parse an AVX register operand (e.g., %xmm0, %ymm15, %zmm31). -/
+def parseAvxRegW : Parser AvxRegW := do
+  skipHWs
+  let _ ← pchar '%'
+  -- Match standard or uppercase variants of the AVX prefixes
+  let pfx ← (pstring "xmm" <|> pstring "XMM" <|>
+             pstring "ymm" <|> pstring "YMM" <|>
+             pstring "zmm" <|> pstring "ZMM")
+  let idx ← parseNat
+  match toRegMm idx with
+  | none => fail s!"invalid AVX register index: {idx} (must be between 0 and 31)"
+  | some mm =>
+    match pfx.toLower with
+    | "xmm" => pure ⟨ .W128, .xmm mm ⟩
+    | "ymm" => pure ⟨ .W256, .ymm mm ⟩
+    | "zmm" => pure ⟨ .W512, .zmm mm ⟩
+    | _ => fail s!"unknown AVX register prefix: {pfx}"
 end RegParsing
 
 /-- Parse a register operand: %rax, %eax, %ax, %al, etc. -/
@@ -341,8 +376,13 @@ def parseRegOrMem: Parser (MaybeAddrWidth × MaybeOpWidth RegOrMem) := do
   skipHWs
   let c ← peek!
   if c == '%' then
-    let ⟨ w, r ⟩ ← parseRegW
-    pure (.none, ⟨ .some w, .reg r ⟩)
+    (attempt do
+      let ⟨ w, r ⟩ ← parseAvxRegW
+      pure (.none, ⟨ .some w, .avx r ⟩)
+    ) <|> (do
+      let ⟨ w, r ⟩ ← parseRegW
+      pure (.none, ⟨ .some w, .reg r ⟩)
+    )
   else if c == '(' || c == '-' || c.isDigit then
     let (w, m) ← parseMemory
     pure (w, ⟨ .none, .mem m ⟩)
@@ -662,6 +702,12 @@ def parseInstr : Parser Instr := do
       fail "inconsistency in {mn}"
     else
       pure ⟨ addr_w, w, .lea dst src ⟩
+
+  | "movups" =>
+    commaSeparated .none parseRegOrMem parseRegOrMem .movups
+
+  | "vmovups" =>
+    commaSeparated .none parseRegOrMem parseRegOrMem .vmovups
 
   -- Bitwise - 64-bit
   | "xor" =>

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -472,6 +472,16 @@ def parseCondCode (suffix : String.Slice) : Parser CondCode :=
 -- Instruction Parsing
 -- ============================================================================
 
+/-- Helper to construct an Instr from an Operation, defaulting address size to .W64 -/
+def toInstr (addr : MaybeAddrWidth) {w : Width} (op : Operation w) : Instr :=
+  let _ : AddressSize := { address_size := addr.getD .W64 }
+  ↑op
+
+/-- Helper to construct an Instr from an AvxOperation, defaulting address size to .W64 -/
+def toAvxInstr (addr : MaybeAddrWidth) {w : AvxWidth} (op : AvxOperation w) : Instr :=
+  let _ : AddressSize := { address_size := addr.getD .W64 }
+  ↑op
+
 /-- Parse a comma separator. -/
 def parseComma : Parser Unit := do
   skipHWs
@@ -511,29 +521,31 @@ def instrWidth (s: String): Parser Width :=
 
 def commaSeparated {T1 T2} (op_w: Option Width) (p1: Parser (MaybeAddrWidth × MaybeOpWidth T1)) (p2: Parser (MaybeAddrWidth × MaybeOpWidth T2))
   (mk: {op_w: Width} → T2 op_w → T1 op_w → Operation op_w): Parser Instr := do
-  match op_w with
+    match op_w with
     | .none =>
       let src ← p1; parseComma
-      let (addr_w, ⟨ w, src, dst ⟩) ← ascribeOrInfer src p2
-      pure (.regular (addr_w.getD .W64) w (mk dst src))
+      let (addr_w, ⟨ _w, src, dst ⟩) ← ascribeOrInfer src p2
+      pure (toInstr addr_w (mk dst src))
     | .some w =>
       let (addr_w1, src) ← parseAO p1 w
       parseComma
       let (addr_w2, dst) ← parseAO p2 w
-      pure (.regular ((← mergeAddrWidths addr_w1 addr_w2).getD .W64) w (mk dst src))
+      let addr_w ← mergeAddrWidths addr_w1 addr_w2
+      pure (toInstr addr_w (mk dst src))
 
 def commaSeparatedAvx {T1 T2} (op_w: Option AvxWidth) (p1: Parser (MaybeAddrWidth × MaybeAvxOpWidth T1)) (p2: Parser (MaybeAddrWidth × MaybeAvxOpWidth T2))
   (mk: {op_w: AvxWidth} → T2 op_w → T1 op_w → AvxOperation op_w): Parser Instr := do
   match op_w with
   | .none =>
     let src ← p1; parseComma
-    let (addr_w, ⟨ w, src, dst ⟩) ← ascribeOrInferAvx src p2
-    pure (.avx (addr_w.getD .W64) w (mk dst src))
+    let (addr_w, ⟨ _w, src, dst ⟩) ← ascribeOrInferAvx src p2
+    pure (toAvxInstr addr_w (mk dst src))
   | .some w =>
     let (addr_w1, src) ← parseAvxAO p1 w
     parseComma
     let (addr_w2, dst) ← parseAvxAO p2 w
-    pure (.avx ((← mergeAddrWidths addr_w1 addr_w2).getD .W64) w (mk dst src))
+    let addr_w ← mergeAddrWidths addr_w1 addr_w2
+    pure (toAvxInstr addr_w (mk dst src))
 
 def assertW {T} (v: MaybeOpWidth T): Parser (Σ w: Width, T w) :=
   match v with
@@ -601,25 +613,25 @@ def parseInstr : Parser Instr := do
     commaSeparated w parseOperand parseRegOrMem .sbb
 
   | "mul" =>
-    let (addr_w, src) ← parseRegOrMem
-    let ⟨ w, src ⟩ ← assertW src
-    pure (.regular (addr_w.getD .W64) w (.mul src))
+    let ( addr_w, src) ← parseRegOrMem
+    let ⟨ _w, src ⟩ ← assertW src
+    pure (toInstr addr_w (.mul src))
 
   | "mulq" | "mull" | "mulw" | "mulb" =>
     let w ← instrWidth mn
-    let (addr_w, src) ← parseRegOrMemAO w
-    pure (.regular (addr_w.getD .W64) w (.mul src))
+    let ( addr_w, src ) ← parseRegOrMemAO w
+    pure (toInstr addr_w (.mul src))
 
   | "mulx" =>
     -- Per Intel SDM: MULX dest1 and dest2 must be registers
     -- mulxq src, lo, hi (AT&T: src → rdx*src, result in lo:hi)
-    let (addr_w, src) ← parseRegOrMem; parseComma
+    let ( addr_w, src ) ← parseRegOrMem; parseComma
     let lo ← parseRegW; parseComma
     let hi ← parseRegW
     match src, lo, hi with
     | ⟨ .none, src ⟩, ⟨ w1, lo ⟩, ⟨ w2, hi ⟩ =>
       if h: w1 = w2 then
-        pure (.regular (addr_w.getD .W64) w1 (.mulx (h ▸ hi) lo src))
+        pure (toInstr addr_w (.mulx (h ▸ hi) lo src))
       else
         fail "mulx not homogenous"
     | ⟨ .some w3, src ⟩, ⟨ w1, lo ⟩, ⟨ w2, hi ⟩ =>
@@ -627,7 +639,7 @@ def parseInstr : Parser Instr := do
         let hi := h ▸ hi
         if h: w1 = w3 then
           let src := h ▸ src
-          pure (.regular (addr_w.getD .W64) w1 (.mulx hi lo src))
+          pure (toInstr addr_w (.mulx hi lo src))
         else
           fail "mulx not homogenous"
       else
@@ -635,10 +647,10 @@ def parseInstr : Parser Instr := do
 
   | "mulxq" | "mulxl" =>
     let w ← instrWidth mn
-    let (addr_w, src) ← parseRegOrMemAO w; parseComma
+    let ( addr_w, src ) ← parseRegOrMemAO w; parseComma
     let lo ← parseRegO w; parseComma
     let hi ← parseRegO w
-    pure (.regular (addr_w.getD .W64) w (.mulx hi lo src))
+    pure (toInstr addr_w (.mulx hi lo src))
 
   | "imul" =>
     (attempt do
@@ -648,15 +660,16 @@ def parseInstr : Parser Instr := do
         let (addr_w2, ⟨ w, src2, dst ⟩) ← ascribeOrInfer src2 parseRegA
         let (addr_w1, src1) := src1
         let src1 ← ascribe w src1
-        pure (.regular ((← mergeAddrWidths addr_w1 addr_w2).getD .W64) w (.imul (.some dst) src2 src1)))
+        let addr_w ← mergeAddrWidths addr_w1 addr_w2
+        pure (toInstr addr_w (.imul (.some dst) src2 src1)))
       <|> (do
-        let (addr_w, ⟨ w, src1, src2 ⟩) ← ascribeOrInfer src1 parseRegOrMem
-        pure (.regular (addr_w.getD .W64) w (.imul .none src2 src1))
+        let (addr_w, ⟨_w, src1, src2 ⟩) ← ascribeOrInfer src1 parseRegOrMem
+        pure (toInstr addr_w (.imul .none src2 src1))
       )
     ) <|> (do
       let (addr_w, src) ← parseRegOrMem
-      let ⟨ w, src ⟩ ← assertW src
-      pure (.regular (addr_w.getD .W64) w (.imul1 src))
+      let ⟨_w, src ⟩ ← assertW src
+      pure (toInstr addr_w (.imul1 src))
     )
 
   | "imulq" | "imull" | "imulw" | "imulb" =>
@@ -666,36 +679,38 @@ def parseInstr : Parser Instr := do
       (attempt do
         let (addr_w2, src2) ← parseRegOrMemAO w; parseComma
         let dst ← parseRegO w
-        pure (.regular ((← mergeAddrWidths addr_w1 addr_w2).getD .W64) w (.imul (.some dst) src2 src1))
+        let addr_w ← mergeAddrWidths addr_w1 addr_w2
+        pure (toInstr addr_w (.imul (.some dst) src2 src1))
       ) <|>
       (do
         let (addr_w2, src2) ← parseRegOrMemAO w
-        pure (.regular ((← mergeAddrWidths addr_w1 addr_w2).getD .W64) w (.imul none src2 src1))
+        let addr_w ← mergeAddrWidths addr_w1 addr_w2
+        pure (toInstr addr_w (.imul none src2 src1))
       )
     ) <|>
     (do
       let (addr_w, src) ← parseRegOrMemAO w
-      pure (.regular (addr_w.getD .W64) w (.imul1 src))
+      pure (toInstr addr_w (.imul1 src))
     )
   | "neg" =>
-    let (addr_w, dst) ← parseRegOrMem
-    let ⟨ w, dst ⟩ ← assertW dst
-    pure (.regular (addr_w.getD .W64) w (.neg dst))
+    let ( addr_w, dst) ← parseRegOrMem
+    let ⟨ _w, dst ⟩ ← assertW dst
+    pure (toInstr addr_w (.neg dst))
 
   | "negq" | "negl" | "negw" | "negb" =>
     let w ← instrWidth mn
-    let (addr_w, dst) ← parseRegOrMemAO w
-    pure (.regular (addr_w.getD .W64) w (.neg dst))
+    let ( addr_w, dst ) ← parseRegOrMemAO w
+    pure (toInstr addr_w (.neg dst))
 
   | "dec" =>
-    let (addr_w, dst) ← parseRegOrMem
-    let ⟨ w, dst ⟩ ← assertW dst
-    pure (.regular (addr_w.getD .W64) w (.dec dst))
+    let ( addr_w, dst ) ← parseRegOrMem
+    let ⟨ _w, dst ⟩ ← assertW dst
+    pure (toInstr addr_w (.dec dst))
 
   | "decq" | "decl" | "decw" | "decb" =>
     let w ← instrWidth mn
-    let (addr_w, dst) ← parseRegOrMemAO w
-    pure (.regular (addr_w.getD .W64) w (.dec dst))
+    let ( addr_w, dst ) ← parseRegOrMemAO w
+    pure (toInstr addr_w (.dec dst))
 
   | "mov" | "movabs" =>
     commaSeparated .none parseOperand parseRegOrMem .mov
@@ -708,14 +723,14 @@ def parseInstr : Parser Instr := do
   | "movsx" =>
     -- Must be a register otherwise lacking type info
     let ⟨ _w_src, src ⟩ ← parseRegW
-    let ⟨ w_dst, dst ⟩ ← parseRegW
-    pure (.regular .W64 w_dst (.movsx dst (.reg src)))
+    let ⟨ _w_dst, dst ⟩ ← parseRegW
+    pure (toInstr .none (.movsx (.reg dst) (.reg src)))
 
   | "movzx" =>
     -- Must be a register otherwise lacking type info
     let ⟨ _w_src, src ⟩ ← parseRegW
-    let ⟨ w_dst, dst ⟩ ← parseRegW
-    pure (.regular .W64 w_dst (.movzx dst (.reg src)))
+    let ⟨ _w_dst, dst ⟩ ← parseRegW
+    pure (toInstr .none (.movzx (.reg dst) (.reg src)))
 
   | "movsbw" | "movsbl" | "movsbq" | "movswl" | "movswq" =>
     let w_dst ← instrWidth mn
@@ -723,7 +738,7 @@ def parseInstr : Parser Instr := do
     let w_src ← Char.toWidth c_src
     let src ← parseRegO w_src; parseComma
     let dst ← parseRegO w_dst
-    pure (.regular .W64 w_dst (.movsx dst (.reg src)))
+    pure (toInstr .none (.movsx (.reg dst) (.reg src)))
 
   | "movzbw" | "movzbl" | "movzbq" | "movzwl" | "movzwq" =>
     let w_dst ← instrWidth mn
@@ -731,21 +746,21 @@ def parseInstr : Parser Instr := do
     let w_src ← Char.toWidth c_src
     let src ← parseRegO w_src; parseComma
     let dst ← parseRegO w_dst
-    pure (.regular .W64 w_dst (.movzx dst (.reg src)))
+    pure (toInstr .none (.movzx (.reg dst) (.reg src)))
 
   | "lea" =>
-    let (addr_w, src) ← parseMemory; parseComma
-    let ⟨ w, dst ⟩ ← parseRegW
-    pure (.regular addr_w w (.lea dst src))
+    let ( addr_w, src ) ← parseMemory; parseComma
+    let ⟨ _w, dst ⟩ ← parseRegW
+    pure (toInstr (some addr_w) (.lea dst src))
 
   | "leaq" | "leal" | "leaw" | "leab" =>
     let w2 ← instrWidth mn
-    let (addr_w, src) ← parseMemory; parseComma
+    let ( addr_w, src ) ← parseMemory; parseComma
     let ⟨ w, dst ⟩ ← parseRegW
     if w2 ≠ w then
       fail "inconsistency in {mn}"
     else
-      pure (.regular addr_w w (.lea dst src))
+      pure (toInstr (some addr_w) (.lea dst src))
 
   | "movups" =>
     commaSeparatedAvx .none parseAvxRegOrMem parseAvxRegOrMem .movups
@@ -769,14 +784,14 @@ def parseInstr : Parser Instr := do
     commaSeparated w parseOperand parseRegOrMem .and
 
   | "not" =>
-    let (addr_w, dst) ← parseRegOrMem
-    let ⟨ w, dst ⟩ ← assertW dst
-    pure (.regular (addr_w.getD .W64) w (.not dst))
+    let ( addr_w, dst ) ← parseRegOrMem
+    let ⟨ _w, dst ⟩ ← assertW dst
+    pure (toInstr addr_w (.not dst))
 
   | "notq" | "notl" | "notw" | "notb" =>
     let w ← instrWidth mn
-    let (addr_w, dst) ← parseRegOrMemAO w
-    pure (.regular (addr_w.getD .W64) w (.not dst))
+    let ( addr_w, dst ) ← parseRegOrMemAO w
+    pure (toInstr addr_w (.not dst))
 
   | "or" =>
     commaSeparated .none parseOperand parseRegOrMem .or
@@ -805,40 +820,40 @@ def parseInstr : Parser Instr := do
   | "shl"
   | "sal" =>
     let cnt ← parseOptionalShiftAndComma
-    let (addr_w, dst) ← parseRegOrMem
-    let ⟨ w, dst ⟩ ← assertW dst
-    pure (.regular (addr_w.getD .W64) w (.shl dst cnt))
+    let ( addr_w, dst ) ← parseRegOrMem
+    let ⟨ _w, dst ⟩ ← assertW dst
+    pure (toInstr addr_w (.shl dst cnt))
 
   | "shlq" | "shll" | "shlw" | "shlb"
   | "salq" | "sall" | "salw" | "salb" =>
     let w ← instrWidth mn
     let cnt ← parseOptionalShiftAndComma
-    let (addr_w, dst) ← parseRegOrMemAO w
-    pure (.regular (addr_w.getD .W64) w (.shl dst cnt))
+    let ( addr_w, dst ) ← parseRegOrMemAO w
+    pure (toInstr addr_w (.shl dst cnt))
 
   | "shr" =>
     let cnt ← parseOptionalShiftAndComma
-    let (addr_w, dst) ← parseRegOrMem
-    let ⟨ w, dst ⟩ ← assertW dst
-    pure (.regular (addr_w.getD .W64) w (.shr dst cnt))
+    let ( addr_w, dst ) ← parseRegOrMem
+    let ⟨ _w, dst ⟩ ← assertW dst
+    pure (toInstr addr_w (.shr dst cnt))
 
   | "shrq" | "shrl" | "shrw" | "shrb" =>
     let w ← instrWidth mn
     let cnt ← parseOptionalShiftAndComma
-    let (addr_w, dst) ← parseRegOrMemAO w
-    pure (.regular (addr_w.getD .W64) w (.shr dst cnt))
+    let ( addr_w, dst ) ← parseRegOrMemAO w
+    pure (toInstr addr_w (.shr dst cnt))
 
   | "sar" =>
     let cnt ← parseOptionalShiftAndComma
-    let (addr_w, dst) ← parseRegOrMem
-    let ⟨ w, dst ⟩ ← assertW dst
-    pure (.regular (addr_w.getD .W64) w (.sar dst cnt))
+    let ( addr_w, dst ) ← parseRegOrMem
+    let ⟨ _w, dst ⟩ ← assertW dst
+    pure (toInstr addr_w (.sar dst cnt))
 
   | "sarq" | "sarl" | "sarw" | "sarb" =>
     let w ← instrWidth mn
     let cnt ← parseOptionalShiftAndComma
-    let (addr_w, dst) ← parseRegOrMemAO w
-    pure (.regular (addr_w.getD .W64) w (.sar dst cnt))
+    let ( addr_w, dst ) ← parseRegOrMemAO w
+    pure (toInstr addr_w (.sar dst cnt))
 
   | "shld" =>
     let cnt ← parseShiftExpr; parseComma
@@ -861,32 +876,32 @@ def parseInstr : Parser Instr := do
   -- Rotate instructions - 64-bit
   | "rol" =>
     let cnt ← parseOptionalShiftAndComma
-    let (addr_w, dst) ← parseRegOrMem
-    let ⟨ w, dst ⟩ ← assertW dst
-    pure (.regular (addr_w.getD .W64) w (.rol dst cnt))
+    let ( addr_w, dst ) ← parseRegOrMem
+    let ⟨ _w, dst ⟩ ← assertW dst
+    pure (toInstr addr_w (.rol dst cnt))
 
   | "rolq" | "roll" | "rolw" | "rolb" =>
     let w ← instrWidth mn
     let cnt ← parseOptionalShiftAndComma
-    let (addr_w, dst) ← parseRegOrMemAO w
-    pure (.regular (addr_w.getD .W64) w (.rol dst cnt))
+    let ( addr_w, dst ) ← parseRegOrMemAO w
+    pure (toInstr addr_w (.rol dst cnt))
 
   | "ror" =>
     let cnt ← parseOptionalShiftAndComma
-    let (addr_w, dst) ← parseRegOrMem
-    let ⟨ w, dst ⟩ ← assertW dst
-    pure (.regular (addr_w.getD .W64) w (.ror dst cnt))
+    let ( addr_w, dst ) ← parseRegOrMem
+    let ⟨ _w, dst ⟩ ← assertW dst
+    pure (toInstr addr_w (.ror dst cnt))
 
   | "rorq" | "rorl" | "rorw" | "rorb" =>
     let w ← instrWidth mn
     let cnt ← parseOptionalShiftAndComma
-    let (addr_w, dst) ← parseRegOrMemAO w
-    pure (.regular (addr_w.getD .W64) w (.ror dst cnt))
+    let ( addr_w, dst ) ← parseRegOrMemAO w
+    pure (toInstr addr_w (.ror dst cnt))
 
   -- Byte swap
   | "bswap" =>
-    let ⟨ w, dst ⟩ ← parseRegW
-    pure (.regular .W64 w (.bswap dst))
+    let ⟨ _w, dst ⟩ ← parseRegW
+    pure (toInstr .none (.bswap dst))
 
   | "bswapq" | "bswapl" =>
     let ⟨ w, dst ⟩ ← parseRegW
@@ -894,47 +909,47 @@ def parseInstr : Parser Instr := do
     if w2 ≠ w then
       fail "inconsistency in {mn}"
     else
-      pure (.regular .W64 w (.bswap dst))
+      pure (toInstr .none (.bswap dst))
 
   -- Stack operations
   | "push" =>
-    let (addr_w, src) ← parseOperand
-    let ⟨ w, src ⟩ ← assertW src
-    pure (.regular (addr_w.getD .W64) w (.push src))
+    let ( addr_w, src ) ← parseOperand
+    let ⟨ _w, src ⟩ ← assertW src
+    pure (toInstr addr_w (.push src))
 
   | "pushq" | "pushl" | "pushw" | "pushb" =>
     let w ← instrWidth mn
-    let (addr_w, src) ← parseOperandAO w
-    pure (.regular (addr_w.getD .W64) w (.push src))
+    let ( addr_w, src ) ← parseOperandAO w
+    pure (toInstr addr_w (.push src))
 
   | "pop" =>
-    let (addr_w, dst) ← parseRegOrMem
-    let ⟨ w, dst ⟩ ← assertW dst
-    pure (.regular (addr_w.getD .W64) w (.pop dst))
+    let ( addr_w, dst) ← parseRegOrMem
+    let ⟨ _w, dst ⟩ ← assertW dst
+    pure (toInstr addr_w (.pop dst))
 
   | "popq" | "popl" | "popw" | "popb" =>
     let w ← instrWidth mn
-    let (addr_w, dst) ← parseRegOrMemAO w
-    pure (.regular (addr_w.getD .W64) w (.pop dst))
+    let ( addr_w, dst ) ← parseRegOrMemAO w
+    pure (toInstr addr_w (.pop dst))
 
   | "ret" | "retq" =>
-    pure (.regular .W64 .W64 .ret)
+    pure (toInstr .none (w := .W64) .ret)
 
   | "call" | "callq" =>
-    let (addr_w, target) ← parseRelRegOrMem
-    pure (.regular (addr_w.getD .W64) .W64 (.call target))
+    let ( addr_w, target ) ← parseRelRegOrMem
+    pure (toInstr addr_w (w := .W64) (.call target))
 
   -- Control flow - unconditional jump
   | "jmp" | "jmpq" =>
-    let (addr_w, target) ← parseRelRegOrMem
-    pure (.regular (addr_w.getD .W64) .W64 (.jmp target))
+    let ( addr_w, target ) ← parseRelRegOrMem
+    pure (toInstr addr_w (w := .W64) (.jmp target))
 
   | "nop" =>
     (do
       skipHWs
       let sz ← parseHexOrDec
-      pure (.regular .W64 .W64 (.nop sz.toNat))
-    ) <|> (pure (.regular .W64 .W64 (.nop 1)))
+      pure (toInstr .none (w := .W64) (.nop sz.toNat))
+    ) <|> (pure (toInstr .none (w := .W64) (.nop 1)))
 
   -- Control flow - conditional jumps
   | _ =>
@@ -942,11 +957,11 @@ def parseInstr : Parser Instr := do
       let cc ← parseCondCode (mn.drop 1)
       skipHWs
       let target ← parseLabelRaw
-      pure (.regular .W64 .W64 (.jcc cc target))
+      pure (toInstr .none (w := .W64) (.jcc cc target))
     else if mn.startsWith "set" then
       let cc ← parseCondCode (mn.drop 3)
       let (addr_w, dst) ← parseRegOrMemAO .W8
-      pure (.regular (addr_w.getD .W64) .W8 (.setcc cc dst))
+      pure (toInstr addr_w (.setcc cc dst))
     else if mn.startsWith "cmov" then
       -- TODO: are the suffixed variants really used here? do we truly need to
       -- handle cmovzb and the like? how many are there? we could conceivably
@@ -986,7 +1001,7 @@ def parseAlign : Parser Instr := do
     let pad ← parseHexOrDec
     pure (some pad.toNat)
   ) <|> pure none
-  pure (.regular .W64 .W64 (.nopalign alignment.toNat pad))
+  pure (toInstr .none (w := .W64) (.nopalign alignment.toNat pad))
 
 def skipSpaceAndCheckLineEnd : Parser Bool := do
   skipHWs

--- a/Kraken/Parser.lean
+++ b/Kraken/Parser.lean
@@ -26,6 +26,9 @@ open Std.Internal.Parsec.String
 def MaybeOpWidth (T: Width → Type) :=
   Σ (w: Option Width), match w with | .some w => T w | .none => { w: Width } → T w
 
+def MaybeAvxOpWidth (T: AvxWidth → Type) :=
+  Σ (w: Option AvxWidth), match w with | .some w => T w | .none => { w: AvxWidth } → T w
+
 -- Most of our parsing functions return a MaybeAddrWidth × MaybeTyped T, in case
 -- the operand we just parsed happens to be a memory operand, which thus allows
 -- the assembler to infer the address width used for the instruction (see
@@ -54,6 +57,15 @@ def ascribe {T: Width → Type} (w: Width) (v: MaybeOpWidth T): Parser (T w) := 
     else
       fail s!"type error: {w} != {w2}"
 
+def ascribeAvx {T: AvxWidth → Type} (w: AvxWidth) (v: MaybeAvxOpWidth T): Parser (T w) := do
+match v with
+  | ⟨ .none, v ⟩ => pure v
+  | ⟨ .some w2, v ⟩ =>
+    if h: w = w2 then
+          pure (h ▸ v)
+    else
+          fail s!"type error: {w} != {w2}"
+
 def ascribeOrInfer {T1 T2} (op1: MaybeAddrWidth × MaybeOpWidth T1) (next: Parser (MaybeAddrWidth × MaybeOpWidth T2)): Parser (MaybeAddrWidth × Σ w, T1 w × T2 w) := do
   let (addr_w2, op2) ← next
   let (addr_w1, op1) := op1
@@ -69,6 +81,21 @@ def ascribeOrInfer {T1 T2} (op1: MaybeAddrWidth × MaybeOpWidth T1) (next: Parse
     | ⟨ .none, _ ⟩ =>
       fail "missing type annotation"
 
+def ascribeOrInferAvx {T1 T2} (op1: MaybeAddrWidth × MaybeAvxOpWidth T1) (next: Parser (MaybeAddrWidth × MaybeAvxOpWidth T2)): Parser (MaybeAddrWidth × Σ w, T1 w × T2 w) := do
+  let (addr_w2, op2) ← next
+  let (addr_w1, op1) := op1
+  let addr_w ← mergeAddrWidths addr_w1 addr_w2
+  match op1 with
+    | ⟨ .some w1, op1 ⟩ =>
+      let op2 ← ascribeAvx w1 op2
+      pure (addr_w, ⟨ w1, op1, op2 ⟩)
+    | ⟨ .none, op1 ⟩ =>
+      match op2 with
+      | ⟨ .some w2, op2 ⟩ =>
+        pure (addr_w, ⟨ w2, op1, op2 ⟩)
+      | ⟨ .none, _ ⟩ =>
+        fail "missing type annotation"
+
 -- Naming convention: O = function takes an operand width
 def parseO {T1} (op: Parser (MaybeOpWidth T1)) (w: Width): Parser (T1 w) := do
   let op ← op
@@ -80,6 +107,10 @@ def parseAO {T1} (op: Parser (MaybeAddrWidth × MaybeOpWidth T1)) (w: Width): Pa
   let op ← ascribe w op
   pure (addr_w, op)
 
+def parseAvxAO {T1} (op: Parser (MaybeAddrWidth × MaybeAvxOpWidth T1)) (w: AvxWidth): Parser (MaybeAddrWidth × T1 w) := do
+  let (addr_w, op) ← op
+  let op ← ascribeAvx w op
+  pure (addr_w, op)
 
 -- ============================================================================
 -- Lexical Utilities
@@ -136,11 +167,6 @@ def parseInt : Parser Int := do
   let neg ← (pchar '-' *> pure true) <|> pure false
   let val ← parseHexOrDec
   pure (if neg then -val else val)
-
-/-- Helper to parse a standard natural number. -/
-def parseNat : Parser Nat := do
-  let digits ← many1 digit
-  pure (digits.foldl (fun acc d => acc * 10 + (d.toNat - '0'.toNat)) 0)
 
 /-- Parse a name (identifier or label). -/
 def parseName : Parser String := do
@@ -209,7 +235,7 @@ def parseAvxRegW : Parser AvxRegW := do
   let pfx ← (pstring "xmm" <|> pstring "XMM" <|>
              pstring "ymm" <|> pstring "YMM" <|>
              pstring "zmm" <|> pstring "ZMM")
-  let idx ← parseNat
+  let idx ← digits
   match toRegMm idx with
   | none => fail s!"invalid AVX register index: {idx} (must be between 0 and 31)"
   | some mm =>
@@ -376,18 +402,25 @@ def parseRegOrMem: Parser (MaybeAddrWidth × MaybeOpWidth RegOrMem) := do
   skipHWs
   let c ← peek!
   if c == '%' then
-    (attempt do
-      let ⟨ w, r ⟩ ← parseAvxRegW
-      pure (.none, ⟨ .some w, .avx r ⟩)
-    ) <|> (do
-      let ⟨ w, r ⟩ ← parseRegW
-      pure (.none, ⟨ .some w, .reg r ⟩)
-    )
+    let ⟨ w, r ⟩ ← parseRegW
+    pure (.none, ⟨ .some w, .reg r ⟩)
   else if c == '(' || c == '-' || c.isDigit then
     let (w, m) ← parseMemory
     pure (w, ⟨ .none, .mem m ⟩)
   else
     fail s!"expected register or memory operand, got {c}"
+
+def parseAvxRegOrMem: Parser (MaybeAddrWidth × MaybeAvxOpWidth AvxRegOrMem) := do
+  skipHWs
+  let c ← peek!
+  if c == '%' then
+    let ⟨ w, r ⟩ ← parseAvxRegW
+    pure (.none, ⟨ .some w, .avx r ⟩)
+  else if c == '(' || c == '-' || c.isDigit then
+    let (w, m) ← parseMemory
+    pure (w, ⟨ .none, .mem m ⟩)
+  else
+      fail s!"expected AVX register or memory operand, got {c}"
 
 def parseRelRegOrMem: Parser (MaybeAddrWidth × RelRegOrMem) := do
   skipHWs
@@ -478,17 +511,29 @@ def instrWidth (s: String): Parser Width :=
 
 def commaSeparated {T1 T2} (op_w: Option Width) (p1: Parser (MaybeAddrWidth × MaybeOpWidth T1)) (p2: Parser (MaybeAddrWidth × MaybeOpWidth T2))
   (mk: {op_w: Width} → T2 op_w → T1 op_w → Operation op_w): Parser Instr := do
-    match op_w with
+  match op_w with
     | .none =>
       let src ← p1; parseComma
       let (addr_w, ⟨ w, src, dst ⟩) ← ascribeOrInfer src p2
-      pure ⟨ addr_w.getD .W64, w, mk dst src ⟩
+      pure (.regular (addr_w.getD .W64) w (mk dst src))
     | .some w =>
       let (addr_w1, src) ← parseAO p1 w
       parseComma
       let (addr_w2, dst) ← parseAO p2 w
-      -- flip the direction here
-      pure ⟨ (← mergeAddrWidths addr_w1 addr_w2).getD .W64, w, mk dst src ⟩
+      pure (.regular ((← mergeAddrWidths addr_w1 addr_w2).getD .W64) w (mk dst src))
+
+def commaSeparatedAvx {T1 T2} (op_w: Option AvxWidth) (p1: Parser (MaybeAddrWidth × MaybeAvxOpWidth T1)) (p2: Parser (MaybeAddrWidth × MaybeAvxOpWidth T2))
+  (mk: {op_w: AvxWidth} → T2 op_w → T1 op_w → AvxOperation op_w): Parser Instr := do
+  match op_w with
+  | .none =>
+    let src ← p1; parseComma
+    let (addr_w, ⟨ w, src, dst ⟩) ← ascribeOrInferAvx src p2
+    pure (.avx (addr_w.getD .W64) w (mk dst src))
+  | .some w =>
+    let (addr_w1, src) ← parseAvxAO p1 w
+    parseComma
+    let (addr_w2, dst) ← parseAvxAO p2 w
+    pure (.avx ((← mergeAddrWidths addr_w1 addr_w2).getD .W64) w (mk dst src))
 
 def assertW {T} (v: MaybeOpWidth T): Parser (Σ w: Width, T w) :=
   match v with
@@ -558,12 +603,12 @@ def parseInstr : Parser Instr := do
   | "mul" =>
     let (addr_w, src) ← parseRegOrMem
     let ⟨ w, src ⟩ ← assertW src
-    pure ⟨ addr_w.getD .W64, w, .mul src ⟩
+    pure (.regular (addr_w.getD .W64) w (.mul src))
 
   | "mulq" | "mull" | "mulw" | "mulb" =>
     let w ← instrWidth mn
     let (addr_w, src) ← parseRegOrMemAO w
-    pure ⟨ addr_w.getD .W64, w, .mul src ⟩
+    pure (.regular (addr_w.getD .W64) w (.mul src))
 
   | "mulx" =>
     -- Per Intel SDM: MULX dest1 and dest2 must be registers
@@ -574,7 +619,7 @@ def parseInstr : Parser Instr := do
     match src, lo, hi with
     | ⟨ .none, src ⟩, ⟨ w1, lo ⟩, ⟨ w2, hi ⟩ =>
       if h: w1 = w2 then
-        pure ⟨ addr_w.getD .W64, w1, .mulx (h ▸ hi) lo src ⟩
+        pure (.regular (addr_w.getD .W64) w1 (.mulx (h ▸ hi) lo src))
       else
         fail "mulx not homogenous"
     | ⟨ .some w3, src ⟩, ⟨ w1, lo ⟩, ⟨ w2, hi ⟩ =>
@@ -582,7 +627,7 @@ def parseInstr : Parser Instr := do
         let hi := h ▸ hi
         if h: w1 = w3 then
           let src := h ▸ src
-          pure ⟨ addr_w.getD .W64, w1, .mulx hi lo src ⟩
+          pure (.regular (addr_w.getD .W64) w1 (.mulx hi lo src))
         else
           fail "mulx not homogenous"
       else
@@ -593,7 +638,7 @@ def parseInstr : Parser Instr := do
     let (addr_w, src) ← parseRegOrMemAO w; parseComma
     let lo ← parseRegO w; parseComma
     let hi ← parseRegO w
-    pure ⟨ addr_w.getD .W64, w, .mulx hi lo src ⟩
+    pure (.regular (addr_w.getD .W64) w (.mulx hi lo src))
 
   | "imul" =>
     (attempt do
@@ -603,15 +648,15 @@ def parseInstr : Parser Instr := do
         let (addr_w2, ⟨ w, src2, dst ⟩) ← ascribeOrInfer src2 parseRegA
         let (addr_w1, src1) := src1
         let src1 ← ascribe w src1
-        pure ⟨ (← mergeAddrWidths addr_w1 addr_w2).getD .W64, w, .imul (.some dst) src2 src1 ⟩)
+        pure (.regular ((← mergeAddrWidths addr_w1 addr_w2).getD .W64) w (.imul (.some dst) src2 src1)))
       <|> (do
         let (addr_w, ⟨ w, src1, src2 ⟩) ← ascribeOrInfer src1 parseRegOrMem
-        pure ⟨ addr_w.getD .W64, w, .imul .none src2 src1 ⟩
+        pure (.regular (addr_w.getD .W64) w (.imul .none src2 src1))
       )
     ) <|> (do
       let (addr_w, src) ← parseRegOrMem
       let ⟨ w, src ⟩ ← assertW src
-      pure ⟨ addr_w.getD .W64, w, .imul1 src ⟩
+      pure (.regular (addr_w.getD .W64) w (.imul1 src))
     )
 
   | "imulq" | "imull" | "imulw" | "imulb" =>
@@ -621,37 +666,36 @@ def parseInstr : Parser Instr := do
       (attempt do
         let (addr_w2, src2) ← parseRegOrMemAO w; parseComma
         let dst ← parseRegO w
-        pure ⟨ (← mergeAddrWidths addr_w1 addr_w2).getD .W64, w, .imul (.some dst) src2 src1 ⟩
+        pure (.regular ((← mergeAddrWidths addr_w1 addr_w2).getD .W64) w (.imul (.some dst) src2 src1))
       ) <|>
       (do
         let (addr_w2, src2) ← parseRegOrMemAO w
-        pure ⟨ (← mergeAddrWidths addr_w1 addr_w2).getD .W64, w, .imul none src2 src1 ⟩
+        pure (.regular ((← mergeAddrWidths addr_w1 addr_w2).getD .W64) w (.imul none src2 src1))
       )
     ) <|>
     (do
       let (addr_w, src) ← parseRegOrMemAO w
-      pure ⟨ addr_w.getD .W64, w, .imul1 src ⟩
+      pure (.regular (addr_w.getD .W64) w (.imul1 src))
     )
-
   | "neg" =>
     let (addr_w, dst) ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
-    pure ⟨ addr_w.getD .W64, w, .neg dst ⟩
+    pure (.regular (addr_w.getD .W64) w (.neg dst))
 
   | "negq" | "negl" | "negw" | "negb" =>
     let w ← instrWidth mn
     let (addr_w, dst) ← parseRegOrMemAO w
-    pure ⟨ addr_w.getD .W64, w, .neg dst ⟩
+    pure (.regular (addr_w.getD .W64) w (.neg dst))
 
   | "dec" =>
     let (addr_w, dst) ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
-    pure ⟨ addr_w.getD .W64, w, .dec dst ⟩
+    pure (.regular (addr_w.getD .W64) w (.dec dst))
 
   | "decq" | "decl" | "decw" | "decb" =>
     let w ← instrWidth mn
     let (addr_w, dst) ← parseRegOrMemAO w
-    pure ⟨ addr_w.getD .W64, w, .dec dst ⟩
+    pure (.regular (addr_w.getD .W64) w (.dec dst))
 
   | "mov" | "movabs" =>
     commaSeparated .none parseOperand parseRegOrMem .mov
@@ -665,13 +709,13 @@ def parseInstr : Parser Instr := do
     -- Must be a register otherwise lacking type info
     let ⟨ _w_src, src ⟩ ← parseRegW
     let ⟨ w_dst, dst ⟩ ← parseRegW
-    pure ⟨ .W64, w_dst, .movsx dst (.reg src) ⟩
+    pure (.regular .W64 w_dst (.movsx dst (.reg src)))
 
   | "movzx" =>
     -- Must be a register otherwise lacking type info
     let ⟨ _w_src, src ⟩ ← parseRegW
     let ⟨ w_dst, dst ⟩ ← parseRegW
-    pure ⟨ .W64, w_dst, .movzx dst (.reg src) ⟩
+    pure (.regular .W64 w_dst (.movzx dst (.reg src)))
 
   | "movsbw" | "movsbl" | "movsbq" | "movswl" | "movswq" =>
     let w_dst ← instrWidth mn
@@ -679,7 +723,7 @@ def parseInstr : Parser Instr := do
     let w_src ← Char.toWidth c_src
     let src ← parseRegO w_src; parseComma
     let dst ← parseRegO w_dst
-    pure ⟨ .W64, w_dst, .movsx dst (.reg src) ⟩
+    pure (.regular .W64 w_dst (.movsx dst (.reg src)))
 
   | "movzbw" | "movzbl" | "movzbq" | "movzwl" | "movzwq" =>
     let w_dst ← instrWidth mn
@@ -687,12 +731,12 @@ def parseInstr : Parser Instr := do
     let w_src ← Char.toWidth c_src
     let src ← parseRegO w_src; parseComma
     let dst ← parseRegO w_dst
-    pure ⟨ .W64, w_dst, .movzx dst (.reg src) ⟩
+    pure (.regular .W64 w_dst (.movzx dst (.reg src)))
 
   | "lea" =>
     let (addr_w, src) ← parseMemory; parseComma
     let ⟨ w, dst ⟩ ← parseRegW
-    pure ⟨ addr_w, w, .lea dst src ⟩
+    pure (.regular addr_w w (.lea dst src))
 
   | "leaq" | "leal" | "leaw" | "leab" =>
     let w2 ← instrWidth mn
@@ -701,13 +745,13 @@ def parseInstr : Parser Instr := do
     if w2 ≠ w then
       fail "inconsistency in {mn}"
     else
-      pure ⟨ addr_w, w, .lea dst src ⟩
+      pure (.regular addr_w w (.lea dst src))
 
   | "movups" =>
-    commaSeparated .none parseRegOrMem parseRegOrMem .movups
+    commaSeparatedAvx .none parseAvxRegOrMem parseAvxRegOrMem .movups
 
   | "vmovups" =>
-    commaSeparated .none parseRegOrMem parseRegOrMem .vmovups
+    commaSeparatedAvx .none parseAvxRegOrMem parseAvxRegOrMem .vmovups
 
   -- Bitwise - 64-bit
   | "xor" =>
@@ -727,12 +771,12 @@ def parseInstr : Parser Instr := do
   | "not" =>
     let (addr_w, dst) ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
-    pure ⟨ addr_w.getD .W64, w, .not dst ⟩
+    pure (.regular (addr_w.getD .W64) w (.not dst))
 
   | "notq" | "notl" | "notw" | "notb" =>
     let w ← instrWidth mn
     let (addr_w, dst) ← parseRegOrMemAO w
-    pure ⟨ addr_w.getD .W64, w, .not dst ⟩
+    pure (.regular (addr_w.getD .W64) w (.not dst))
 
   | "or" =>
     commaSeparated .none parseOperand parseRegOrMem .or
@@ -763,38 +807,38 @@ def parseInstr : Parser Instr := do
     let cnt ← parseOptionalShiftAndComma
     let (addr_w, dst) ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
-    pure ⟨ addr_w.getD .W64, w, .shl dst cnt ⟩
+    pure (.regular (addr_w.getD .W64) w (.shl dst cnt))
 
   | "shlq" | "shll" | "shlw" | "shlb"
   | "salq" | "sall" | "salw" | "salb" =>
     let w ← instrWidth mn
     let cnt ← parseOptionalShiftAndComma
     let (addr_w, dst) ← parseRegOrMemAO w
-    pure ⟨ addr_w.getD .W64, w, .shl dst cnt ⟩
+    pure (.regular (addr_w.getD .W64) w (.shl dst cnt))
 
   | "shr" =>
     let cnt ← parseOptionalShiftAndComma
     let (addr_w, dst) ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
-    pure ⟨ addr_w.getD .W64, w, .shr dst cnt ⟩
+    pure (.regular (addr_w.getD .W64) w (.shr dst cnt))
 
   | "shrq" | "shrl" | "shrw" | "shrb" =>
     let w ← instrWidth mn
     let cnt ← parseOptionalShiftAndComma
     let (addr_w, dst) ← parseRegOrMemAO w
-    pure ⟨ addr_w.getD .W64, w, .shr dst cnt ⟩
+    pure (.regular (addr_w.getD .W64) w (.shr dst cnt))
 
   | "sar" =>
     let cnt ← parseOptionalShiftAndComma
     let (addr_w, dst) ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
-    pure ⟨ addr_w.getD .W64, w, .sar dst cnt ⟩
+    pure (.regular (addr_w.getD .W64) w (.sar dst cnt))
 
   | "sarq" | "sarl" | "sarw" | "sarb" =>
     let w ← instrWidth mn
     let cnt ← parseOptionalShiftAndComma
     let (addr_w, dst) ← parseRegOrMemAO w
-    pure ⟨ addr_w.getD .W64, w, .sar dst cnt ⟩
+    pure (.regular (addr_w.getD .W64) w (.sar dst cnt))
 
   | "shld" =>
     let cnt ← parseShiftExpr; parseComma
@@ -819,30 +863,30 @@ def parseInstr : Parser Instr := do
     let cnt ← parseOptionalShiftAndComma
     let (addr_w, dst) ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
-    pure ⟨ addr_w.getD .W64, w, .rol dst cnt ⟩
+    pure (.regular (addr_w.getD .W64) w (.rol dst cnt))
 
   | "rolq" | "roll" | "rolw" | "rolb" =>
     let w ← instrWidth mn
     let cnt ← parseOptionalShiftAndComma
     let (addr_w, dst) ← parseRegOrMemAO w
-    pure ⟨ addr_w.getD .W64, w, .rol dst cnt ⟩
+    pure (.regular (addr_w.getD .W64) w (.rol dst cnt))
 
   | "ror" =>
     let cnt ← parseOptionalShiftAndComma
     let (addr_w, dst) ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
-    pure ⟨ addr_w.getD .W64, w, .ror dst cnt ⟩
+    pure (.regular (addr_w.getD .W64) w (.ror dst cnt))
 
   | "rorq" | "rorl" | "rorw" | "rorb" =>
     let w ← instrWidth mn
     let cnt ← parseOptionalShiftAndComma
     let (addr_w, dst) ← parseRegOrMemAO w
-    pure ⟨ addr_w.getD .W64, w, .ror dst cnt ⟩
+    pure (.regular (addr_w.getD .W64) w (.ror dst cnt))
 
   -- Byte swap
   | "bswap" =>
     let ⟨ w, dst ⟩ ← parseRegW
-    pure ⟨ .W64, w, .bswap dst ⟩
+    pure (.regular .W64 w (.bswap dst))
 
   | "bswapq" | "bswapl" =>
     let ⟨ w, dst ⟩ ← parseRegW
@@ -850,47 +894,47 @@ def parseInstr : Parser Instr := do
     if w2 ≠ w then
       fail "inconsistency in {mn}"
     else
-      pure ⟨ .W64, w, .bswap dst ⟩
+      pure (.regular .W64 w (.bswap dst))
 
   -- Stack operations
   | "push" =>
     let (addr_w, src) ← parseOperand
     let ⟨ w, src ⟩ ← assertW src
-    pure ⟨ addr_w.getD .W64, w, .push src ⟩
+    pure (.regular (addr_w.getD .W64) w (.push src))
 
   | "pushq" | "pushl" | "pushw" | "pushb" =>
     let w ← instrWidth mn
     let (addr_w, src) ← parseOperandAO w
-    pure ⟨ addr_w.getD .W64, w, .push src ⟩
+    pure (.regular (addr_w.getD .W64) w (.push src))
 
   | "pop" =>
     let (addr_w, dst) ← parseRegOrMem
     let ⟨ w, dst ⟩ ← assertW dst
-    pure ⟨ addr_w.getD .W64, w, .pop dst ⟩
+    pure (.regular (addr_w.getD .W64) w (.pop dst))
 
   | "popq" | "popl" | "popw" | "popb" =>
     let w ← instrWidth mn
     let (addr_w, dst) ← parseRegOrMemAO w
-    pure ⟨ addr_w.getD .W64, w, .pop dst ⟩
+    pure (.regular (addr_w.getD .W64) w (.pop dst))
 
   | "ret" | "retq" =>
-    pure ⟨ .W64, .W64, .ret ⟩
+    pure (.regular .W64 .W64 .ret)
 
   | "call" | "callq" =>
     let (addr_w, target) ← parseRelRegOrMem
-    pure ⟨ addr_w.getD .W64, .W64, .call target ⟩
+    pure (.regular (addr_w.getD .W64) .W64 (.call target))
 
   -- Control flow - unconditional jump
   | "jmp" | "jmpq" =>
     let (addr_w, target) ← parseRelRegOrMem
-    pure ⟨ addr_w.getD .W64, .W64, .jmp target ⟩
+    pure (.regular (addr_w.getD .W64) .W64 (.jmp target))
 
   | "nop" =>
     (do
       skipHWs
       let sz ← parseHexOrDec
-      pure ⟨ .W64, .W64, .nop sz.toNat ⟩
-    ) <|> (pure ⟨ .W64, .W64, .nop 1 ⟩)
+      pure (.regular .W64 .W64 (.nop sz.toNat))
+    ) <|> (pure (.regular .W64 .W64 (.nop 1)))
 
   -- Control flow - conditional jumps
   | _ =>
@@ -898,11 +942,11 @@ def parseInstr : Parser Instr := do
       let cc ← parseCondCode (mn.drop 1)
       skipHWs
       let target ← parseLabelRaw
-      pure ⟨ .W64, .W64, .jcc cc target ⟩
+      pure (.regular .W64 .W64 (.jcc cc target))
     else if mn.startsWith "set" then
       let cc ← parseCondCode (mn.drop 3)
       let (addr_w, dst) ← parseRegOrMemAO .W8
-      pure ⟨ addr_w.getD .W64, .W8, .setcc cc dst ⟩
+      pure (.regular (addr_w.getD .W64) .W8 (.setcc cc dst))
     else if mn.startsWith "cmov" then
       -- TODO: are the suffixed variants really used here? do we truly need to
       -- handle cmovzb and the like? how many are there? we could conceivably
@@ -942,7 +986,7 @@ def parseAlign : Parser Instr := do
     let pad ← parseHexOrDec
     pure (some pad.toNat)
   ) <|> pure none
-  pure ⟨ .W64, .W64, .nopalign alignment.toNat pad ⟩
+  pure (.regular .W64 .W64 (.nopalign alignment.toNat pad))
 
 def skipSpaceAndCheckLineEnd : Parser Bool := do
   skipHWs

--- a/Kraken/ParserTests.lean
+++ b/Kraken/ParserTests.lean
@@ -13,17 +13,15 @@ open Instr Operand Reg
 -- Test: Simple instruction
 /--
 info: [Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.add ↑(low Reg64.rbx Width.W64) ↑↑(low Reg64.rax Width.W64) }] : List Directive
+    (regular Width.W64 Width.W64
+      (Operation.add ↑(low Reg64.rbx Width.W64) ↑↑(low Reg64.rax Width.W64)))] : List Directive
 -/
 #guard_msgs in
 #check parse("addq %rax, %rbx")
 
 -- Test: Immediate operand
 /--
-info: [Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.mov ↑(low Reg64.rax Width.W64) ↑↑42 }] : List Directive
+info: [Directive.instr (regular Width.W64 Width.W64 (Operation.mov ↑(low Reg64.rax Width.W64) ↑↑42))] : List Directive
 -/
 #guard_msgs in
 #check parse("movq $42, %rax")
@@ -32,10 +30,9 @@ info: [Directive.instr
 -- Test: Memory operand with displacement
 /--
 info: [Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation :=
-        Operation.mov ↑(low Reg64.rax Width.W64)
-          ↑↑{ base := some (RegOrRip.reg Reg64.rsp), idx := none, disp := ↑8 } }] : List Directive
+    (regular Width.W64 Width.W64
+      (Operation.mov ↑(low Reg64.rax Width.W64)
+        ↑↑{ base := some (RegOrRip.reg Reg64.rsp), idx := none, disp := ↑8 }))] : List Directive
 -/
 #guard_msgs in
 #check parse("movq 8(%rsp), %rax")
@@ -44,11 +41,10 @@ info: [Directive.instr
 -- Test: Memory operand with index and scale
 /--
 info: [Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation :=
-        Operation.mov ↑(low Reg64.rax Width.W64)
-          ↑↑{ base := some (RegOrRip.reg Reg64.rsi),
-                idx := some { reg := Reg64.r15, scale := Width.W64 } } }] : List Directive
+    (regular Width.W64 Width.W64
+      (Operation.mov ↑(low Reg64.rax Width.W64)
+        ↑↑{ base := some (RegOrRip.reg Reg64.rsi),
+              idx := some { reg := Reg64.r15, scale := Width.W64 } }))] : List Directive
 -/
 #guard_msgs in
 #check parse("movq (%rsi, %r15, 8), %rax")
@@ -57,9 +53,7 @@ info: [Directive.instr
 -- Test: Labeled instruction
 /--
 info: [Directive.label "loop",
-  Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.add ↑(low Reg64.rcx Width.W64) ↑↑1 }] : List Directive
+  Directive.instr (regular Width.W64 Width.W64 (Operation.add ↑(low Reg64.rcx Width.W64) ↑↑1))] : List Directive
 -/
 #guard_msgs in
 #check parse("loop: addq $1, %rcx")
@@ -67,9 +61,7 @@ info: [Directive.label "loop",
 
 -- Test: Conditional jump
 /--
-info: [Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.jcc CondCode.nz "loop" }] : List Directive
+info: [Directive.instr (regular Width.W64 Width.W64 (Operation.jcc CondCode.nz "loop"))] : List Directive
 -/
 #guard_msgs in
 #check parse("jnz loop")
@@ -77,19 +69,10 @@ info: [Directive.instr
 
 -- Test: Multi-line program
 /--
-info: [Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.mov ↑(low Reg64.rax Width.W64) ↑↑0 },
-  Directive.label "loop",
-  Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.add ↑(low Reg64.rax Width.W64) ↑↑1 },
-  Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.cmp ↑(low Reg64.rax Width.W64) ↑↑10 },
-  Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.jcc CondCode.nz "loop" }] : List Directive
+info: [Directive.instr (regular Width.W64 Width.W64 (Operation.mov ↑(low Reg64.rax Width.W64) ↑↑0)), Directive.label "loop",
+  Directive.instr (regular Width.W64 Width.W64 (Operation.add ↑(low Reg64.rax Width.W64) ↑↑1)),
+  Directive.instr (regular Width.W64 Width.W64 (Operation.cmp ↑(low Reg64.rax Width.W64) ↑↑10)),
+  Directive.instr (regular Width.W64 Width.W64 (Operation.jcc CondCode.nz "loop"))] : List Directive
 -/
 #guard_msgs in
 #check parse("
@@ -102,18 +85,14 @@ loop:
 
 -- Test: Negative immediate
 /--
-info: [Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.add ↑(low Reg64.rax Width.W64) ↑↑(-1) }] : List Directive
+info: [Directive.instr (regular Width.W64 Width.W64 (Operation.add ↑(low Reg64.rax Width.W64) ↑↑(-1)))] : List Directive
 -/
 #guard_msgs in
 #check parse("addq $-1, %rax")
 
 -- Test: Hex immediate
 /--
-info: [Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.mov ↑(low Reg64.rax Width.W64) ↑↑255 }] : List Directive
+info: [Directive.instr (regular Width.W64 Width.W64 (Operation.mov ↑(low Reg64.rax Width.W64) ↑↑255))] : List Directive
 -/
 #guard_msgs in
 #check parse("movq $0xff, %rax")
@@ -121,9 +100,8 @@ info: [Directive.instr
 -- Test: mulx instruction
 /--
 info: [Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation :=
-        Operation.mulx (low Reg64.r10 Width.W64) (low Reg64.r9 Width.W64) ↑(low Reg64.r8 Width.W64) }] : List Directive
+    (regular Width.W64 Width.W64
+      (Operation.mulx (low Reg64.r10 Width.W64) (low Reg64.r9 Width.W64) ↑(low Reg64.r8 Width.W64)))] : List Directive
 -/
 #guard_msgs in
 #check parse("mulxq %r8, %r9, %r10")
@@ -131,8 +109,8 @@ info: [Directive.instr
 -- Test: xor for zeroing
 /--
 info: [Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation := Operation.xor ↑(low Reg64.rax Width.W64) ↑↑(low Reg64.rax Width.W64) }] : List Directive
+    (regular Width.W64 Width.W64
+      (Operation.xor ↑(low Reg64.rax Width.W64) ↑↑(low Reg64.rax Width.W64)))] : List Directive
 -/
 #guard_msgs in
 #check parse("xorq %rax, %rax")
@@ -140,22 +118,20 @@ info: [Directive.instr
 -- Test: lea with complex addressing
 /--
 info: [Directive.instr
-    { address_size := Width.W64, operation_size := Width.W64,
-      operation :=
-        Operation.lea (low Reg64.rax Width.W64)
-          { base := some (RegOrRip.reg Reg64.rbp), idx := some { reg := Reg64.rcx, scale := Width.W32 },
-            disp := ↑16 } }] : List Directive
+    (regular Width.W64 Width.W64
+      (Operation.lea (low Reg64.rax Width.W64)
+        { base := some (RegOrRip.reg Reg64.rbp), idx := some { reg := Reg64.rcx, scale := Width.W32 },
+          disp := ↑16 }))] : List Directive
 -/
 #guard_msgs in
 #check parse("leaq 16(%rbp, %rcx, 4), %rax")
 
 /--
 info: [Directive.instr
-    { address_size := Width.W32, operation_size := Width.W64,
-      operation :=
-        Operation.lea (low Reg64.rax Width.W64)
-          { base := some (RegOrRip.reg Reg64.rbp), idx := some { reg := Reg64.rcx, scale := Width.W32 },
-            disp := ↑16 } }] : List Directive
+    (regular Width.W32 Width.W64
+      (Operation.lea (low Reg64.rax Width.W64)
+        { base := some (RegOrRip.reg Reg64.rbp), idx := some { reg := Reg64.rcx, scale := Width.W32 },
+          disp := ↑16 }))] : List Directive
 -/
 #guard_msgs in
 #check parse("leaq 16(%ebp, %ecx, 4), %rax")

--- a/Kraken/PrintIntel.lean
+++ b/Kraken/PrintIntel.lean
@@ -12,6 +12,17 @@ instance : ToString Reg64 where
   | .r8  => "r8"  | .r9  => "r9"  | .r10 => "r10" | .r11 => "r11"
   | .r12 => "r12" | .r13 => "r13" | .r14 => "r14" | .r15 => "r15"
 
+instance : ToString RegMm where
+  toString r := match r with
+  | .mm0  => "mm0"  | .mm1  => "mm1"  | .mm2  => "mm2"  | .mm3  => "mm3"
+  | .mm4  => "mm4"  | .mm5  => "mm5"  | .mm6  => "mm6"  | .mm7  => "mm7"
+  | .mm8  => "mm8"  | .mm9  => "mm9"  | .mm10 => "mm10" | .mm11 => "mm11"
+  | .mm12 => "mm12" | .mm13 => "mm13" | .mm14 => "mm14" | .mm15 => "mm15"
+  | .mm16 => "mm16" | .mm17 => "mm17" | .mm18 => "mm18" | .mm19 => "mm19"
+  | .mm20 => "mm20" | .mm21 => "mm21" | .mm22 => "mm22" | .mm23 => "mm23"
+  | .mm24 => "mm24" | .mm25 => "mm25" | .mm26 => "mm26" | .mm27 => "mm27"
+  | .mm28 => "mm28" | .mm29 => "mm29" | .mm30 => "mm30" | .mm31 => "mm31"
+
 def Reg.toStr {w} (r : Reg w) : String := match w, r with
   | .W64, .low r _ => toString r
   | .W32, .low r _ => match r with
@@ -30,8 +41,15 @@ def Reg.toStr {w} (r : Reg w) : String := match w, r with
     | .r8  => "r8b" | .r9  => "r9b" | .r10 => "r10b" | .r11 => "r11b"
     | .r12 => "r12b"| .r13 => "r13b"| .r14 => "r14b"| .r15 => "r15b"
   | .W8, .ah => "ah" | .W8, .bh => "bh" | .W8, .ch => "ch" | .W8, .dh => "dh"
+  | _, .low r _ => "INVALID_" ++ toString r
 
 instance {w} : ToString (Reg w) where toString := Reg.toStr
+
+instance {w} : ToString (AvxReg w) where
+  toString r := match r with
+  | .xmm r => "x" ++ toString r
+  | .ymm r => "y" ++ toString r
+  | .zmm r => "z" ++ toString r
 
 def RegOrRip.toStr (b : RegOrRip) (addr_w : Width := .W64) : String := match b with
   | .reg r => toString (Reg.low r addr_w)
@@ -55,7 +73,11 @@ instance : ToString AddrExpr where toString a := a.toStr
 
 def RegOrMem.toStr {w} (rm : RegOrMem w) (addr_w : Width := .W64) : String := match rm with
   | .reg r => ToString.toString r
+  | .avx r => ToString.toString r
   | .mem a => match w with
+    | .W512 => "ZWORD PTR " ++ a.toStr addr_w
+    | .W256 => "YWORD PTR " ++ a.toStr addr_w
+    | .W128 => "OWORD PTR " ++ a.toStr addr_w
     | .W64 => "QWORD PTR " ++ a.toStr addr_w
     | .W32 => "DWORD PTR " ++ a.toStr addr_w
     | .W16 => "WORD PTR " ++ a.toStr addr_w
@@ -85,6 +107,8 @@ def Operation.toStr {w} (op : Operation w) (addr_w : Width := .W64) : String := 
   | .mov dst src => s!"mov {dst.toStr addr_w}, {src.toStr addr_w}"
   | .movsx dst src => s!"movsx {dst.toStr addr_w}, {src.toStr addr_w}"
   | .movzx dst src => s!"movzx {dst.toStr addr_w}, {src.toStr addr_w}"
+  | .movups dst src => s!"movups {dst.toStr addr_w}, {src.toStr addr_w}"
+  | .vmovups dst src => s!"vmovups {dst.toStr addr_w}, {src.toStr addr_w}"
   | .push src => s!"push {src.toStr addr_w}"
   | .pop dst => s!"pop {dst.toStr addr_w}"
   | .setcc cc dst => s!"set{cc} {dst.toStr addr_w}"
@@ -137,4 +161,3 @@ instance : ToString Directive where
   | .instr i => ToString.toString i
   | .label l => s!"{l}:"
   | .byteArray bs => ".byte "++", ".intercalate (bs.toList.map (fun b => s!"{b}"))
-

--- a/Kraken/PrintIntel.lean
+++ b/Kraken/PrintIntel.lean
@@ -82,9 +82,9 @@ instance {w} : ToString (RegOrMem w) where toString rm := rm.toStr
 def AvxRegOrMem.toStr {w} (rm : AvxRegOrMem w) (addr_w : Width := .W64) : String := match rm with
   | .avx r => ToString.toString r
   | .mem a => match w with
-    | .W512 => "ZWORD PTR " ++ a.toStr addr_w
-    | .W256 => "YWORD PTR " ++ a.toStr addr_w
-    | .W128 => "OWORD PTR " ++ a.toStr addr_w
+    | .W512 => "ZMMWORD PTR " ++ a.toStr addr_w
+    | .W256 => "YMMWORD PTR " ++ a.toStr addr_w
+    | .W128 => "XMMWORD PTR " ++ a.toStr addr_w
 instance {w} : ToString (AvxRegOrMem w) where toString rm := rm.toStr
 
 def Operand.toStr {w} (op : Operand w) (addr_w : Width := .W64) : String := match op with

--- a/Kraken/PrintIntel.lean
+++ b/Kraken/PrintIntel.lean
@@ -41,7 +41,6 @@ def Reg.toStr {w} (r : Reg w) : String := match w, r with
     | .r8  => "r8b" | .r9  => "r9b" | .r10 => "r10b" | .r11 => "r11b"
     | .r12 => "r12b"| .r13 => "r13b"| .r14 => "r14b"| .r15 => "r15b"
   | .W8, .ah => "ah" | .W8, .bh => "bh" | .W8, .ch => "ch" | .W8, .dh => "dh"
-  | _, .low r _ => "INVALID_" ++ toString r
 
 instance {w} : ToString (Reg w) where toString := Reg.toStr
 
@@ -73,21 +72,29 @@ instance : ToString AddrExpr where toString a := a.toStr
 
 def RegOrMem.toStr {w} (rm : RegOrMem w) (addr_w : Width := .W64) : String := match rm with
   | .reg r => ToString.toString r
-  | .avx r => ToString.toString r
   | .mem a => match w with
-    | .W512 => "ZWORD PTR " ++ a.toStr addr_w
-    | .W256 => "YWORD PTR " ++ a.toStr addr_w
-    | .W128 => "OWORD PTR " ++ a.toStr addr_w
     | .W64 => "QWORD PTR " ++ a.toStr addr_w
     | .W32 => "DWORD PTR " ++ a.toStr addr_w
     | .W16 => "WORD PTR " ++ a.toStr addr_w
     | .W8 => "BYTE PTR " ++ a.toStr addr_w
 instance {w} : ToString (RegOrMem w) where toString rm := rm.toStr
 
+def AvxRegOrMem.toStr {w} (rm : AvxRegOrMem w) (addr_w : Width := .W64) : String := match rm with
+  | .avx r => ToString.toString r
+  | .mem a => match w with
+    | .W512 => "ZWORD PTR " ++ a.toStr addr_w
+    | .W256 => "YWORD PTR " ++ a.toStr addr_w
+    | .W128 => "OWORD PTR " ++ a.toStr addr_w
+instance {w} : ToString (AvxRegOrMem w) where toString rm := rm.toStr
+
 def Operand.toStr {w} (op : Operand w) (addr_w : Width := .W64) : String := match op with
   | .regOrMem rm => rm.toStr addr_w
   | .imm v => toString v
 instance {w} : ToString (Operand w) where toString op := op.toStr
+
+def AvxOperand.toStr {w} (op : AvxOperand w) (addr_w : Width := .W64) : String := match op with
+  | .regOrMem rm => rm.toStr addr_w
+instance {w} : ToString (AvxOperand w) where toString op := op.toStr
 
 def RelRegOrMem.toStr (rel : RelRegOrMem) (addr_w : Width := .W64) : String := match rel with
   | .rel (.sub e .after_current_instruction) => toString e
@@ -107,8 +114,6 @@ def Operation.toStr {w} (op : Operation w) (addr_w : Width := .W64) : String := 
   | .mov dst src => s!"mov {dst.toStr addr_w}, {src.toStr addr_w}"
   | .movsx dst src => s!"movsx {dst.toStr addr_w}, {src.toStr addr_w}"
   | .movzx dst src => s!"movzx {dst.toStr addr_w}, {src.toStr addr_w}"
-  | .movups dst src => s!"movups {dst.toStr addr_w}, {src.toStr addr_w}"
-  | .vmovups dst src => s!"vmovups {dst.toStr addr_w}, {src.toStr addr_w}"
   | .push src => s!"push {src.toStr addr_w}"
   | .pop dst => s!"pop {dst.toStr addr_w}"
   | .setcc cc dst => s!"set{cc} {dst.toStr addr_w}"
@@ -153,8 +158,15 @@ def Operation.toStr {w} (op : Operation w) (addr_w : Width := .W64) : String := 
   | .nopalign a (some p) => s!".align {a}, {p}"
 instance {w} : ToString (Operation w) where toString op := op.toStr
 
+def AvxOperation.toStr {w} (op : AvxOperation w) (addr_w : Width := .W64) : String := match op with
+  | .movups dst src => s!"movups {dst.toStr addr_w}, {src.toStr addr_w}"
+  | .vmovups dst src => s!"vmovups {dst.toStr addr_w}, {src.toStr addr_w}"
+instance {w} : ToString (Operation w) where toString op := op.toStr
+
 instance : ToString Instr where
-  toString i := i.operation.toStr i.address_size
+  toString i := match i with
+  | .regular a _ o => o.toStr a
+  | .avx a _ o => o.toStr a
 
 instance : ToString Directive where
   toString

--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -28,6 +28,13 @@ def offset {w} (r : Reg w) : Nat := match r with
   | .ah | .bh | .ch | .dh => 8
 end Reg
 
+namespace AvxReg
+def base {w} (r : AvxReg w) : RegMm := match r with
+  | .xmm r => r
+  | .ymm r => r
+  | .zmm r => r
+end AvxReg
+
 structure Reg64s where
   rax : UInt64 := 0
   rbx : UInt64 := 0
@@ -76,6 +83,89 @@ def Reg64s.set (s : Reg64s) {w} (r : Reg w) (v : w.type) : Reg64s := match r wit
   | .ah | .bh | .ch | .dh => let old := s.get64 r.base;
     s.set64 r.base (old.replaceLow (BitVec.append v (s.get (.low r.base .W8))))
 
+def ZmmValue : Type := BitVec 512
+  deriving Repr, BEq, DecidableEq, Hashable, Hashable, Lean.ToExpr
+
+def zmmZero : ZmmValue := 0#512
+
+structure RegZmms where
+  zmm0  : ZmmValue := zmmZero
+  zmm1  : ZmmValue := zmmZero
+  zmm2  : ZmmValue := zmmZero
+  zmm3  : ZmmValue := zmmZero
+  zmm4  : ZmmValue := zmmZero
+  zmm5  : ZmmValue := zmmZero
+  zmm6  : ZmmValue := zmmZero
+  zmm7  : ZmmValue := zmmZero
+  zmm8  : ZmmValue := zmmZero
+  zmm9  : ZmmValue := zmmZero
+  zmm10 : ZmmValue := zmmZero
+  zmm11 : ZmmValue := zmmZero
+  zmm12 : ZmmValue := zmmZero
+  zmm13 : ZmmValue := zmmZero
+  zmm14 : ZmmValue := zmmZero
+  zmm15 : ZmmValue := zmmZero
+  zmm16 : ZmmValue := zmmZero
+  zmm17 : ZmmValue := zmmZero
+  zmm18 : ZmmValue := zmmZero
+  zmm19 : ZmmValue := zmmZero
+  zmm20 : ZmmValue := zmmZero
+  zmm21 : ZmmValue := zmmZero
+  zmm22 : ZmmValue := zmmZero
+  zmm23 : ZmmValue := zmmZero
+  zmm24 : ZmmValue := zmmZero
+  zmm25 : ZmmValue := zmmZero
+  zmm26 : ZmmValue := zmmZero
+  zmm27 : ZmmValue := zmmZero
+  zmm28 : ZmmValue := zmmZero
+  zmm29 : ZmmValue := zmmZero
+  zmm30 : ZmmValue := zmmZero
+  zmm31 : ZmmValue := zmmZero
+  zmm32 : ZmmValue := zmmZero
+  deriving Repr, BEq, DecidableEq, Hashable, Hashable, Lean.ToExpr
+
+def RegZmms.get512 (s : RegZmms) (r : RegMm) : Width.W512.type := (match r with
+  | .mm0  => s.zmm0  | .mm1  => s.zmm1  | .mm2  => s.zmm2  | .mm3  => s.zmm3
+  | .mm4  => s.zmm4  | .mm5  => s.zmm5  | .mm6  => s.zmm6  | .mm7  => s.zmm7
+  | .mm8  => s.zmm8  | .mm9  => s.zmm9  | .mm10 => s.zmm10 | .mm11 => s.zmm11
+  | .mm12 => s.zmm12 | .mm13 => s.zmm13 | .mm14 => s.zmm14 | .mm15 => s.zmm15
+  | .mm16 => s.zmm16 | .mm17 => s.zmm17 | .mm18 => s.zmm18 | .mm19 => s.zmm19
+  | .mm20 => s.zmm20 | .mm21 => s.zmm21 | .mm22 => s.zmm22 | .mm23 => s.zmm23
+  | .mm24 => s.zmm24 | .mm25 => s.zmm25 | .mm26 => s.zmm26 | .mm27 => s.zmm27
+  | .mm28 => s.zmm28 | .mm29 => s.zmm29 | .mm30 => s.zmm30 | .mm31 => s.zmm31)
+
+def RegZmms.set512 (regs : RegZmms) (r : RegMm) (v : Width.W512.type) : RegZmms :=
+  match r with
+  | .mm0  => { regs with zmm0  := v } | .mm1  => { regs with zmm1  := v }
+  | .mm2  => { regs with zmm2  := v } | .mm3  => { regs with zmm3  := v }
+  | .mm4  => { regs with zmm4  := v } | .mm5  => { regs with zmm5  := v }
+  | .mm6  => { regs with zmm6  := v } | .mm7  => { regs with zmm7  := v }
+  | .mm8  => { regs with zmm8  := v } | .mm9  => { regs with zmm9  := v }
+  | .mm10 => { regs with zmm10 := v } | .mm11 => { regs with zmm11 := v }
+  | .mm12 => { regs with zmm12 := v } | .mm13 => { regs with zmm13 := v }
+  | .mm14 => { regs with zmm14 := v } | .mm15 => { regs with zmm15 := v }
+  | .mm16 => { regs with zmm16 := v } | .mm17 => { regs with zmm17 := v }
+  | .mm18 => { regs with zmm18 := v } | .mm19 => { regs with zmm19 := v }
+  | .mm20 => { regs with zmm20 := v } | .mm21 => { regs with zmm21 := v }
+  | .mm22 => { regs with zmm22 := v } | .mm23 => { regs with zmm23 := v }
+  | .mm24 => { regs with zmm24 := v } | .mm25 => { regs with zmm25 := v }
+  | .mm26 => { regs with zmm26 := v } | .mm27 => { regs with zmm27 := v }
+  | .mm28 => { regs with zmm28 := v } | .mm29 => { regs with zmm29 := v }
+  | .mm30 => { regs with zmm30 := v } | .mm31 => { regs with zmm31 := v }
+
+def RegZmms.get (s : RegZmms) {w} (r : AvxReg w) : w.type :=
+  (s.get512 r.base).take w.bits
+
+def RegZmms.set (s : RegZmms) {w} (r : AvxReg w) (v : w.type) : RegZmms := match r with
+  | .zmm r => s.set512 r v
+  | .ymm r => s.set512 r (v.zeroExtend _)
+  | .xmm r => s.set512 r (v.zeroExtend _)
+
+def RegZmms.setLegacy (s : RegZmms) {w} (r : AvxReg w) (v : w.type) : RegZmms := match r with
+  | .zmm r => s.set512 r v  -- impossible
+  | .ymm r => s.set512 r ((s.get512 r).replaceLow v)  -- impossible
+  | .xmm r => s.set512 r ((s.get512 r).replaceLow v)
+
 def BitVec.toAddressSize [address_size: AddressSize] (w: BitVec 64): BitVec address_size.address_size.bits :=
   w.take address_size.address_size.bits
 
@@ -92,6 +182,7 @@ abbrev DataMem := Mem 64
 instance : Repr DataMem where reprPrec _ _ := "<opaque memory>"
 structure MachineData where -- does not include code or program position
   regs : Reg64s := {}
+  zmms : RegZmms := {}
   status : StatusFlags := .mk false false false false false false
   dmem : DataMem := ∅
   deriving Repr, BEq, DecidableEq
@@ -186,15 +277,28 @@ def RegOrMem.interp {w} [Labels] [AddressSize]
   (ret : w.type → MachineData → Effects) :=
   match o with
   | .reg r => ret (s.regs.get r) s
+  | .avx r => ret (s.zmms.get r) s
   | .mem a => s.load ((a.interp s.regs p).zeroExtend _) w ret
 
 def MachineData.setReg (s : MachineData) {w} (r : Reg w) (v : w.type) : MachineData :=
   { s with regs := s.regs.set r v }
 
+def MachineData.setAvx (s : MachineData) {w} (r : AvxReg w) (v : w.type) : MachineData :=
+  { s with zmms := s.zmms.set r v }
+
+def MachineData.setAvxLegacy (s : MachineData) {w} (r : AvxReg w) (v : w.type) : MachineData :=
+  { s with zmms := s.zmms.setLegacy r v }
+
 def MachineData.set {w} [Labels] [AddressSize] (s : MachineData) (d : Dst w) (v : w.type) (p : Std.Rco Int64) (ret : MachineData → Effects) : Effects :=
   match d with
   | .reg r => ret (s.setReg r v)
+  | .avx r => ret (s.setAvx r v)
   | .mem a => s.store ((a.interp s.regs p).zeroExtend _) v ret
+
+def MachineData.setLegacy {w} [Labels] [AddressSize] (s : MachineData) (d : Dst w) (v : w.type) (p : Std.Rco Int64) (ret : MachineData → Effects) : Effects :=
+  match d with
+  | .avx r => ret (s.setAvxLegacy r v)
+  | _ => MachineData.set s d v p ret
 
 def Operand.interp {w} [Labels] [AddressSize]
   (o : Operand w) (s : MachineData) (p : Std.Rco Int64)
@@ -254,6 +358,8 @@ def Operation.interp [Labels] [address_size : AddressSize]
   | .mov dst src => src.interp s p (fun val s => s.set dst val p next)
   | .movsx dst src => src.interp s p (fun val s => s.set dst (val.signExtend _) p next)
   | .movzx dst src => src.interp s p (fun val s => s.set dst (val.zeroExtend _) p next)
+  | .movups dst src => src.interp s p (fun val s => s.setLegacy dst val p next)
+  | .vmovups dst src => src.interp s p (fun val s => s.set dst val p next)
   | .push src =>
     src.interp s p (fun v s =>
     let rsp := s.regs.get64 .rsp - w.bytesv
@@ -623,8 +729,3 @@ abbrev eval [layout : Layout] (prog : Program) := (layout prog).eval
   let start := exe.labels.label "main"
   let data := { dmem := Mem.storeInt {} 0x100 8 0x1337, regs := {rsp := 0x100} }
   (exe.eval (data, start) (fun (_, pc) => pc = 0x1337)).bind (fun s => .ok s.1.regs.rax)
-
-
-
-
-

--- a/Kraken/Semantics.lean
+++ b/Kraken/Semantics.lean
@@ -124,7 +124,7 @@ structure RegZmms where
   zmm32 : ZmmValue := zmmZero
   deriving Repr, BEq, DecidableEq, Hashable, Hashable, Lean.ToExpr
 
-def RegZmms.get512 (s : RegZmms) (r : RegMm) : Width.W512.type := (match r with
+def RegZmms.get512 (s : RegZmms) (r : RegMm) : AvxWidth.W512.type := (match r with
   | .mm0  => s.zmm0  | .mm1  => s.zmm1  | .mm2  => s.zmm2  | .mm3  => s.zmm3
   | .mm4  => s.zmm4  | .mm5  => s.zmm5  | .mm6  => s.zmm6  | .mm7  => s.zmm7
   | .mm8  => s.zmm8  | .mm9  => s.zmm9  | .mm10 => s.zmm10 | .mm11 => s.zmm11
@@ -134,7 +134,7 @@ def RegZmms.get512 (s : RegZmms) (r : RegMm) : Width.W512.type := (match r with
   | .mm24 => s.zmm24 | .mm25 => s.zmm25 | .mm26 => s.zmm26 | .mm27 => s.zmm27
   | .mm28 => s.zmm28 | .mm29 => s.zmm29 | .mm30 => s.zmm30 | .mm31 => s.zmm31)
 
-def RegZmms.set512 (regs : RegZmms) (r : RegMm) (v : Width.W512.type) : RegZmms :=
+def RegZmms.set512 (regs : RegZmms) (r : RegMm) (v : AvxWidth.W512.type) : RegZmms :=
   match r with
   | .mm0  => { regs with zmm0  := v } | .mm1  => { regs with zmm1  := v }
   | .mm2  => { regs with zmm2  := v } | .mm3  => { regs with zmm3  := v }
@@ -190,6 +190,7 @@ structure MachineData where -- does not include code or program position
 -- We only allow nondeterministic choices for a fixed set of types.
 class inductive NondetSupportingType : Type -> Type
   | bitvec (w : Width) : NondetSupportingType w.type
+  | avx_bitvec (aw : AvxWidth) : NondetSupportingType aw.type
   | bool : NondetSupportingType Bool
   | statusFlags : NondetSupportingType StatusFlags
 
@@ -198,8 +199,10 @@ def NondetSupportingType.from_hash {α} [t : NondetSupportingType α] (h : UInt6
   | .bool => h % 2 != 0
   | .statusFlags => let h := h.toBitVec; (.mk h[0] h[1] h[2] h[3] h[4] h[5])
   | .bitvec w => h.toBitVec.setWidth w.bits
+  | .avx_bitvec w => h.toBitVec.setWidth w.bits
 
 instance (w : Width) : NondetSupportingType w.type := .bitvec w
+instance (w : AvxWidth) : NondetSupportingType w.type := .avx_bitvec w
 instance : NondetSupportingType Bool := .bool
 instance : NondetSupportingType StatusFlags := .statusFlags
 
@@ -243,6 +246,14 @@ def MachineData.load
     | .some i => ret (.ofInt _ i) s
     | .none => nonmem_load s.dmem addr w (fun v dmem => ret v { s with dmem }))
 
+def MachineData.loadAvx
+  (s : MachineData) (addr : BitVec 64) (w : AvxWidth)
+  (ret : w.type → MachineData → Effects): Effects :=
+  require_read_access addr .W64 (fun _unit =>
+match Mem.loadInt s.dmem addr w.bytes with
+    | .some i => ret (.ofInt _ i) s
+    | .none => unimplemented "AVX nonmem load not supported")
+
 def MachineData.store (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.type) (ret: MachineData → Effects) : Effects :=
   require_write_access addr w (fun _unit =>
     match Mem.loadInt s.dmem addr w.bytes with
@@ -250,6 +261,12 @@ def MachineData.store (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.ty
         ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
     | .none => nonmem_store s.dmem addr v (fun dmem' => ret { s with dmem := dmem' }))
 
+def MachineData.storeAvx (s : MachineData) (addr : BitVec 64) {w : AvxWidth} (v : w.type) (ret: MachineData → Effects) : Effects :=
+  require_write_access addr .W64 (fun _unit =>
+match Mem.loadInt s.dmem addr w.bytes with
+    | .some _ =>
+        ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
+    | .none => unimplemented "AVX nonmem store not supported")
 
 class Labels where label : Label → Int64
 export Labels (label)
@@ -275,30 +292,40 @@ def AddrExpr.interp [Labels] [address_size : AddressSize] (a : AddrExpr) (s : Re
 def RegOrMem.interp {w} [Labels] [AddressSize]
   (o : RegOrMem w) (s : MachineData) (p : Std.Rco Int64)
   (ret : w.type → MachineData → Effects) :=
-  match o with
+match o with
   | .reg r => ret (s.regs.get r) s
-  | .avx r => ret (s.zmms.get r) s
   | .mem a => s.load ((a.interp s.regs p).zeroExtend _) w ret
+
+def AvxRegOrMem.interp {w} [Labels] [AddressSize]
+  (o : AvxRegOrMem w) (s : MachineData) (p : Std.Rco Int64)
+  (ret : w.type → MachineData → Effects) :=
+match o with
+  | .avx r => ret (s.zmms.get r) s
+  | .mem a => s.loadAvx ((a.interp s.regs p).zeroExtend _) w ret
 
 def MachineData.setReg (s : MachineData) {w} (r : Reg w) (v : w.type) : MachineData :=
   { s with regs := s.regs.set r v }
 
-def MachineData.setAvx (s : MachineData) {w} (r : AvxReg w) (v : w.type) : MachineData :=
+def MachineData.setAvxReg (s : MachineData) {w : AvxWidth} (r : AvxReg w) (v : w.type) : MachineData :=
   { s with zmms := s.zmms.set r v }
 
-def MachineData.setAvxLegacy (s : MachineData) {w} (r : AvxReg w) (v : w.type) : MachineData :=
+def MachineData.setAvxLegacyReg (s : MachineData) {w : AvxWidth} (r : AvxReg w) (v : w.type) : MachineData :=
   { s with zmms := s.zmms.setLegacy r v }
 
 def MachineData.set {w} [Labels] [AddressSize] (s : MachineData) (d : Dst w) (v : w.type) (p : Std.Rco Int64) (ret : MachineData → Effects) : Effects :=
   match d with
   | .reg r => ret (s.setReg r v)
-  | .avx r => ret (s.setAvx r v)
   | .mem a => s.store ((a.interp s.regs p).zeroExtend _) v ret
 
-def MachineData.setLegacy {w} [Labels] [AddressSize] (s : MachineData) (d : Dst w) (v : w.type) (p : Std.Rco Int64) (ret : MachineData → Effects) : Effects :=
-  match d with
-  | .avx r => ret (s.setAvxLegacy r v)
-  | _ => MachineData.set s d v p ret
+def MachineData.setAvx {aw} [Labels] [AddressSize] (s : MachineData) (d : AvxDst aw) (v : aw.type) (p : Std.Rco Int64) (ret : MachineData → Effects) : Effects :=
+match d with
+  | .avx r => ret (s.setAvxReg r v)
+  | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v ret
+
+def MachineData.setAvxLegacy {w} [Labels] [AddressSize] (s : MachineData) (d : AvxDst w) (v : w.type) (p : Std.Rco Int64) (ret : MachineData → Effects) : Effects :=
+match d with
+  | .avx r => ret (s.setAvxLegacyReg r v)
+  | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v ret
 
 def Operand.interp {w} [Labels] [AddressSize]
   (o : Operand w) (s : MachineData) (p : Std.Rco Int64)
@@ -307,6 +334,12 @@ def Operand.interp {w} [Labels] [AddressSize]
   | regOrMem rm => rm.interp s p ret
   | .imm v => ret ((v.interp p).toBitVec.truncate _) s
   -- we rely on assemblers erroring out on too-large immediates in uniform ops
+
+def AvxOperand.interp {aw} [Labels] [AddressSize]
+  (o : AvxOperand aw) (s : MachineData) (p : Std.Rco Int64)
+  (ret : aw.type → MachineData → Effects) :=
+match o with
+  | regOrMem rm => rm.interp s p ret
 
 def CondCode.interp (cc : CondCode) (s : StatusFlags) : Bool := match cc with
   | .z  => s.zf | .nz => !s.zf | .c  => s.cf | .nc => !s.cf
@@ -358,8 +391,6 @@ def Operation.interp [Labels] [address_size : AddressSize]
   | .mov dst src => src.interp s p (fun val s => s.set dst val p next)
   | .movsx dst src => src.interp s p (fun val s => s.set dst (val.signExtend _) p next)
   | .movzx dst src => src.interp s p (fun val s => s.set dst (val.zeroExtend _) p next)
-  | .movups dst src => src.interp s p (fun val s => s.setLegacy dst val p next)
-  | .vmovups dst src => src.interp s p (fun val s => s.set dst val p next)
   | .push src =>
     src.interp s p (fun v s =>
     let rsp := s.regs.get64 .rsp - w.bytesv
@@ -633,11 +664,24 @@ def Operation.interp [Labels] [address_size : AddressSize]
     jmp (.ofBitVec ra) { s with regs := s.regs.set64 .rsp (rsp + 8) })
   | nop _ | nopalign _ _ => next s
 
+-- AVX Operations Interpreter
+def AvxOperation.interp [Labels] [address_size : AddressSize]
+  {w} (i : AvxOperation w) (p : Std.Rco Int64) (s : MachineData)
+  (next : MachineData → Effects) : Effects :=
+match i with
+  | .movups dst src => src.interp s p (fun val s => s.setAvxLegacy dst val p next)
+  | .vmovups dst src => src.interp s p (fun val s => s.setAvx dst val p next)
+
 def Instr.interp [Labels]
   (i : Instr) (s : MachineData) (p : Std.Rco Int64)
   (next : MachineData → Effects) (jmp : Int64 → MachineData → Effects) : Effects :=
   require_exec_access p (fun _unit =>
-    Operation.interp (w := i.operation_size ) (address_size := .mk i.address_size) i.operation p s next jmp)
+    match i with
+      | .regular addr_sz op_sz op =>
+          Operation.interp (w := op_sz) (address_size := .mk addr_sz) op p s next jmp
+      | .avx addr_sz op_sz op =>
+          AvxOperation.interp (w := op_sz) (address_size := .mk addr_sz) op p s next
+  )
 
 def Directive.interp [Labels]
   (d : Directive) (s : MachineData) (p : Std.Rco Int64)
@@ -706,7 +750,7 @@ where
 def Directive.fakeSize (hashOfProgram : UInt64) (d : Directive) : Nat :=
   match d with
   | .label _ => 0
-  | .instr (.mk _ _ (.nop sz)) => sz -- may be zero
+  | .instr (.regular _ _ (.nop sz)) => sz -- may be zero
   | .instr i => (1 + hash (hashOfProgram, i) % 15).toNat
   | .byteArray bs => bs.size
 
@@ -723,9 +767,9 @@ abbrev eval [layout : Layout] (prog : Program) := (layout prog).eval
 #eval
   let exe := Program.fakeLayout [
     .label "main",
-    .instr (.mk .W64 .W64 (.lea (.low .rax .W64) (.mk .none .none (.int64 41)))),
-    .instr (.mk .W64 .W64 (.inc (.reg (.low .rax .W64)))),
-    .instr (.mk .W64 .W64 .ret) ]
+    .instr (.regular .W64 .W64 (.lea (.low .rax .W64) (.mk .none .none (.int64 41)))),
+    .instr (.regular .W64 .W64 (.inc (.reg (.low .rax .W64)))),
+    .instr (.regular .W64 .W64 .ret) ]
   let start := exe.labels.label "main"
   let data := { dmem := Mem.storeInt {} 0x100 8 0x1337, regs := {rsp := 0x100} }
   (exe.eval (data, start) (fun (_, pc) => pc = 0x1337)).bind (fun s => .ok s.1.regs.rax)

--- a/Kraken/Syntax.lean
+++ b/Kraken/Syntax.lean
@@ -244,6 +244,12 @@ inductive Instr
   | avx (address_size : Width) (operation_size : AvxWidth) (operation : AvxOperation operation_size)
   deriving Repr, DecidableEq, Hashable, Lean.ToExpr
 
+instance [AddressSize] {w : Width} : CoeOut (Operation w) Instr where
+  coe op := Instr.regular address_size w op
+
+instance [AddressSize] {w : AvxWidth} : CoeOut (AvxOperation w) Instr where
+  coe op := Instr.avx address_size w op
+
 instance : Repr ByteArray where reprPrec _ _ := "<opaque byte array>"
 
 deriving instance Lean.ToExpr for ByteArray

--- a/Kraken/Syntax.lean
+++ b/Kraken/Syntax.lean
@@ -1,14 +1,14 @@
 import Lean
 import Std
 
-inductive Width | W8 | W16 | W32 | W64 | W128 | W256 | W512 deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
+inductive Width | W8 | W16 | W32 | W64 deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 instance : ToString Width where
-  toString | .W8 => "w8" | .W16 => "w16" | .W32 => "w32" | .W64 => "w64" | .W128 => "w128" | .W256 => "w256" | .W512 => "w512"
+  toString | .W8 => "w8" | .W16 => "w16" | .W32 => "w32" | .W64 => "w64"
 
 namespace Width
-@[simp, reducible] def bits : Width → Nat | W8 => 8 | W16 => 16 | W32 => 32 | W64 => 64 | W128 => 128 | W256 => 256 | W512 => 512
-@[simp, reducible] def bytes : Width → Nat | W8 => 1 | W16 => 2 | W32 => 4 | W64 => 8 | W128 => 16 | W256 => 32 | W512 => 64
+@[simp, reducible] def bits : Width → Nat | W8 => 8 | W16 => 16 | W32 => 32 | W64 => 64
+@[simp, reducible] def bytes : Width → Nat | W8 => 1 | W16 => 2 | W32 => 4 | W64 => 8
 abbrev bytesv (w : Width) {n} : BitVec n := BitVec.ofNat n w.bytes
 abbrev type (w : Width) : Type := BitVec w.bits
 instance {w : Width} : Coe Bool w.type where coe := fun b : Bool => BitVec.ofNat _ b.toNat
@@ -26,14 +26,27 @@ unif_hint (w : Width) where
 unif_hint (w : Width) where
   w =?= Width.W64 |- Width.type w =?= BitVec 64
 
-unif_hint (w : Width) where
-  w =?= Width.W128 |- Width.type w =?= BitVec 128
+inductive AvxWidth | W128 | W256 | W512 deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
-unif_hint (w : Width) where
-  w =?= Width.W256 |- Width.type w =?= BitVec 256
+instance : ToString AvxWidth where
+  toString |.W128 => "w128" | .W256 => "w256" | .W512 => "w512"
 
-unif_hint (w : Width) where
-  w =?= Width.W512 |- Width.type w =?= BitVec 512
+namespace AvxWidth
+@[simp, reducible] def bits : AvxWidth → Nat | W128 => 128 | W256 => 256 | W512 => 512
+@[simp, reducible] def bytes : AvxWidth → Nat | W128 => 16 | W256 => 32 | W512 => 64
+abbrev bytesv (w : AvxWidth) {n} : BitVec n := BitVec.ofNat n w.bytes
+abbrev type (w : AvxWidth) : Type := BitVec w.bits
+instance {w : AvxWidth} : Coe Bool w.type where coe := fun b : Bool => BitVec.ofNat _ b.toNat
+end AvxWidth
+
+unif_hint (w : AvxWidth) where
+  w =?= AvxWidth.W128 |- AvxWidth.type w =?= BitVec 128
+
+unif_hint (w : AvxWidth) where
+  w =?= AvxWidth.W256 |- AvxWidth.type w =?= BitVec 256
+
+unif_hint (w : AvxWidth) where
+  w =?= AvxWidth.W512 |- AvxWidth.type w =?= BitVec 512
 
 inductive RegMm
   | mm0  | mm1  | mm2  | mm3
@@ -58,10 +71,10 @@ inductive Reg : Width → Type
   | ah : Reg .W8 | bh : Reg .W8 | ch : Reg .W8| dh : Reg .W8
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
-inductive AvxReg : Width → Type
-  | xmm (_ : RegMm) : AvxReg Width.W128
-  | ymm (_ : RegMm) : AvxReg Width.W256
-  | zmm (_ : RegMm) : AvxReg Width.W512
+inductive AvxReg : AvxWidth → Type
+  | xmm (_ : RegMm) : AvxReg AvxWidth.W128
+  | ymm (_ : RegMm) : AvxReg AvxWidth.W256
+  | zmm (_ : RegMm) : AvxReg AvxWidth.W512
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 abbrev Label := String
@@ -83,7 +96,7 @@ attribute [coe] ConstExpr.int64
 structure RegW where (w : Width) (reg : Reg w)
   deriving Repr, DecidableEq, Hashable, Lean.ToExpr, Hashable, Lean.ToExpr
 
-structure AvxRegW where (w : Width) (reg : AvxReg w)
+structure AvxRegW where (w : AvxWidth) (reg : AvxReg w)
   deriving Repr, DecidableEq, Hashable, Lean.ToExpr, Hashable, Lean.ToExpr
 
 -- For address expressions, the width of the register is determined only by the
@@ -121,19 +134,21 @@ structure AddrExpr where
 class AddressSize where address_size : Width
 export AddressSize (address_size)
 
--- We already admit impossible instructions like mov [rax] [rax];
--- instead of splitting the world of operands (or sub-splitting
--- RegOrMem into regular registers or AvxRegOrMem), allow RegOrMem
--- to use avx registers directly.
-inductive RegOrMem w | reg (r : Reg w) | avx (r : AvxReg w) | mem (_ : AddrExpr)
+inductive RegOrMem w | reg (r : Reg w) | mem (_ : AddrExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 instance {w} : Coe AddrExpr (RegOrMem w) where coe := RegOrMem.mem
 attribute [coe] RegOrMem.mem
 instance {w} : Coe (Reg w) (RegOrMem w) where coe := .reg
 attribute [coe] RegOrMem.reg
-instance {w} : Coe (AvxReg w) (RegOrMem w) where coe := .avx
-attribute [coe] RegOrMem.avx
 abbrev Dst := RegOrMem
+
+inductive AvxRegOrMem (w : AvxWidth) | avx (r : AvxReg w) | mem (_ : AddrExpr)
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
+instance {w} : Coe AddrExpr (AvxRegOrMem w) where coe := AvxRegOrMem.mem
+attribute [coe] AvxRegOrMem.mem
+instance {w} : Coe (AvxReg w) (AvxRegOrMem w) where coe := .avx
+attribute [coe] AvxRegOrMem.avx
+abbrev AvxDst := AvxRegOrMem
 
 inductive Operand w | regOrMem (_ : RegOrMem w) | imm (v : ConstExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
@@ -142,8 +157,15 @@ attribute [coe] Operand.regOrMem
 instance {w} : Coe ConstExpr (Operand w) where coe := Operand.imm
 attribute [coe] Operand.imm
 abbrev Operand.reg {w} (r : Reg w) : Operand w := regOrMem (.reg r)
-abbrev Operand.avx {w} (r : AvxReg w) : Operand w := regOrMem (.avx r)
 abbrev Operand.mem {w} (m : AddrExpr) : Operand w := regOrMem (.mem m)
+
+-- TODO: We could remove this and use AvxRegOrMem directly.
+inductive AvxOperand (w : AvxWidth) | regOrMem (_ : AvxRegOrMem w)
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
+instance {w} : Coe (AvxRegOrMem w) (AvxOperand w) where coe := .regOrMem
+attribute [coe] AvxOperand.regOrMem
+abbrev AvxOperand.avx {w} (r : AvxReg w) : AvxOperand w := regOrMem (.avx r)
+abbrev AvxOperand.mem {w} (m : AddrExpr) : AvxOperand w := regOrMem (.mem m)
 
 inductive CondCode | z | nz | c | nc | a | be
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
@@ -163,8 +185,6 @@ inductive Operation (w : Width)
   | mov (_ : Dst w) (src : Operand w)
   | movsx {w'} (_ : Dst w) (src : RegOrMem w') -- {_ : w'.bits < w.bits ∧ w'.bits < 32}
   | movzx {w'} (_ : Dst w) (src : RegOrMem w') -- {_ : w'.bits < w.bits ∧ w'.bits < 32}
-  | movups (_ : Dst w) (src : RegOrMem w) -- sse regs
-  | vmovups (_ : Dst w) (src : RegOrMem w) -- avx regs
   | push (src : Operand w)
   | pop  (_ : Dst w)
   | setcc (_ : CondCode) (_ : Dst w) -- {_ : w = .W8}
@@ -214,10 +234,14 @@ inductive Operation (w : Width)
   | nopalign (alignment : Nat) (pad : Option Nat)
   deriving Repr, DecidableEq, Hashable, Lean.ToExpr
 
-structure Instr where
-  address_size : Width
-  operation_size : Width
-  operation : Operation operation_size
+inductive AvxOperation (w : AvxWidth)
+  | movups (_ : AvxDst w) (src : AvxRegOrMem w) -- sse regs only (TODO: constrain to .W128)
+  | vmovups (_ : AvxDst w) (src : AvxRegOrMem w)
+  deriving Repr, DecidableEq, Hashable, Lean.ToExpr
+
+inductive Instr
+  | regular (address_size : Width) (operation_size : Width) (operation : Operation operation_size)
+  | avx (address_size : Width) (operation_size : AvxWidth) (operation : AvxOperation operation_size)
   deriving Repr, DecidableEq, Hashable, Lean.ToExpr
 
 instance : Repr ByteArray where reprPrec _ _ := "<opaque byte array>"

--- a/Kraken/Syntax.lean
+++ b/Kraken/Syntax.lean
@@ -1,14 +1,14 @@
 import Lean
 import Std
 
-inductive Width | W8 | W16 | W32 | W64 deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
+inductive Width | W8 | W16 | W32 | W64 | W128 | W256 | W512 deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 instance : ToString Width where
-  toString | .W8 => "w8" | .W16 => "w16" | .W32 => "w32" | .W64 => "w64"
+  toString | .W8 => "w8" | .W16 => "w16" | .W32 => "w32" | .W64 => "w64" | .W128 => "w128" | .W256 => "w256" | .W512 => "w512"
 
 namespace Width
-@[simp, reducible] def bits : Width → Nat | W8 => 8 | W16 => 16 | W32 => 32 | W64 => 64
-@[simp, reducible] def bytes : Width → Nat | W8 => 1 | W16 => 2 | W32 => 4 | W64 => 8
+@[simp, reducible] def bits : Width → Nat | W8 => 8 | W16 => 16 | W32 => 32 | W64 => 64 | W128 => 128 | W256 => 256 | W512 => 512
+@[simp, reducible] def bytes : Width → Nat | W8 => 1 | W16 => 2 | W32 => 4 | W64 => 8 | W128 => 16 | W256 => 32 | W512 => 64
 abbrev bytesv (w : Width) {n} : BitVec n := BitVec.ofNat n w.bytes
 abbrev type (w : Width) : Type := BitVec w.bits
 instance {w : Width} : Coe Bool w.type where coe := fun b : Bool => BitVec.ofNat _ b.toNat
@@ -26,6 +26,26 @@ unif_hint (w : Width) where
 unif_hint (w : Width) where
   w =?= Width.W64 |- Width.type w =?= BitVec 64
 
+unif_hint (w : Width) where
+  w =?= Width.W128 |- Width.type w =?= BitVec 128
+
+unif_hint (w : Width) where
+  w =?= Width.W256 |- Width.type w =?= BitVec 256
+
+unif_hint (w : Width) where
+  w =?= Width.W512 |- Width.type w =?= BitVec 512
+
+inductive RegMm
+  | mm0  | mm1  | mm2  | mm3
+  | mm4  | mm5  | mm6  | mm7
+  | mm8  | mm9  | mm10 | mm11
+  | mm12 | mm13 | mm14 | mm15
+  | mm16 | mm17 | mm18 | mm19
+  | mm20 | mm21 | mm22 | mm23
+  | mm24 | mm25 | mm26 | mm27
+  | mm28 | mm29 | mm30 | mm31
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
+
 inductive Reg64
   | rax | rbx | rcx | rdx
   | rsi | rdi | rsp | rbp
@@ -36,6 +56,12 @@ inductive Reg64
 inductive Reg : Width → Type
   | low (_ : Reg64) (w : Width) : Reg w
   | ah : Reg .W8 | bh : Reg .W8 | ch : Reg .W8| dh : Reg .W8
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
+
+inductive AvxReg : Width → Type
+  | xmm (_ : RegMm) : AvxReg Width.W128
+  | ymm (_ : RegMm) : AvxReg Width.W256
+  | zmm (_ : RegMm) : AvxReg Width.W512
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 abbrev Label := String
@@ -55,6 +81,9 @@ attribute [coe] ConstExpr.label
 attribute [coe] ConstExpr.int64
 
 structure RegW where (w : Width) (reg : Reg w)
+  deriving Repr, DecidableEq, Hashable, Lean.ToExpr, Hashable, Lean.ToExpr
+
+structure AvxRegW where (w : Width) (reg : AvxReg w)
   deriving Repr, DecidableEq, Hashable, Lean.ToExpr, Hashable, Lean.ToExpr
 
 -- For address expressions, the width of the register is determined only by the
@@ -92,12 +121,18 @@ structure AddrExpr where
 class AddressSize where address_size : Width
 export AddressSize (address_size)
 
-inductive RegOrMem w | reg (r : Reg w) | mem (_ : AddrExpr)
+-- We already admit impossible instructions like mov [rax] [rax];
+-- instead of splitting the world of operands (or sub-splitting
+-- RegOrMem into regular registers or AvxRegOrMem), allow RegOrMem
+-- to use avx registers directly.
+inductive RegOrMem w | reg (r : Reg w) | avx (r : AvxReg w) | mem (_ : AddrExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 instance {w} : Coe AddrExpr (RegOrMem w) where coe := RegOrMem.mem
 attribute [coe] RegOrMem.mem
 instance {w} : Coe (Reg w) (RegOrMem w) where coe := .reg
 attribute [coe] RegOrMem.reg
+instance {w} : Coe (AvxReg w) (RegOrMem w) where coe := .avx
+attribute [coe] RegOrMem.avx
 abbrev Dst := RegOrMem
 
 inductive Operand w | regOrMem (_ : RegOrMem w) | imm (v : ConstExpr)
@@ -107,6 +142,7 @@ attribute [coe] Operand.regOrMem
 instance {w} : Coe ConstExpr (Operand w) where coe := Operand.imm
 attribute [coe] Operand.imm
 abbrev Operand.reg {w} (r : Reg w) : Operand w := regOrMem (.reg r)
+abbrev Operand.avx {w} (r : AvxReg w) : Operand w := regOrMem (.avx r)
 abbrev Operand.mem {w} (m : AddrExpr) : Operand w := regOrMem (.mem m)
 
 inductive CondCode | z | nz | c | nc | a | be
@@ -127,6 +163,8 @@ inductive Operation (w : Width)
   | mov (_ : Dst w) (src : Operand w)
   | movsx {w'} (_ : Dst w) (src : RegOrMem w') -- {_ : w'.bits < w.bits ∧ w'.bits < 32}
   | movzx {w'} (_ : Dst w) (src : RegOrMem w') -- {_ : w'.bits < w.bits ∧ w'.bits < 32}
+  | movups (_ : Dst w) (src : RegOrMem w) -- sse regs
+  | vmovups (_ : Dst w) (src : RegOrMem w) -- avx regs
   | push (src : Operand w)
   | pop  (_ : Dst w)
   | setcc (_ : CondCode) (_ : Dst w) -- {_ : w = .W8}

--- a/Kraken/Test/asm/test_avx_mov.S
+++ b/Kraken/Test/asm/test_avx_mov.S
@@ -24,3 +24,27 @@ vmovups (%rsp), %xmm1
 vmovups %xmm1, 16(%rsp)
 movq 16(%rsp), %rcx  # 45
 movq 24(%rsp), %rdx  # 44
+
+# Test avx vmovups with ymms
+popq %rcx
+popq %rcx
+popq %rcx
+popq %rcx
+
+pushq %rax  # 0x38
+pushq %rax  # 0x30
+pushq %rax  # 0x28
+pushq %rax  # 0x20
+pushq $10   # 0x18
+pushq $11   # 0x10
+pushq $12   # 0x8
+pushq $13   # 0x0
+
+vmovups (%rsp), %ymm2
+vmovups %ymm2, 0x20(%rsp)
+movq 0x20(%rsp), %r13  # 13
+movq 0x28(%rsp), %r12  # 12
+movq 0x30(%rsp), %r11  # 11
+movq 0x38(%rsp), %r10  # 10
+
+# TODO: zmms neeed avx512 support in the test harness

--- a/Kraken/Test/asm/test_avx_mov.S
+++ b/Kraken/Test/asm/test_avx_mov.S
@@ -1,0 +1,26 @@
+# Test: movups on AVX registers
+#
+# Need to check xmm status
+
+# The stack should be dqword-aligned.
+pushq %rax  # 24
+pushq %rax  # 16
+pushq $42   # 8
+pushq $43   # 0
+
+# Test legacy movups (non-zeroing); note size suffixes aren't used and only the xmms work.
+movups (%rsp), %xmm0
+movups %xmm0, 16(%rsp)
+movq 16(%rsp), %rsi  # 43
+movq 24(%rsp), %rdi  # 42
+
+# Test avx vmovups (zeroing)
+# addq $16, %rsp  # causes a disagreement about pf and sf?
+popq %rcx
+popq %rcx
+pushq $44
+pushq $45
+vmovups (%rsp), %xmm1
+vmovups %xmm1, 16(%rsp)
+movq 16(%rsp), %rcx  # 45
+movq 24(%rsp), %rdx  # 44

--- a/Kraken/Test/asm/test_avx_mov.S
+++ b/Kraken/Test/asm/test_avx_mov.S
@@ -40,6 +40,7 @@ pushq $11   # 0x10
 pushq $12   # 0x8
 pushq $13   # 0x0
 
+# nb: this is allowed to be unaligned!
 vmovups (%rsp), %ymm2
 vmovups %ymm2, 0x20(%rsp)
 movq 0x20(%rsp), %r13  # 13


### PR DESCRIPTION
This PR adds ISA state support for the AVX registers zmm0-31, which alias to ymm0-31 and xmm0-31. It provides initial implementations for the {v,}movups instructions, leaving out writemasks for now.

There was (and still is) some question about how operand widths should be factored (i.e., if AVX widths should be part of `Width` or some special `AvxWidth`), in part because it permits us to represent some impossible registers (like a 512-bit rax). After starting to push through the PR with a separate width type (and just before adding AVX-specific widths to AVX insns), it seemed like going all the way through would result in a lot of duplication in Semantics (given that widths are pretty pervasive there). Furthermore, we already permit impossible instructions to be encoded (like insns that take two memory operands), so the infelicity of a very wide rax might be tolerable?

This is a draft CL. We don't currently test the ymm/zmms or all combinations of operator kinds, nor do we actually check the status of the xmm registers in tests (the test in the PR does this via the stack). Other deficiencies are expected.