### PR TITLE
feat(x64): compare ymm register state and sparsely produce output

### DIFF
--- a/Kraken/X64/Test/asm_tests.py
+++ b/Kraken/X64/Test/asm_tests.py
@@ -160,7 +160,7 @@ def compare_states(real: ExecutionState, kraken: ExecutionState, undefined_flags
         if rv != kv:
             diffs.append(f"{r}: x86={rv:#x} ({rv}), kraken={kv:#x} ({kv})")
 
-    for r in [r for r in ZMMS]:
+    for r in ZMMS:
         rv, kv = real.zmms.get(r, '0'), kraken.zmms.get(r, '0')
         if rv != kv:
             diffs.append(f"{r}: x86={rv}, kraken={kv}")

--- a/Kraken/X64/Test/asm_tests.py
+++ b/Kraken/X64/Test/asm_tests.py
@@ -17,6 +17,10 @@ ATT2INTEL = BIN_DIR / "att2intel"
 
 REGS = ["rax", "rbx", "rcx", "rdx", "rsi", "rdi", "rsp", "rbp",
         "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15"]
+# The extended zmm registers are frequently unavailable on actual machines.
+ZMMS = [f"zmm{i}" for i in range(32)]
+# ymm16..31 are only available on AVX512(VL), but we'll assume we have AVX2.
+SAFE_YMMS = [f"ymm{i}" for i in range(16)]
 # Maps each flag to its bit in the EFLAGS register.
 FLAG_MAP = {"cf": 0, "pf": 2, "af": 4, "zf": 6, "sf": 7, "of": 11}
 TIMEOUT_SECONDS = 50
@@ -30,10 +34,14 @@ class Color:
 
 def get_boilerplate(instruction_text: str) -> str:
   reg_count = len(REGS)
+  ymm_count = len(SAFE_YMMS)
   # We move all base registers + the eflags register into memory, so as to dump it later to stdout.
-  total_bytes = (reg_count + 1) * 8
+  # nb: we only read the YMM values since ZMMs are not widely supported
+  total_bytes = (reg_count + 1) * 8 + ymm_count * 32
+  ymm_base = (reg_count + 1) * 8
 
   moves = "\n    ".join([f"movq %{reg}, _final_state + {i*8}(%rip)" for i, reg in enumerate(REGS)])
+  ymm_moves = "\n    ".join([f"vmovups %{ymm}, _final_state + {ymm_base + i * 32}(%rip)" for i, ymm in enumerate(SAFE_YMMS)])
 
   return f"""
 .data
@@ -61,7 +69,8 @@ _start:
 {instruction_text}
 # --- Test Code End ---
     movq _old_rsp(%rip), %rsp   # Restore the old stack pointer.
-{moves}
+    {moves}
+    {ymm_moves}
     pushfq
     popq %rax
     movq %rax, _final_state + {reg_count * 8}(%rip)
@@ -82,16 +91,22 @@ _start:
 @dataclass
 class ExecutionState:
     regs: Dict[str, int]
+    zmms: Dict[str, int]
     flags: Dict[str, bool]
 
 def parse_raw_state(raw_bytes: bytes) -> ExecutionState:
-    fmt = f"<{len(REGS)}Q Q"
+    fmt = f"<{len(REGS)}Q Q" + "32s" * len(SAFE_YMMS)
     unpacked = struct.unpack(fmt, raw_bytes)
-    reg_values = unpacked[:-1]
-    rflags = unpacked[-1]
-
+    reg_values = unpacked[:len(REGS)]
+    rflags = unpacked[len(REGS)]
+    ymm_raw = unpacked[len(REGS) + 1:]
+    ymm_values = [
+        f"{int.from_bytes(chunk, byteorder='little'):x}"
+        for chunk in ymm_raw
+    ]
     return ExecutionState(
         regs=dict(zip(REGS, reg_values)),
+        zmms=dict(zip(ZMMS, ymm_values)),
         flags={name: bool(rflags & (1 << bit)) for name, bit in FLAG_MAP.items()}
     )
 
@@ -119,7 +134,7 @@ def run_kraken(path: Path) -> Tuple[Optional[ExecutionState], Optional[str]]:
     try:
         res = subprocess.run([KRAKEN_RUNNER, path], capture_output=True, check=True, timeout=TIMEOUT_SECONDS)
         data = json.loads(res.stdout)
-        return ExecutionState(regs=data["regs"], flags=data["flags"]), None
+        return ExecutionState(regs=data["regs"], zmms=data["zmms"], flags=data["flags"]), None
     except subprocess.CalledProcessError as e:
         return None, f"Kraken Error:\n{(e.stderr or b"").decode(errors="replace").strip()}"
     # This except clause ensures any stderr messages are shown even if there is a timeout
@@ -141,9 +156,14 @@ def get_undefined_flags(path: Path) -> List[str]:
 def compare_states(real: ExecutionState, kraken: ExecutionState, undefined_flags: List[str]) -> List[str]:
     diffs = []
     for r in [r for r in REGS if r != "rsp"]:
-        rv, kv = real.regs[r], kraken.regs[r]
+        rv, kv = real.regs.get(r, 0), kraken.regs.get(r, 0)
         if rv != kv:
             diffs.append(f"{r}: x86={rv:#x} ({rv}), kraken={kv:#x} ({kv})")
+
+    for r in [r for r in ZMMS]:
+        rv, kv = real.zmms.get(r, '0'), kraken.zmms.get(r, '0')
+        if rv != kv:
+            diffs.append(f"{r}: x86={rv}, kraken={kv}")
 
     for f in [f for f in FLAG_MAP if not f in undefined_flags]:
         if real.flags[f] != kraken.flags[f]:

--- a/KrakenRunnerX64.lean
+++ b/KrakenRunnerX64.lean
@@ -23,25 +23,38 @@ open Lean
 -- TODO Add memory, for now we only track and compare registers and flags.
 structure StateSummary where
   regs : List (String × UInt64)
+  zmms : List (String × ZmmValue)
   flags : List (String × Bool)
 
--- Custom json serialization for the state summary.
+-- Custom json serialization for the state summary. Registers with zero values
+-- are not included.
 instance : ToJson StateSummary where
   toJson s :=
-    let regs := s.regs.map (fun (k, v) => (k, Json.num v.toNat))
+    let regs := s.regs.filterMap (fun (k, v) => if v == 0 then none else some (k, Json.num v.toNat))
+    let zmms := s.zmms.filterMap (fun (k, v) => if v == 0#512 then none else some (k, Json.str (String.ofList (Nat.toDigits 16 v.toNat))))
     let flags := s.flags.map (fun (k, v) => (k, toJson v))
     Json.mkObj [
       ("regs", Json.mkObj regs),
+      ("zmms", Json.mkObj zmms),
       ("flags", Json.mkObj flags)
     ]
 
 def summarize (s : MachineData) : StateSummary :=
   let r := s.regs
+  let z := s.zmms
   let f := s.status
   { regs := [("rax", r.rax), ("rbx", r.rbx), ("rcx", r.rcx), ("rdx", r.rdx),
              ("rsi", r.rsi), ("rdi", r.rdi), ("rbp", r.rbp), ("r8", r.r8),
              ("r9", r.r9), ("r10", r.r10), ("r11", r.r11), ("r12", r.r12),
              ("r13", r.r13), ("r14", r.r14), ("r15", r.r15)],
+    zmms := [("zmm0", z.zmm0), ("zmm1", z.zmm1), ("zmm2", z.zmm2), ("zmm3", z.zmm3),
+             ("zmm4", z.zmm4), ("zmm5", z.zmm5), ("zmm6", z.zmm6), ("zmm7", z.zmm7),
+             ("zmm8", z.zmm8), ("zmm9", z.zmm9), ("zmm10", z.zmm10), ("zmm11", z.zmm11),
+             ("zmm12", z.zmm12), ("zmm13", z.zmm13), ("zmm14", z.zmm14), ("zmm15", z.zmm15),
+             ("zmm16", z.zmm16), ("zmm17", z.zmm17), ("zmm18", z.zmm18), ("zmm19", z.zmm19),
+             ("zmm20", z.zmm20), ("zmm21", z.zmm21), ("zmm22", z.zmm22), ("zmm23", z.zmm23),
+             ("zmm24", z.zmm24), ("zmm25", z.zmm25), ("zmm26", z.zmm26), ("zmm27", z.zmm27),
+             ("zmm28", z.zmm28), ("zmm29", z.zmm29), ("zmm30", z.zmm30), ("zmm31", z.zmm31)],
     flags := [("cf", f.cf), ("pf", f.pf), ("af", f.af),
               ("zf", f.zf), ("sf", f.sf), ("of", f.of)] }
 


### PR DESCRIPTION
This PR adds support for actually checking the values of ymm0-ymm15 against the Kraken semantics. (It seems that most of our machines don't support the extensions required for the zmms, or for *mms above 15).

This PR will also only populate GPRs in the Kraken result json when they have nonzero values. This should reduce noise.

With this change, krakenrunner now produces output that looks like:

```json
{
  "flags":{"af":false,"cf":false,"of":false,"pf":false,"sf":false,"zf":false},
  "regs":{"r10":10,"r11":11,"r12":12,"r13":13,"rcx":44,"rdi":42,"rdx":44,"rsi":43},
  "zmms": {
    "zmm0": "2a000000000000002b",
    "zmm1": "2c000000000000002d",
    "zmm2": "a000000000000000b000000000000000c000000000000000d"
  }
}
```

(on test_avx_mov.S).

I haven't taken a stance about how we should stringify the values of the zmm registers; for now I just did the most direct thing. We may want to split these into vector lanes in the future (eg we'd print ymm2 as <13,12,11,10> instead).