### PR TITLE
fix: avoid ZF, CF, PF disagreements by fixing a starting stack

### DIFF
--- a/Kraken/Test/asm/test_pop_add_bug.S
+++ b/Kraken/Test/asm/test_pop_add_bug.S
@@ -1,0 +1,7 @@
+# We need to start the stack at a plausible address, otherwise
+# we get trivial CF/ZF flag disagreements. Since we don't control the
+# address of the stack when running natively (but we *can* control the
+# last byte), byte-align the stack to avoid PF disagreements.
+
+pushq %rax
+addq $8, %rsp

--- a/Kraken/Test/asm/test_pop_mem_rsp.S
+++ b/Kraken/Test/asm/test_pop_mem_rsp.S
@@ -11,5 +11,6 @@ sub %rsi, %rdi
 sub %rsi, %rax
 mov %rsi, %rsp
 
-xor %rsi, %rsi
-xor %r11, %r11
+# AF is undefined after xor
+mov $0, %rsi
+mov $0, %r11

--- a/Kraken/Test/asm/test_pop_mem_rsp.S
+++ b/Kraken/Test/asm/test_pop_mem_rsp.S
@@ -1,3 +1,5 @@
+# Undefined flags: af
+
 mov %rsp, %rsi
 
 pushq %rsp
@@ -11,6 +13,5 @@ sub %rsi, %rdi
 sub %rsi, %rax
 mov %rsi, %rsp
 
-# AF is undefined after xor
-mov $0, %rsi
-mov $0, %r11
+xor %rsi, %rsi
+xor %r11, %r11

--- a/Kraken/Test/asm/test_pop_rsp.S
+++ b/Kraken/Test/asm/test_pop_rsp.S
@@ -1,3 +1,5 @@
+# Undefined flags: af
+
 mov %rsp, %rsi
 
 pushq $42
@@ -7,5 +9,4 @@ mov %rsp, %rdi
 sub $42, %rdi
 mov %rsi, %rsp
 
-# AF is undefined after xor
-mov $0, %rsi
+xor %rsi, %rsi

--- a/Kraken/Test/asm/test_pop_rsp.S
+++ b/Kraken/Test/asm/test_pop_rsp.S
@@ -6,4 +6,6 @@ pop %rsp
 mov %rsp, %rdi
 sub $42, %rdi
 mov %rsi, %rsp
-xor %rsi, %rsi
+
+# AF is undefined after xor
+mov $0, %rsi

--- a/Kraken/Test/asm_tests.py
+++ b/Kraken/Test/asm_tests.py
@@ -39,13 +39,24 @@ def get_boilerplate(instruction_text: str) -> str:
 .data
 .align 8
 _final_state: .space {total_bytes}
+_old_rsp: .quad 0
 
 .text
 .globl _start
 _start:
+    # Byte-align rsp so we can predict the value of PF.
+    movq %rsp, _old_rsp(%rip)
+    pushfq
+    popq %rax
+    andq $-256, %rsp
+    pushq %rax
+    xorl %eax, %eax
+    popfq
+
 # --- Test Code Start ---
 {instruction_text}
 # --- Test Code End ---
+    movq _old_rsp(%rip), %rsp
 {moves}
     pushfq
     popq %rax

--- a/Kraken/Test/asm_tests.py
+++ b/Kraken/Test/asm_tests.py
@@ -44,7 +44,7 @@ _old_rsp: .quad 0
 .text
 .globl _start
 _start:
-    # Byte-align rsp so we can predict the value of PF.
+    # 256B-align rsp so we can predict the value of PF.
     movq %rsp, _old_rsp(%rip)
     pushfq
     popq %rax

--- a/Kraken/Test/asm_tests.py
+++ b/Kraken/Test/asm_tests.py
@@ -44,19 +44,23 @@ _old_rsp: .quad 0
 .text
 .globl _start
 _start:
-    # 256B-align rsp so we can predict the value of PF.
-    movq %rsp, _old_rsp(%rip)
-    pushfq
-    popq %rax
-    andq $-256, %rsp
-    pushq %rax
-    xorl %eax, %eax
-    popfq
+    # We start at an arbitrary 16B-aligned stack pointer. This makes it
+    # difficult to match the value of PF in the simulator if any computation
+    # is done using rsp (common for cleaning up the stack frame). Since PF
+    # is computed only on the lower 8 bits, if we 256B-align rsp, we can
+    # predict the value of PF (since we can choose rsp in the simulator).
+    movq %rsp, _old_rsp(%rip)   # Save the old rsp.
+    pushfq                      # We have to transfer rflags on the stack.
+    popq %rax                   # Save rflags in rax.
+    andq $-256, %rsp            # 256B-align rsp.
+    pushq %rax                  # Prepare to restore rflags (after xorl stomps them).
+    xorl %eax, %eax             # Zero rax (implicitly zero-extended dword op).
+    popfq                       # Restore rflags + stack alignment.
 
 # --- Test Code Start ---
 {instruction_text}
 # --- Test Code End ---
-    movq _old_rsp(%rip), %rsp
+    movq _old_rsp(%rip), %rsp   # Restore the old stack pointer.
 {moves}
     pushfq
     popq %rax

--- a/KrakenRunner.lean
+++ b/KrakenRunner.lean
@@ -48,9 +48,10 @@ def summarize (s : MachineData) : StateSummary :=
 def _start: String := "_start"
 def _end: String := "_end"
 
--- Give the program a stack of 800B initially.
+-- Give the program a stack of 800B initially, mapped at a plausible place.
 def stackSize := 800
-def initStack : DataMem := (List.replicate stackSize 0xff).At (0-stackSize)
+def stackLocation: UInt64 := 0x7ffecafee200
+def initStack : DataMem := (List.replicate stackSize 0xff).At (stackLocation - stackSize)
 
 def finishCriterion (p: Program) (s: MachineState): Bool :=
   s.2 = p.fakeLayout.labels.label _end
@@ -58,7 +59,8 @@ def finishCriterion (p: Program) (s: MachineState): Bool :=
 def runKraken (asmCode : String)
     : Except String MachineState := do
   let prog ← Kraken.Parser.parse (_start ++ ":" ++ asmCode ++ "\n" ++ _end ++ ":")
-  let initState: MachineState := ({dmem := initStack}, prog.fakeLayout.labels.label _start)
+  let initRegs: Reg64s := {rsp := stackLocation}
+  let initState: MachineState := ({regs := initRegs, dmem := initStack}, prog.fakeLayout.labels.label _start)
   prog.fakeLayout.eval initState (finishCriterion prog)
 
 def main (args : List String) : IO UInt32 := do

--- a/KrakenRunner.lean
+++ b/KrakenRunner.lean
@@ -50,6 +50,12 @@ def _end: String := "_end"
 
 -- Give the program a stack of 800B initially, mapped at a plausible place.
 def stackSize := 800
+-- Place the stack somewhere high in memory, aligned to 256 bytes. This will
+-- help us avoid disagreements with the actual machine: we will avoid over/underflow
+-- when we allocate stack memory using arithmetic instructions (which would happen
+-- if the stack were at 0), and fixing the last byte of the address at 0 means that
+-- we will match PF for these operations (providing that we also align rsp on
+-- hardware).
 def stackLocation: UInt64 := 0x7ffecafee200
 def initStack : DataMem := (List.replicate stackSize 0xff).At (stackLocation - stackSize)
 


### PR DESCRIPTION
We need to start the stack at a plausible address, otherwise we get trivial CF/ZF flag disagreements. Since we don't control the address of the stack when running natively (but we *can* control the last byte), byte-align the stack to avoid PF disagreements.