### PR TITLE
Update Aarch64 support

### DIFF
--- a/Kraken/AArch64/Parser.lean
+++ b/Kraken/AArch64/Parser.lean
@@ -604,7 +604,7 @@ def parseExtOrImmReg (w : Width) : Parser (ExtOrImmReg w) := do
         | .W32 => ExtendType.UXTW
       pure (.ext { reg := regW, ext := { type := extType, amount := ExtendAmount.E0 } })
 
-def parseShiftRegExpr (w : Width) : Parser (ShiftRegExpr w) := do
+def parseShiftRegExpr (w : Width) (allowRor : Bool := false) : Parser (ShiftRegExpr w) := do
   let reg ← parseRegOrZr w
   skipHWs
   let nextC? ← peek?
@@ -616,6 +616,9 @@ def parseShiftRegExpr (w : Width) : Parser (ShiftRegExpr w) := do
       | "lsl" => pure ShiftType.LSL
       | "lsr" => pure ShiftType.LSR
       | "asr" => pure ShiftType.ASR
+      | "ror" =>
+        if allowRor then pure ShiftType.ROR
+        else fail "arithmetic instructions do not support ROR shift"
       | _ => fail s!"unknown shift type: {shiftName}"
     skipHWs
     let amt ← parseInt64
@@ -819,7 +822,7 @@ def parseLogical
   parseComma
   let src1 ← parseRegOrZr w
   parseComma
-  let shiftOp ← parseShiftRegExpr w
+  let shiftOp ← parseShiftRegExpr w true
   pure ⟨w, mkS dstW.reg src1 shiftOp⟩
 
 -- ============================================================================
@@ -955,7 +958,7 @@ def parseInstr : Parser Instr := do
     let src1W ← parseRegOrZrW
     let w := src1W.w
     parseComma
-    let src2 ← parseShiftRegExpr w
+    let src2 ← parseShiftRegExpr w true
     pure ⟨w, .ANDS_s (.low .XZR w) src1W.reg src2⟩
 
   | "lsl"   => parseThreeRegs .LSLV -- Alias of LSLV

--- a/Kraken/AArch64/Parser.lean
+++ b/Kraken/AArch64/Parser.lean
@@ -673,6 +673,13 @@ def parseCondCode (s : String) : Option CondCode :=
   | "nv" => some .NV
   | _ => none
 
+def parseCondArg : Parser CondCode := do
+  skipHWs
+  let name ← parseName
+  match parseCondCode name with
+  | some c => pure c
+  | none => fail s!"unknown condition code: {name}"
+
 -- ============================================================================
 -- Validation Helpers
 -- ============================================================================
@@ -825,6 +832,39 @@ def parseLogical
   let shiftOp ← parseShiftRegExpr w true
   pure ⟨w, mkS dstW.reg src1 shiftOp⟩
 
+def parseCondSelect
+    (mk : {w : Width} → RegOrZr w → RegOrZr w → RegOrZr w → CondCode → Operation w) : Parser Instr := do
+  let dstW ← parseRegOrZrW
+  let w := dstW.w
+  parseComma
+  let src1 ← parseRegOrZr w
+  parseComma
+  let src2 ← parseRegOrZr w
+  parseComma
+  let cond ← parseCondArg
+  pure ⟨w, mk dstW.reg src1 src2 cond⟩
+
+def parseCondAlias
+    (mk : {w : Width} → RegOrZr w → RegOrZr w → RegOrZr w → CondCode → Operation w)
+    (sameSrc : Bool) (useXzr : Bool) : Parser Instr := do
+  let dstW ← parseRegOrZrW
+  let w := dstW.w
+  parseComma
+  let (src1, src2) ← if useXzr then
+    pure (.low .XZR w, .low .XZR w)
+  else if sameSrc then do
+    let s ← parseRegOrZr w
+    parseComma
+    pure (s, s)
+  else do
+    let s1 ← parseRegOrZr w
+    parseComma
+    let s2 ← parseRegOrZr w
+    parseComma
+    pure (s1, s2)
+  let cond ← parseCondArg
+  pure ⟨w, mk dstW.reg src1 src2 cond.invert⟩
+
 -- ============================================================================
 -- Instruction Parsing
 -- ============================================================================
@@ -969,6 +1009,16 @@ def parseInstr : Parser Instr := do
   | "lsrv"  => parseThreeRegs .LSRV
   | "asrv"  => parseThreeRegs .ASRV
   | "rorv"  => parseThreeRegs .RORV
+
+  | "csel"  => parseCondSelect .CSEL
+  | "csinc" => parseCondSelect .CSINC
+  | "csinv" => parseCondSelect .CSINV
+  | "csneg" => parseCondSelect .CSNEG
+  | "cset"  => parseCondAlias .CSINC true true
+  | "csetm" => parseCondAlias .CSINV true true
+  | "cinc"  => parseCondAlias .CSINC true false
+  | "cinv"  => parseCondAlias .CSINV true false
+  | "cneg"  => parseCondAlias .CSNEG true false
 
   | "adr" =>
     let dst ← parseRegOrZr .W64

--- a/Kraken/AArch64/Parser.lean
+++ b/Kraken/AArch64/Parser.lean
@@ -21,8 +21,14 @@ open Std.Internal.Parsec.String
 def skipHWs : Parser Unit := do
   let _ ← many (pchar ' ' <|> pchar '\t')
 
-/-- Skip a line comment starting with # or //. -/
-def skipLineComment : Parser Unit := do
+/-- Skip a trailing line comment starting with `//`. -/
+def skipTrailingComment : Parser Unit := do
+  let _ ← pstring "//"
+  let _ ← many (satisfy fun c => c != '\n')
+  pure ()
+
+/-- Skip a full-line comment starting with `#` or `//`. -/
+def skipFullLineComment : Parser Unit := do
   let _ ← pchar '#' <|> (pstring "//" *> pure '/')
   let _ ← many (satisfy fun c => c != '\n')
   pure ()
@@ -58,14 +64,12 @@ def parseDec : Parser Int := do
 
 def parseNumber : Parser Int := attempt parseHex <|> attempt parseBin <|> parseDec
 
-/-- Parse a signed integer (hex, binary, or decimal), allowing flexible sign/prefix ordering (`#-16`, `-#16`, or `#16`). -/
+/-- Parse a signed integer (hex, binary, or decimal) with optional leading `#` prefix (`#-16`, `-16`, or `#16`). -/
 def parseInt : Parser Int := do
   skipHWs
   let _ ← optional (pchar '#')
   skipHWs
   let neg ← (pchar '-' *> pure true) <|> (pchar '+' *> pure false) <|> pure false
-  skipHWs
-  let _ ← optional (pchar '#')
   skipHWs
   let val ← parseNumber
   pure (if neg then -val else val)
@@ -127,7 +131,7 @@ def parseXRegName (name : String) : Option (Width × XReg) :=
   | "w16" => some (.W32, .X16) | "w17" => some (.W32, .X17) | "w18" => some (.W32, .X18) | "w19" => some (.W32, .X19)
   | "w20" => some (.W32, .X20) | "w21" => some (.W32, .X21) | "w22" => some (.W32, .X22) | "w23" => some (.W32, .X23)
   | "w24" => some (.W32, .X24) | "w25" => some (.W32, .X25) | "w26" => some (.W32, .X26) | "w27" => some (.W32, .X27)
-  | "w28" => some (.W32, .X28) | "w29" | "wfp" => some (.W32, .X29) | "w30" | "wlr" => some (.W32, .X30)
+  | "w28" => some (.W32, .X28) | "w29" => some (.W32, .X29) | "w30" => some (.W32, .X30)
   | _ => none
 
 def checkWidth {T : Width → Type} (expected actual : Width) (val : T actual) : Parser (T expected) :=
@@ -243,16 +247,18 @@ def getMovShift (w : Width) (amt : Nat) : Except String (MovShift w) :=
   | _, _     => .error s!"invalid move wide shift amount {amt} for width {w}"
 
 def getMemExtendType (extName : String) (w : Width) : Except String MemExtendType :=
-  match extName.toLower with
-  | "uxtw" => .ok MemExtendType.UXTW
-  | "sxtw" => .ok MemExtendType.SXTW
-  | "uxtx" => .ok MemExtendType.UXTX
-  | "sxtx" => .ok MemExtendType.SXTX
-  | "lsl" =>
-    match w with
-    | .W64 => .ok MemExtendType.UXTX
-    | .W32 => .ok MemExtendType.UXTW
-  | _ => .error s!"unknown memory extension type: {extName}"
+  match extName.toLower, w with
+  | "uxtw", .W32 => .ok MemExtendType.UXTW
+  | "uxtw", .W64 => .error "UXTW extension requires a 32-bit index register (Wn)"
+  | "sxtw", .W32 => .ok MemExtendType.SXTW
+  | "sxtw", .W64 => .error "SXTW extension requires a 32-bit index register (Wn)"
+  | "uxtx", .W64 => .ok MemExtendType.UXTX
+  | "uxtx", .W32 => .error "UXTX extension requires a 64-bit index register (Xn)"
+  | "sxtx", .W64 => .ok MemExtendType.SXTX
+  | "sxtx", .W32 => .error "SXTX extension requires a 64-bit index register (Xn)"
+  | "lsl",  .W64 => .ok MemExtendType.UXTX
+  | "lsl",  .W32 => .ok MemExtendType.UXTW
+  | ext,    _    => .error s!"unknown memory extension type: {ext}"
 
 def checkUnsignedOffset (w : Width) (imm : Int64) : Except String Unit :=
   let (maxOff, align) := match w with | .W32 => (16380, 4) | .W64 => (32760, 8)
@@ -704,7 +710,7 @@ def isAtLineEndOrComment : Parser Bool := do
   | none | some '\n' =>
     pure true
   | _ =>
-    (attempt skipLineComment *> pure true) <|> pure false
+    (attempt skipTrailingComment *> pure true) <|> pure false
 
 /-- Parses an optional operand using `p`, or returns `defaultVal` if positioned at line end or comment. -/
 def parseOptionalOperand {α : Type} (p : Parser α) (defaultVal : α) : Parser α := do
@@ -1313,16 +1319,21 @@ def parseInstr : Parser Instr := do
     pure ⟨.W64, .NOP⟩
 
   | _ =>
-    if mn.startsWith "b." then
-      match parseCondCode (mn.drop 2).toString with
-      | some cond =>
-        let target ← parseConstExpr
-        if let .int64 imm := target then
-          liftExcept (checkBCondOffset imm)
-        pure ⟨.W64, .B_cond cond target⟩
-      | none => fail s!"unknown condition code in branch instruction: {mnemonic}"
-    else
-      fail s!"unsupported instruction: {mnemonic}"
+    let condStr? :=
+      if mn.startsWith "b." then some (mn.drop 2).toString
+      else if mn.startsWith "b" && mn.length == 3 then some (mn.drop 1).toString
+      else none
+    match condStr?.bind parseCondCode with
+    | some cond =>
+      let target ← parseConstExpr
+      if let .int64 imm := target then
+        liftExcept (checkBCondOffset imm)
+      pure ⟨.W64, .B_cond cond target⟩
+    | none =>
+      if mn.startsWith "b." then
+        fail s!"unknown condition code in branch instruction: {mnemonic}"
+      else
+        fail s!"unsupported instruction: {mnemonic}"
 
 -- ============================================================================
 -- Label Parsing
@@ -1361,15 +1372,21 @@ def checkLineEnd : Parser Unit := do
     Returns a list of directives found on the line. -/
 def parseLine : Parser (List Directive) := do
   skipHWs
-  let labels ← many (attempt do
-    let l ← parseLabelDecl
-    pure (Directive.label l))
-  let instr ← parseOptionalInstr
-  checkLineEnd
-  let labelsList := labels.toList
-  match instr with
-  | some i => pure (labelsList ++ [i])
-  | none   => pure labelsList
+  let c? ← peek?
+  if c? == some '#' || c? == some '/' then
+    let _ ← attempt skipFullLineComment
+    checkLineEnd
+    pure []
+  else
+    let labels ← many (attempt do
+      let l ← parseLabelDecl
+      pure (Directive.label l))
+    let instr ← parseOptionalInstr
+    checkLineEnd
+    let labelsList := labels.toList
+    match instr with
+    | some i => pure (labelsList ++ [i])
+    | none   => pure labelsList
 
 -- ============================================================================
 -- Public API

--- a/Kraken/AArch64/Parser.lean
+++ b/Kraken/AArch64/Parser.lean
@@ -41,31 +41,42 @@ def digit : Parser Char := satisfy fun c => c >= '0' && c <= '9'
 def hexDigit : Parser Char := satisfy fun c =>
   (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
 
+/-- Convert a hexadecimal digit character to its integer value. -/
 def hexVal (c : Char) : Int :=
   if c >= '0' && c <= '9' then c.toNat - '0'.toNat
   else if c >= 'a' && c <= 'f' then c.toNat - 'a'.toNat + 10
   else c.toNat - 'A'.toNat + 10
 
+/-- Parse an unsigned hexadecimal integer literal prefixed by `0x` or `0X`. -/
 def parseHex : Parser Int := do
   let _ ← pstring "0x" <|> pstring "0X"
   let digits ← many1 hexDigit
   pure (digits.foldl (fun acc d => acc * 16 + hexVal d) 0)
 
-/-- Parse a single binary digit (0 or 1). -/
+/-- Parse a single binary digit character (`0` or `1`). -/
 def binDigit : Parser Char := satisfy fun c => c == '0' || c == '1'
 
+/-- Parse an unsigned binary integer literal prefixed by `0b` or `0B`. -/
 def parseBin : Parser Int := do
   let _ ← pstring "0b" <|> pstring "0B"
   let digits ← many1 binDigit
   pure (digits.foldl (fun acc d => acc * 2 + (d.toNat - '0'.toNat)) 0)
 
+/-- Parse an unsigned decimal integer literal (e.g. `4096`). -/
 def parseDec : Parser Int := do
   let digits ← many1 digit
   pure (digits.foldl (fun acc d => acc * 10 + (d.toNat - '0'.toNat)) 0)
 
+/--
+Parse an unsigned integer literal in hexadecimal (`0x...`), binary (`0b...`),
+or decimal format.
+-/
 def parseNumber : Parser Int := attempt parseHex <|> attempt parseBin <|> parseDec
 
-/-- Parse a signed integer (hex, binary, or decimal) with optional leading `#` prefix (`#-16`, `-16`, or `#16`). -/
+/--
+Parse a signed integer literal (hex, binary, or decimal) with an optional
+leading `#` prefix and optional `+`/`-` sign (e.g. `#-16`, `-16`, or `#16`).
+-/
 def parseInt : Parser Int := do
   skipHWs
   let _ ← optional (pchar '#')
@@ -75,13 +86,22 @@ def parseInt : Parser Int := do
   let val ← parseNumber
   pure (if neg then -val else val)
 
-/-- Parse a name (identifier or label). -/
+/--
+Parse a symbol name or identifier (e.g. a register name, instruction mnemonic,
+or label name).
+- Starts with an alphabetic character, `_`, or `.`.
+- Followed by zero or more alphanumeric characters, `_`, or `.`.
+-/
 def parseName : Parser String := do
   let first ← satisfy fun c => c.isAlpha || c == '_' || c == '.'
   let rest ← many (satisfy fun c => c.isAlphanum || c == '_' || c == '.')
   pure (String.ofList (#[first] ++ rest).toList)
 
-/-- Parse an immediate operand as Int64. -/
+/--
+Parse a signed integer literal and convert it to `Int64`.
+- **Limits**: Rejects integer literals outside the signed or unsigned 64-bit
+  range (`[-2^63, 2^64 - 1]`).
+-/
 def parseInt64 : Parser Int64 := do
   let v ← parseInt
   if v < -9223372036854775808 || v >= 18446744073709551616 then
@@ -91,9 +111,15 @@ def parseInt64 : Parser Int64 := do
   else
     Int64.ofInt v)
 
+/-- Parse a raw label name as a string identifier. -/
 def parseLabelRaw : Parser Label := parseName
 
-/-- Parses a constant expression, including numeric immediates (`#16`), labels (`main`), and relocation modifiers (`:pg_hi21:main`, `:lo12:main`). -/
+/--
+Parse a constant expression (`ConstExpr`):
+- Relocation modifiers: `:pg_hi21:symbol` or `:lo12:symbol`.
+- Numeric integer immediate: e.g. `#16`, `#-8`, or `0x1000`.
+- Symbol label: e.g. `main` or `loop`.
+-/
 partial def parseConstExpr : Parser ConstExpr := do
   skipHWs
   let _ ← optional (pchar '#')
@@ -134,12 +160,14 @@ def parseXRegName (name : String) : Option (Width × XReg) :=
   | "w28" => some (.W32, .X28) | "w29" => some (.W32, .X29) | "w30" => some (.W32, .X30)
   | _ => none
 
+/-- Enforce that an operand's actual parsed width matches the expected instruction width (`w`). -/
 def checkWidth {T : Width → Type} (expected actual : Width) (val : T actual) : Parser (T expected) :=
   if h : expected = actual then
     pure (h ▸ val)
   else
     fail s!"expected {expected} register, got {actual}"
 
+/-- Parse a register operand where register index 31 means `SP`/`WSP` (`RegOrSpW`). -/
 def parseRegOrSpW : Parser RegOrSpW := do
   skipHWs
   let name ← parseName
@@ -151,6 +179,7 @@ def parseRegOrSpW : Parser RegOrSpW := do
     | "wsp" => pure ⟨.W32, RegOrSp.WSP⟩
     | _ => fail s!"unknown register or sp: {name}"
 
+/-- Parse a register operand where register index 31 means `XZR`/`WZR` (`RegOrZrW`). -/
 def parseRegOrZrW : Parser RegOrZrW := do
   skipHWs
   let name ← parseName
@@ -162,14 +191,20 @@ def parseRegOrZrW : Parser RegOrZrW := do
     | "wzr" => pure ⟨.W32, RegOrZr.WZR⟩
     | _ => fail s!"unknown register or xzr: {name}"
 
+/-- Parse a `RegOrSp` register operand and verify it matches width `w`. -/
 def parseRegOrSp (w : Width) : Parser (RegOrSp w) := do
   let ⟨w', r⟩ ← parseRegOrSpW
   checkWidth w w' r
 
+/-- Parse a `RegOrZr` register operand and verify it matches width `w`. -/
 def parseRegOrZr (w : Width) : Parser (RegOrZr w) := do
   let ⟨w', r⟩ ← parseRegOrZrW
   checkWidth w w' r
 
+/--
+A generic parsed register (`gpr`, `sp`, or `xzr`) before instruction-specific
+context validation resolves index 31.
+-/
 inductive AnyReg (w : Width)
   | gpr (r : XReg) : AnyReg w
   | sp : AnyReg w
@@ -177,6 +212,7 @@ inductive AnyReg (w : Width)
 
 abbrev AnyRegW := (w : Width) × AnyReg w
 
+/-- Parse any valid register name and return its width and `AnyReg` variant. -/
 def parseAnyRegW : Parser AnyRegW := do
   skipHWs
   let name ← parseName
@@ -190,10 +226,12 @@ def parseAnyRegW : Parser AnyRegW := do
     | "wzr" => pure ⟨.W32, .xzr⟩
     | _ => fail s!"unknown register, sp, or xzr: {name}"
 
+/-- Parse any register name and verify that its width matches `w`. -/
 def parseAnyReg (w : Width) : Parser (AnyReg w) := do
   let ⟨w', r⟩ ← parseAnyRegW
   checkWidth w w' r
 
+/-- Convert `AnyReg w` to `RegOrSp w`, rejecting `XZR`/`WZR` where `SP`/`WSP` is expected. -/
 def AnyReg.toRegOrSp {w : Width} : AnyReg w → Parser (RegOrSp w)
   | .gpr r => pure (.low (.reg r) w)
   | .sp => match w with
@@ -201,6 +239,7 @@ def AnyReg.toRegOrSp {w : Width} : AnyReg w → Parser (RegOrSp w)
     | .W32 => pure RegOrSp.WSP
   | .xzr => fail "xzr/wzr not allowed in immediate/extended register instruction (sp expected)"
 
+/-- Convert `AnyReg w` to `RegOrZr w`, rejecting `SP`/`WSP` where `XZR`/`WZR` is expected. -/
 def AnyReg.toRegOrZr {w : Width} : AnyReg w → Parser (RegOrZr w)
   | .gpr r => pure (.low (.reg r) w)
   | .xzr => match w with
@@ -240,6 +279,11 @@ def liftExcept {α : Type} (res : Except String α) : Parser α :=
   | .ok a => pure a
   | .error msg => fail msg
 
+/--
+Validate a memory extension shift amount (`0` or log2 of access size in bytes).
+- `.W32`: Allows `0` (`E0`) or `2` (`E2`, `LSL #2`).
+- `.W64`: Allows `0` (`E0`) or `3` (`E3`, `LSL #3`).
+-/
 def getMemExtendAmount (w : Width) (amt : Nat) : Except String (MemExtendAmount w) :=
   match w, amt with
   | .W32, 0 => .ok .E0
@@ -248,6 +292,11 @@ def getMemExtendAmount (w : Width) (amt : Nat) : Except String (MemExtendAmount 
   | .W64, 3 => .ok .E3
   | _, _ => .error s!"invalid memory extension shift amount {amt} for width {w}"
 
+/--
+Validate a move-wide immediate shift amount (`MOVZ`/`MOVK`/`MOVN`).
+- `.W32`: Allows `0` or `16`.
+- `.W64`: Allows `0`, `16`, `32`, or `48`.
+-/
 def getMovShift (w : Width) (amt : Nat) : Except String (MovShift w) :=
   match w, amt with
   | _, 0     => .ok .LSL0
@@ -256,6 +305,12 @@ def getMovShift (w : Width) (amt : Nat) : Except String (MovShift w) :=
   | .W64, 48 => .ok .LSL48
   | _, _     => .error s!"invalid move wide shift amount {amt} for width {w}"
 
+/--
+Validate a memory index extension type (`UXTW`, `SXTW`, `UXTX`, `SXTX`, `LSL`)
+and check that the register width matches:
+- `UXTW`/`SXTW` require a 32-bit register (`Wn`).
+- `UXTX`/`SXTX` require a 64-bit register (`Xn`).
+-/
 def getMemExtendType (extName : String) (w : Width) : Except String MemExtendType :=
   match extName.toLower, w with
   | "uxtw", .W32 => .ok MemExtendType.UXTW
@@ -274,6 +329,13 @@ def getMemExtendType (extName : String) (w : Width) : Except String MemExtendTyp
 -- Validation Helpers
 -- ============================================================================
 
+/--
+Validate a load/store immediate byte offset:
+- **Unsigned scaled offset (`allowUnscaled = false` or `isScaled = true`)**:
+  Must be a multiple of 4 in `[0, 16380]` for `.W32` and a multiple of 8 in
+  `[0, 32760]` for `.W64`.
+- **Signed unscaled offset (`allowUnscaled = true`)**: Must be in `[-256, 255]`.
+-/
 def checkLoadStoreOffset (w : Width) (imm : Int64) (allowUnscaled : Bool) : Except String Unit :=
   let (maxOff, align) := match w with | .W32 => (16380, 4) | .W64 => (32760, 8)
   let isScaled := imm.toInt >= 0 && imm.toInt <= maxOff && imm.toInt % align == 0
@@ -285,11 +347,17 @@ def checkLoadStoreOffset (w : Width) (imm : Int64) (allowUnscaled : Bool) : Exce
   else
     .error s!"unsigned offset {imm.toInt} out of range [0, {maxOff}] or not a multiple of {align}"
 
+/-- Validate an unscaled 9-bit signed immediate byte offset for `LDUR`/`STUR` (`[-256, 255]`). -/
 def checkUnscaledOffset (imm : Int64) : Except String Unit :=
   if imm.toInt < -256 || imm.toInt > 255 then
     .error s!"unscaled offset {imm.toInt} out of range [-256, 255]"
   else .ok ()
 
+/--
+Determine whether a load/store immediate address (`AddrExpr`) requires
+automatic conversion to an unscaled `LDUR`/`STUR` instruction (i.e. when the
+offset is negative or not aligned to the access size).
+-/
 def addrExprNeedsUnscaled {w : Width} (addr : AddrExpr w) : Bool :=
   match addr.off with
   | .imm i =>
@@ -300,11 +368,19 @@ def addrExprNeedsUnscaled {w : Width} (addr : AddrExpr w) : Bool :=
     | _, _ => false
   | _ => false
 
+/--
+Determine whether an `AddrOrLit` load operand requires conversion to an
+unscaled instruction.
+-/
 def addrOrLitNeedsUnscaled {w : Width} (a : AddrOrLit w) : Bool :=
   match a with
   | .addr addr => addrExprNeedsUnscaled addr
   | .lit _ => false
 
+/--
+Convert a standard immediate address expression (`AddrExpr`) to an unscaled
+address expression (`UnscaledAddrExpr`).
+-/
 def addrExprToUnscaled {w : Width} (addr : AddrExpr w) : Option UnscaledAddrExpr :=
   match addr.off with
   | .imm i =>
@@ -313,17 +389,28 @@ def addrExprToUnscaled {w : Width} (addr : AddrExpr w) : Option UnscaledAddrExpr
     | some _ => none
   | _ => none
 
+/-- Convert an `AddrOrLit` operand to an unscaled address expression (`UnscaledAddrExpr`). -/
 def addrOrLitToUnscaled {w : Width} (a : AddrOrLit w) : Option UnscaledAddrExpr :=
   match a with
   | .addr addr => addrExprToUnscaled addr
   | .lit _ => none
 
+/--
+Validate an optional shift amount for register operands:
+- Must be in `[0, 31]` for 32-bit instructions (`.W32`).
+- Must be in `[0, 63]` for 64-bit instructions (`.W64`).
+-/
 def checkShiftAmount (w : Width) (amt : Int64) : Except String Unit :=
   let maxAmt := match w with | .W32 => 31 | .W64 => 63
   if amt.toInt < 0 || amt.toInt > maxAmt then
     .error s!"shift amount {amt.toInt} out of range [0, {maxAmt}] for {w.bits}-bit instruction"
   else .ok ()
 
+/--
+Validate a signed immediate byte offset for load/store pair instructions (`LDP`/`STP`):
+- For `.W32`: Multiple of 4 in `[-256, 252]`.
+- For `.W64`: Multiple of 8 in `[-512, 504]`.
+-/
 def checkPairOffset (w : Width) (imm : Int64) : Except String Unit :=
   let (minOff, maxOff, align) := match w with | .W32 => (-256, 252, 4) | .W64 => (-512, 504, 8)
   if imm.toInt < minOff || imm.toInt > maxOff || imm.toInt % align != 0 then
@@ -334,12 +421,20 @@ def intToHexStr (n : Int) : String :=
   if n < 0 then s!"-0x{String.ofList (Nat.toDigits 16 (-n).natAbs)}"
   else s!"0x{String.ofList (Nat.toDigits 16 n.natAbs)}"
 
+/--
+Validate a PC-relative byte offset for `ADR`.
+- Must be a 21-bit signed integer in `[-0x100000, 0xfffff]` (`±1 MB`).
+-/
 def checkAdrOffset (offset : Int64) : Except String Unit :=
   let val := offset.toInt
   if val < -0x100000 || val > 0xfffff then
     .error s!"adr offset {intToHexStr val} out of range [-0x100000, 0xfffff]"
   else .ok ()
 
+/--
+Check whether an `E`-bit unsigned integer consists of a non-empty contiguous
+run of ones starting from bit 0 (`2^k - 1` for `0 < k < E`).
+-/
 def isContiguousOnes (v : Nat) (E : Nat) : Bool :=
   v > 0 && v < ((1 <<< E) - 1) && ((v + 1) &&& v) == 0
 
@@ -352,9 +447,17 @@ def isRotatedRunOfOnesAux (elem : Nat) (E : Nat) : Nat → Bool
       let nextElem := (elem >>> 1) ||| ((elem &&& 1) <<< (E - 1))
       isRotatedRunOfOnesAux nextElem E n
 
+/--
+Determine whether an `E`-bit number (`0 < elem < 2^E - 1`) is a rotated
+contiguous run of ones, as required by ARMv8-A logical immediate encoding.
+-/
 def isRotatedRunOfOnes (elem : Nat) (E : Nat) : Bool :=
   isRotatedRunOfOnesAux elem E E
 
+/--
+Replicate an `E`-bit pattern across an entire `wBits`-wide integer
+(`wBits = 32` or `64`, `E ∈ {2, 4, 8, 16, 32, 64}`).
+-/
 def repeatElement (pattern : Nat) (wBits : Nat) (E : Nat) : Nat :=
   match wBits, E with
   | 64, 64 => pattern
@@ -370,10 +473,20 @@ def repeatElement (pattern : Nat) (wBits : Nat) (E : Nat) : Nat :=
   | 32, 2  => pattern * 0x55555555
   | _, _ => 0
 
+/--
+Check whether an integer value is formed by repeating its low `E`-bit pattern
+across the entire `wBits` width.
+-/
 def isRepeatedPattern (val : Nat) (wBits : Nat) (E : Nat) : Bool :=
   let pattern := val &&& ((1 <<< E) - 1)
   val == repeatElement pattern wBits E
 
+/--
+Determine whether a 32-bit or 64-bit value is a valid ARMv8-A bitmask immediate
+for logical instructions (`AND`, `ORR`, `EOR`, `TST`).
+- Excludes all-zeros and all-ones values.
+- Checks for a repeated rotated run of ones across allowed element sizes `E`.
+-/
 def isValidLogicalImmediate (w : Width) (val : Int64) : Bool :=
   let vNat := match w with
     | .W32 => (val.toBitVec.toNat &&& 0xFFFFFFFF)
@@ -390,12 +503,25 @@ def isValidLogicalImmediate (w : Width) (val : Int64) : Bool :=
       isRepeatedPattern vNat wBits E &&
       isRotatedRunOfOnes (vNat &&& ((1 <<< E) - 1)) E)
 
+/--
+Validate an ARMv8-A bitmask immediate for logical instructions
+(`AND`, `ORR`, `EOR`).
+- Enforces repeated rotated runs of ones across element sizes
+  (2, 4, 8, 16, 32, 64 bits).
+- Rejects all-zeros or all-ones bitmasks (`invalid logical immediate: <hex>`).
+-/
 def checkLogicalImmediate (w : Width) (imm : Int64) : Except String Unit :=
   if isValidLogicalImmediate w imm then
     .ok ()
   else
     .error s!"invalid logical immediate: {intToHexStr imm.toInt}"
 
+/--
+Validate a PC-relative page offset for `ADRP`:
+- Must be 4 KB page aligned (multiple of `0x1000`).
+- Page offset (`offset / 4096`) must fit in a 21-bit signed integer
+  (`[-0x100000, 0xfffff]`).
+-/
 def checkAdrpOffset (offset : Int64) : Except String Unit :=
   let val := offset.toInt
   if val % 0x1000 != 0 then
@@ -406,39 +532,62 @@ def checkAdrpOffset (offset : Int64) : Except String Unit :=
       .error s!"adrp offset {intToHexStr val} out of range [-0x100000000, 0xfffff000]"
     else .ok ()
 
+/--
+Validate a 26-bit signed word offset for unconditional branch (`B` / `BL`):
+- Must be in `[-0x8000000, 0x7fffffc]` (`±128 MB`, multiple of 4).
+-/
 def checkBOffset (offset : Int64) : Except String Unit :=
   let val := offset.toInt
   if val < -0x8000000 || val > 0x7fffffc then
     .error s!"b offset {intToHexStr val} out of range [-0x8000000, 0x7fffffc]"
   else .ok ()
 
+/--
+Validate a 19-bit signed word offset for conditional branch (`B.cond`):
+- Must be in `[-0x100000, 0xffffc]` (`±1 MB`, multiple of 4).
+-/
 def checkBCondOffset (offset : Int64) : Except String Unit :=
   let val := offset.toInt
   if val < -0x100000 || val > 0xffffc then
     .error s!"b.cond offset {intToHexStr val} out of range [-0x100000, 0xffffc]"
   else .ok ()
 
+/--
+Validate a 19-bit signed word offset for compare-and-branch (`CBZ` / `CBNZ`):
+- Must be in `[-0x100000, 0xffffc]` (`±1 MB`) and a multiple of 4.
+-/
 def checkCbzOffset (instrName : String) (offset : Int64) : Except String Unit :=
   let val := offset.toInt
   if val < -0x100000 || val > 0xffffc || val % 4 != 0 then
     .error s!"{instrName} offset {intToHexStr val} out of range [-0x100000, 0xffffc] or not a multiple of 4"
   else .ok ()
 
+/--
+Validate a 14-bit signed word offset for test-bit-and-branch (`TBZ` / `TBNZ`):
+- Must be in `[-0x8000, 0x7fc]` (`±32 KB`) and a multiple of 4.
+-/
 def checkTbzOffset (instrName : String) (offset : Int64) : Except String Unit :=
   let val := offset.toInt
   if val < -0x8000 || val > 0x7fc || val % 4 != 0 then
     .error s!"{instrName} offset {intToHexStr val} out of range [-0x8000, 0x7fc] or not a multiple of 4"
   else .ok ()
 
+/--
+Validate a bit test position for `TBZ` / `TBNZ`:
+- Must be in `[0, 31]` for `.W32` and `[0, 63]` for `.W64`.
+-/
 def checkTbzBitPosition (instrName : String) (w : Width) (bit : Int) : Except String Unit :=
   let maxBit := match w with | .W32 => 31 | .W64 => 63
   if bit < 0 || bit > maxBit then
     .error s!"{instrName} bit position {bit} out of range [0, {maxBit}] for {w.bits}-bit instruction"
   else .ok ()
 
-/-- Validates architectural constraints for `LDP` and `STP` instructions:
-    1. For `LDP`, `rt1` and `rt2` cannot be identical unless they are `XZR`/`WZR`.
-    2. If writeback (`!` pre-index or post-index) is used, the base register (`Rn`) cannot be one of the transfer registers (`rt1` or `rt2`). -/
+/--
+Validate architectural constraints for `LDP` and `STP` instructions:
+1. For `LDP`, `rt1` and `rt2` cannot be identical unless they are `XZR`/`WZR`.
+2. If writeback (`!` pre-index or post-index) is used, the base register (`Rn`)
+   cannot be one of the transfer registers (`rt1` or `rt2`).
+-/
 def checkLdpStpRegisters {w : Width} (isLdp : Bool) (reg1 : RegOrZr w) (reg2 : RegOrZr w) (mem : AddrExpr w) : Except String Unit := do
   if isLdp && reg1 == reg2 && (RegOrZr.toXReg? reg1).isSome then
     throw "unpredictable: identical destination registers in ldp instruction"
@@ -453,11 +602,16 @@ def checkLdpStpRegisters {w : Width} (isLdp : Bool) (reg1 : RegOrZr w) (reg2 : R
 -- Operand Parsing
 -- ============================================================================
 
-/-- Parses memory addressing operands for general load/store instructions (`LDR`/`STR`).
-    Supports the following AArch64 addressing modes:
-    1. **Base-only / Post-indexed**: `[base]` or `[base], #imm`
-    2. **Immediate / Pre-indexed**: `[base, #imm]` or `[base, #imm]!` or `[base, #:lo12:label]`
-    3. **Register offset with optional extension/shift**: `[base, Rm]` or `[base, Rm, ext #amount]` -/
+/--
+Parse memory addressing operands for general load/store instructions
+(`LDR` / `STR`).
+Supports the following AArch64 addressing modes:
+1. **Base-only / Post-indexed**: `[base]` or `[base], #imm`
+2. **Immediate / Pre-indexed**: `[base, #imm]`, `[base, #imm]!`, or
+   `[base, #:lo12:label]`
+3. **Register offset with optional extension/shift**: `[base, Rm]` or
+   `[base, Rm, ext #amount]`
+-/
 def parseAddr (w : Width) (allowUnscaled : Bool := false) : Parser (AddrExpr w) := do
   skipHWs
   let _ ← pchar '['
@@ -535,6 +689,11 @@ def parseAddr (w : Width) (allowUnscaled : Bool := false) : Parser (AddrExpr w) 
   else
     fail s!"expected ',' or ']' after base register in memory operand, got {c}"
 
+/--
+Parse unscaled immediate memory addressing (`[base]` or `[base, #imm]`) for
+`LDUR` / `STUR`.
+- Enforces that `#imm` is a 9-bit signed integer in `[-256, 255]`.
+-/
 def parseUnscaledAddr : Parser UnscaledAddrExpr := do
   skipHWs
   let _ ← pchar '['
@@ -561,6 +720,12 @@ def parseUnscaledAddr : Parser UnscaledAddrExpr := do
   else
     fail s!"expected ',' or ']' after base register in unscaled address operand, got {c}"
 
+/--
+Parse a memory source operand for `LDR`:
+- Standard address expression (`[base, ...]`).
+- PC-relative literal pool constant (`=const_expr`).
+- PC-relative symbol label (`label`).
+-/
 def parseAddrOrLit (w : Width) (allowUnscaled : Bool := false) : Parser (AddrOrLit w) := do
   skipHWs
   let c ← peek!
@@ -575,6 +740,12 @@ def parseAddrOrLit (w : Width) (allowUnscaled : Bool := false) : Parser (AddrOrL
     let l ← parseLabelRaw
     pure (.lit (.addr { label := l }))
 
+/--
+Parse memory addressing for load/store pair (`LDP` / `STP`):
+- Supports base-only (`[base]`), immediate offset (`[base, #imm]`),
+  pre-indexed (`[base, #imm]!`), and post-indexed (`[base], #imm`).
+- Enforces pair offset scaling and alignment via `checkPairOffset`.
+-/
 def parsePairAddr (w : Width) : Parser (AddrExpr w) := do
   skipHWs
   let _ ← pchar '['
@@ -610,6 +781,10 @@ def parsePairAddr (w : Width) : Parser (AddrExpr w) := do
   else
     fail s!"expected ',' or ']' after base register in pair memory operand, got {c}"
 
+/--
+Parse an optional extend shift amount (`#0` to `#4`) after an extend suffix.
+- Defaults to `E0` (`#0`) if omitted.
+-/
 def parseExtendAmount : Parser ExtendAmount := do
   skipHWs
   (do
@@ -626,6 +801,11 @@ def parseExtendAmount : Parser ExtendAmount := do
     | _ => fail s!"invalid extend amount: {val}"
   ) <|> pure ExtendAmount.E0
 
+/--
+Validate and map an arithmetic extension mnemonic (`UXTB`, `SXTB`, `UXTH`,
+`SXTH`, `UXTW`, `SXTW`, `UXTX`, `SXTX`, `LSL`).
+- Maps `LSL` to `UXTX` for `.W64` and `UXTW` for `.W32`.
+-/
 def getExtendType (extName : String) (w : Width) : Except String ExtendType :=
   match extName.toLower with
   | "uxtb" => .ok ExtendType.UXTB
@@ -642,10 +822,15 @@ def getExtendType (extName : String) (w : Width) : Except String ExtendType :=
     | .W32 => .ok ExtendType.UXTW
   | _ => .error s!"unknown extension type: {extName}"
 
-/-- Parses the second source operand of an `ADD_e` instruction (`add dst, src1, src2`).
-    `src2` can either be:
-    1. **Immediate operand**: `#imm` or `#imm, lsl #12` (or a relocation modifier `:lo12:label` with no shift).
-    2. **Extended/shifted register operand**: `Rm` or `Rm, ext #amount` (e.g. `x2, uxtw #2` or `x2, lsl #2`). -/
+/--
+Parse the second source operand of an `ADD_e` instruction
+(`add dst, src1, src2`).
+`src2` can either be:
+1. **Immediate operand**: `#imm` or `#imm, lsl #12` (or a relocation modifier
+   `:lo12:label` with no shift).
+2. **Extended/shifted register operand**: `Rm` or `Rm, ext #amount`
+   (e.g. `x2, uxtw #2` or `x2, lsl #2`).
+-/
 def parseExtOrImmReg (w : Width) : Parser (ExtOrImmReg w) := do
   skipHWs
   let c ← peek!
@@ -699,6 +884,12 @@ def parseExtOrImmReg (w : Width) : Parser (ExtOrImmReg w) := do
         | .W32 => ExtendType.UXTW
       pure (.ext { reg := regW, ext := { type := extType, amount := ExtendAmount.E0 } })
 
+/--
+Parse a shifted register operand (`Rm` or `Rm, shift #amount`).
+- Supports `LSL`, `LSR`, `ASR`, and optionally `ROR` (if `allowRor = true`).
+- Enforces shift amount bounds (`[0, 31]` for `.W32`, `[0, 63]` for `.W64`).
+- Rejects `ROR` in arithmetic instructions.
+-/
 def parseShiftRegExpr (w : Width) (allowRor : Bool := false) : Parser (ShiftRegExpr w) := do
   let reg ← parseRegOrZr w
   skipHWs
@@ -726,8 +917,11 @@ def parseShiftRegExpr (w : Width) (allowRor : Bool := false) : Parser (ShiftRegE
 -- Optional Operand Parsing
 -- ============================================================================
 
-/-- Checks if the parser is positioned at horizontal whitespace followed by line end, EOF, or comment.
-    If a comment is present, it is consumed up to the newline. -/
+/--
+Check if the parser is positioned at horizontal whitespace followed by line
+end, EOF, or comment.
+If a comment is present, it is consumed up to the newline.
+-/
 def isAtLineEndOrComment : Parser Bool := do
   skipHWs
   let c? ← peek?
@@ -737,7 +931,10 @@ def isAtLineEndOrComment : Parser Bool := do
   | _ =>
     (attempt skipTrailingComment *> pure true) <|> pure false
 
-/-- Parses an optional operand using `p`, or returns `defaultVal` if positioned at line end or comment. -/
+/--
+Parse an optional operand using `p`, or return `defaultVal` if positioned at
+line end or comment.
+-/
 def parseOptionalOperand {α : Type} (p : Parser α) (defaultVal : α) : Parser α := do
   if (← isAtLineEndOrComment) then
     pure defaultVal
@@ -768,6 +965,7 @@ def parseCondCode (s : String) : Option CondCode :=
   | "nv" => some .NV
   | _ => none
 
+/-- Parse a condition code operand (`cond`). -/
 def parseCondArg : Parser CondCode := do
   skipHWs
   let name ← parseName
@@ -779,6 +977,12 @@ def parseCondArg : Parser CondCode := do
 -- Instruction Parsing Helpers
 -- ============================================================================
 
+/--
+Parse arithmetic instructions without flags (`ADD`, `SUB`).
+- Supports both extended-register (`_e`: `ADD SP, SP, X0`) and shifted-register
+  (`_s`: `ADD X0, X1, X2, lsl #2`) forms.
+- Handles stack pointer (`SP`) disambiguation for operand index 31.
+-/
 def parseArithNoFlags
     (mkE : {w : Width} → RegOrSp w → RegOrSp w → ExtOrImmReg w → Operation w)
     (mkS : {w : Width} → RegOrZr w → RegOrZr w → ShiftRegExpr w → Operation w) : Parser Instr := do
@@ -809,6 +1013,11 @@ def parseArithNoFlags
       let extOp ← parseExtOrImmReg w
       pure ⟨w, mkE dstSp src1Sp extOp⟩)
 
+/--
+Parse arithmetic instructions that set flags (`ADDS`, `SUBS`).
+- Rejects `SP` / `WSP` as destination register.
+- Supports both extended-register (`_e`) and shifted-register (`_s`) forms.
+-/
 def parseArithFlags (instrName : String)
     (mkE : {w : Width} → RegOrZr w → RegOrSp w → ExtOrImmReg w → Operation w)
     (mkS : {w : Width} → RegOrZr w → RegOrZr w → ShiftRegExpr w → Operation w) : Parser Instr := do
@@ -841,6 +1050,11 @@ def parseArithFlags (instrName : String)
       let extOp ← parseExtOrImmReg w
       pure ⟨w, mkE dstZr src1Sp extOp⟩)
 
+/--
+Parse comparison instructions (`CMP`, `CMN`).
+- Models them architecturally as `SUBS` / `ADDS` with destination hardcoded to
+  `XZR` / `WZR`.
+-/
 def parseCompare
     (mkE : {w : Width} → RegOrZr w → RegOrSp w → ExtOrImmReg w → Operation w)
     (mkS : {w : Width} → RegOrZr w → RegOrZr w → ShiftRegExpr w → Operation w) : Parser Instr := do
@@ -868,6 +1082,11 @@ def parseCompare
       let extOp ← parseExtOrImmReg w
       pure ⟨w, mkE dstZr src1Sp extOp⟩)
 
+/--
+Parse three-register instructions (`ADC`, `SBC`, `LSLV`, `LSRV`, `ASRV`,
+`RORV`).
+- Enforces matching register widths across all three operands.
+-/
 def parseThreeRegs
     (mk : {w : Width} → RegOrZr w → RegOrZr w → RegOrZr w → Operation w) : Parser Instr := do
   let dstW ← parseRegOrZrW
@@ -878,6 +1097,10 @@ def parseThreeRegs
   let src2 ← parseRegOrZr w
   pure ⟨w, mk dstW.reg src1 src2⟩
 
+/--
+Parse four-register multiply-accumulate instructions (`MADD`, `MSUB`).
+- Enforces matching register widths across all four operands (`dst, rn, rm, ra`).
+-/
 def parseFourRegs
     (mk : {w : Width} → RegOrZr w → RegOrZr w → RegOrZr w → RegOrZr w → Operation w) : Parser Instr := do
   let dstW ← parseRegOrZrW
@@ -890,6 +1113,12 @@ def parseFourRegs
   let src3 ← parseRegOrZr w
   pure ⟨w, mk dstW.reg src1 src2 src3⟩
 
+/--
+Parse logical instructions without flags (`AND`, `ORR`, `EOR`).
+- Supports immediate bitmask (`_i`: `#imm`) and shifted-register (`_s`,
+  including `ROR`) forms.
+- Validates bitmasks.
+-/
 def parseLogicalNoFlags
     (mkI : {w : Width} → RegOrSp w → RegOrZr w → ConstExpr → Operation w)
     (mkS : {w : Width} → RegOrZr w → RegOrZr w → ShiftRegExpr w → Operation w) : Parser Instr := do
@@ -911,6 +1140,10 @@ def parseLogicalNoFlags
     let shiftOp ← parseShiftRegExpr w true
     pure ⟨w, mkS dstZr src1 shiftOp⟩
 
+/--
+Parse logical instructions that set flags (`ANDS`, `TST`).
+- `TST` is modeled architecturally as `ANDS` with destination `XZR` / `WZR`.
+-/
 def parseLogicalFlags
     (mkI : {w : Width} → RegOrZr w → RegOrZr w → ConstExpr → Operation w)
     (mkS : {w : Width} → RegOrZr w → RegOrZr w → ShiftRegExpr w → Operation w) : Parser Instr := do
@@ -930,6 +1163,10 @@ def parseLogicalFlags
     let shiftOp ← parseShiftRegExpr w true
     pure ⟨w, mkS dstW.reg src1 shiftOp⟩
 
+/--
+Parse register-only logical instructions (`ORN`, `BIC`).
+- Supports shifted-register operands (including `ROR`).
+-/
 def parseLogical
     (mkS : {w : Width} → RegOrZr w → RegOrZr w → ShiftRegExpr w → Operation w) : Parser Instr := do
   let dstW ← parseRegOrZrW
@@ -940,6 +1177,7 @@ def parseLogical
   let shiftOp ← parseShiftRegExpr w true
   pure ⟨w, mkS dstW.reg src1 shiftOp⟩
 
+/-- Parse conditional select instructions (`CSEL`, `CSINC`, `CSINV`, `CSNEG`). -/
 def parseCondSelect
     (mk : {w : Width} → RegOrZr w → RegOrZr w → RegOrZr w → CondCode → Operation w) : Parser Instr := do
   let dstW ← parseRegOrZrW
@@ -952,6 +1190,12 @@ def parseCondSelect
   let cond ← parseCondArg
   pure ⟨w, mk dstW.reg src1 src2 cond⟩
 
+/--
+Parse conditional select alias instructions (`CSET`, `CSETM`, `CNEG`).
+- `CSET dst, cond` maps to `CSINC dst, xzr, xzr, cond.invert`.
+- `CSETM dst, cond` maps to `CSINV dst, xzr, xzr, cond.invert`.
+- `CNEG dst, src, cond` maps to `CSNEG dst, src, src, cond.invert`.
+-/
 def parseCondAlias
     (mk : {w : Width} → RegOrZr w → RegOrZr w → RegOrZr w → CondCode → Operation w)
     (sameSrc : Bool) (useXzr : Bool) : Parser Instr := do
@@ -973,6 +1217,11 @@ def parseCondAlias
   let cond ← parseCondArg
   pure ⟨w, mk dstW.reg src1 src2 cond.invert⟩
 
+/--
+Check whether an unsigned bit vector value can be moved into a register using
+a single `MOVZ` instruction (i.e., it has at most one non-zero 16-bit halfword).
+- Returns `(imm16, shift)` for `LSL0`, `LSL16`, `LSL32`, or `LSL48`.
+-/
 def tryMovz (w : Width) (val : BitVec w.bits) : Option (Int64 × MovShift w) :=
   let n := val.toNat
   if n >>> 16 == 0 then
@@ -990,6 +1239,13 @@ def tryMovz (w : Width) (val : BitVec w.bits) : Option (Int64 × MovShift w) :=
       else
         none
 
+/--
+Check whether a bit vector value can be moved using a single `MOVZ` or `MOVN`
+instruction.
+- First tries `MOVZ` on `val`.
+- If that fails, tries `MOVZ` on the bitwise NOT (`~~~val`), which maps to `MOVN`.
+- Returns `(isMovn, imm16, shift)`.
+-/
 def tryMovzOrMovn (w : Width) (val : BitVec w.bits) : Option (Bool × Int64 × MovShift w) :=
   match tryMovz w val with
   | some (imm16, shift) => some (false, imm16, shift)
@@ -999,6 +1255,15 @@ def tryMovzOrMovn (w : Width) (val : BitVec w.bits) : Option (Bool × Int64 × M
     | some (imm16, shift) => some (true, imm16, shift)
     | none => none
 
+/--
+Parse flexible `MOV` alias instructions (`MOV dst, src` or `MOV dst, #imm`).
+- For register moves:
+  - Maps to `ADD_e dstSp, srcSp, #0` if either operand is `SP`/`WSP`.
+  - Maps to `ORR_s dstZr, xzr, srcZr` for general-purpose registers.
+- For immediate moves (`MOV dst, #imm`):
+  - Automatically selects `MOVZ`, `MOVN`, or bitwise `ORR_i` depending on encoding.
+  - Fails if the immediate cannot be encoded in a single instruction.
+-/
 def parseMov : Parser Instr := do
   let dstW ← parseAnyRegW
   let w := dstW.1
@@ -1038,6 +1303,10 @@ def parseMov : Parser Instr := do
       let srcZr ← srcAny.toRegOrZr
       pure ⟨w, .ORR_s dstZr (.low .XZR w) { reg := srcZr, amount := 0, shift := .LSL }⟩
 
+/--
+Parse `MVN` (Move NOT) alias instructions (`MVN dst, src`).
+- Maps architecturally to `ORN dst, xzr, src` with an optional shift.
+-/
 def parseMvn : Parser Instr := do
   let dstW ← parseRegOrZrW
   let w := dstW.w
@@ -1045,6 +1314,11 @@ def parseMvn : Parser Instr := do
   let shiftOp ← parseShiftRegExpr w true
   pure ⟨w, .ORN_s dstW.reg (.low .XZR w) shiftOp⟩
 
+/--
+Parse move wide instructions (`MOVZ`, `MOVK`, `MOVN`) with explicit
+16-bit immediates and optional `LSL` shift (`#0`, `#16`, `#32`, `#48`).
+- Enforces immediate range `[0, 65535]` and only allows `LSL` shifts.
+-/
 def parseMoveWide
     (mk : {w : Width} → RegOrZr w → ConstExpr → MovShift w → Operation w) : Parser Instr := do
   let dstW ← parseRegOrZrW
@@ -1066,6 +1340,11 @@ def parseMoveWide
   ) <|> liftExcept (getMovShift w 0)
   pure ⟨w, mk dstW.reg imm shift⟩
 
+/--
+Parse load/store pair instructions (`LDP`, `STP`).
+- Syntax: `ldp reg1, reg2, [base, #imm]`.
+- Validates registers and pair addressing mode via `checkLdpStpRegisters`.
+-/
 def parsePairMem
     (mk : {w : Width} → RegOrZr w → RegOrZr w → AddrExpr w → Operation w)
     (isLdp : Bool) : Parser Instr := do
@@ -1077,6 +1356,10 @@ def parsePairMem
   liftExcept (checkLdpStpRegisters isLdp reg1W.reg reg2 mem)
   pure ⟨reg1W.w, mk reg1W.reg reg2 mem⟩
 
+/--
+Parse instructions that take three 64-bit general-purpose register operands
+(`X0`-`X30`), such as `SMULH` and `UMULH`.
+-/
 def parseThreeRegsW64
     (mk : RegOrZr .W64 → RegOrZr .W64 → RegOrZr .W64 → Operation .W64) : Parser Instr := do
   let dst ← parseRegOrZr .W64
@@ -1086,6 +1369,11 @@ def parseThreeRegsW64
   let src2 ← parseRegOrZr .W64
   pure ⟨.W64, mk dst src1 src2⟩
 
+/--
+Parse 3-register alias instructions that map to 4-register operations with
+`XZR`/`WZR` as the implicit fourth register operand (e.g. `MUL dst, src1, src2`
+as `MADD dst, src1, src2, xzr`).
+-/
 def parseThreeRegsWithZr
     (mk : {w : Width} → RegOrZr w → RegOrZr w → RegOrZr w → RegOrZr w → Operation w) : Parser Instr := do
   let dstW ← parseRegOrZrW
@@ -1096,6 +1384,10 @@ def parseThreeRegsWithZr
   let src2 ← parseRegOrZr w
   pure ⟨w, mk dstW.reg src1 src2 (.low .XZR w)⟩
 
+/--
+Parse negation alias instructions (`NEG dst, src` or `NEGS dst, src`).
+- Maps architecturally to `SUB dst, xzr, src` or `SUBS dst, xzr, src` with an optional shift.
+-/
 def parseNegAlias
     (mk : {w : Width} → RegOrZr w → RegOrZr w → ShiftRegExpr w → Operation w) : Parser Instr := do
   let dstW ← parseRegOrZrW
@@ -1104,6 +1396,12 @@ def parseNegAlias
   let src ← parseRegOrZr w
   pure ⟨w, mk dstW.reg (.low .XZR w) { reg := src, amount := 0, shift := .LSL }⟩
 
+/--
+Parse `TST` (Test bits and set flags) alias instructions (`TST src1, src2`
+or `TST src1, #imm`).
+- Maps architecturally to `ANDS xzr, src1, src2` (register/shifted) or
+  `ANDS_i xzr, src1, #imm` (immediate).
+-/
 def parseTstAlias : Parser Instr := do
   let src1W ← parseRegOrZrW
   let w := src1W.w
@@ -1119,6 +1417,11 @@ def parseTstAlias : Parser Instr := do
     let src2 ← parseShiftRegExpr w true
     pure ⟨w, .ANDS_s (.low .XZR w) src1W.reg src2⟩
 
+/--
+Parse PC-relative address calculation instructions (`ADR`, `ADRP`).
+- Validates offset alignment and bounds via `checkOffset`
+  (`checkAdrOffset` / `checkAdrpOffset`).
+-/
 def parseAdr (checkOffset : Int64 → Except String Unit)
     (mk : RegOrZr .W64 → ConstExpr → Operation .W64) : Parser Instr := do
   let dst ← parseRegOrZr .W64
@@ -1128,16 +1431,26 @@ def parseAdr (checkOffset : Int64 → Except String Unit)
     liftExcept (checkOffset imm)
   pure ⟨.W64, mk dst target⟩
 
+/--
+Parse unconditional relative branches (`B`, `BL`).
+- Enforces 26-bit signed word offset limits (`±128 MB`).
+-/
 def parseBranch (mk : ConstExpr → Operation .W64) : Parser Instr := do
   let target ← parseConstExpr
   if let .int64 imm := target then
     liftExcept (checkBOffset imm)
   pure ⟨.W64, mk target⟩
 
+/-- Parse indirect branches via register (`BLR`, `BR`). -/
 def parseBranchReg (mk : RegOrZr .W64 → Operation .W64) : Parser Instr := do
   let target ← parseRegOrZr .W64
   pure ⟨.W64, mk target⟩
 
+/--
+Parse compare-and-branch instructions (`CBZ`, `CBNZ`).
+- Syntax: `cbz reg, target`.
+- Validates 19-bit signed word target offset (`±1 MB`).
+-/
 def parseCbz (name : String)
     (mk : {w : Width} → RegOrZr w → ConstExpr → Operation w) : Parser Instr := do
   let regW ← parseRegOrZrW
@@ -1147,6 +1460,12 @@ def parseCbz (name : String)
     liftExcept (checkCbzOffset name imm)
   pure ⟨regW.w, mk regW.reg target⟩
 
+/--
+Parse test-bit-and-branch instructions (`TBZ`, `TBNZ`).
+- Syntax: `tbz reg, #bit, target`.
+- Enforces bit position bounds (`[0, 31]` for `.W32`, `[0, 63]` for `.W64`)
+  and 14-bit signed word target offset (`±32 KB`).
+-/
 def parseTbz (name : String)
     (mk : {w : Width} → RegOrZr w → Nat → ConstExpr → Operation w) : Parser Instr := do
   let regW ← parseRegOrZrW
@@ -1300,8 +1619,10 @@ def parseInstr : Parser Instr := do
 -- Line and Program Parsing
 -- ============================================================================
 
-/-- Parse an optional label (name followed by colon).
-    Uses attempt for proper backtracking if colon is not found. -/
+/--
+Parse an optional symbol label declaration (name followed by `:`).
+- Uses `attempt` for clean backtracking if `:` is not found after the name.
+-/
 def parseLabelDecl : Parser Label := do
   skipHWs
   attempt do
@@ -1310,6 +1631,10 @@ def parseLabelDecl : Parser Label := do
     let _ ← pchar ':'
     pure name
 
+/--
+Parse an optional instruction on the current line, returning `none` if at
+line end or comment.
+-/
 def parseOptionalInstr : Parser (Option Directive) := do
   if (← isAtLineEndOrComment) then
     pure none
@@ -1317,14 +1642,25 @@ def parseOptionalInstr : Parser (Option Directive) := do
     let i ← parseInstr
     pure (some (Directive.instr i))
 
+/--
+Verify that no unexpected trailing characters remain on the line after
+parsing operands/instructions.
+- Fails with `unexpected trailing characters on line` if extra tokens exist.
+-/
 def checkLineEnd : Parser Unit := do
   if (← isAtLineEndOrComment) then
     pure ()
   else
     fail "unexpected trailing characters on line"
 
-/-- Parse a single line: optional label, followed by optional instruction or directive.
-    Returns a list of directives found on the line. -/
+/--
+Parse a single assembly line:
+- Zero or more label declarations (`label:`).
+- Optional instruction (`ldr x0, [sp]`).
+- Optional comment (`# comment` or `// comment`).
+- Returns the list of AST directives (`Directive.label`, `Directive.instr`)
+  found on the line.
+-/
 def parseLine : Parser (List Directive) := do
   skipHWs
   let c? ← peek?

--- a/Kraken/AArch64/Parser.lean
+++ b/Kraken/AArch64/Parser.lean
@@ -234,6 +234,14 @@ def getMemExtendAmount (w : Width) (amt : Nat) : Except String (MemExtendAmount 
   | .W64, 3 => .ok .E3
   | _, _ => .error s!"invalid memory extension shift amount {amt} for width {w}"
 
+def getMovShift (w : Width) (amt : Nat) : Except String (MovShift w) :=
+  match w, amt with
+  | _, 0     => .ok .LSL0
+  | _, 16    => .ok .LSL16
+  | .W64, 32 => .ok .LSL32
+  | .W64, 48 => .ok .LSL48
+  | _, _     => .error s!"invalid move wide shift amount {amt} for width {w}"
+
 def getMemExtendType (extName : String) (w : Width) : Except String MemExtendType :=
   match extName.toLower with
   | "uxtw" => .ok MemExtendType.UXTW
@@ -961,6 +969,99 @@ def parseCondAlias
   let cond ← parseCondArg
   pure ⟨w, mk dstW.reg src1 src2 cond.invert⟩
 
+def tryMovz (w : Width) (val : BitVec w.bits) : Option (Int64 × MovShift w) :=
+  let n := val.toNat
+  if n >>> 16 == 0 then
+    some (.ofNat n, .LSL0)
+  else if n &&& 0xFFFF == 0 && n >>> 32 == 0 then
+    some (.ofNat (n >>> 16), .LSL16)
+  else
+    match w with
+    | .W32 => none
+    | .W64 =>
+      if n &&& 0xFFFFFFFF == 0 && n >>> 48 == 0 then
+        some (.ofNat (n >>> 32), .LSL32)
+      else if n &&& 0xFFFFFFFFFFFF == 0 then
+        some (.ofNat (n >>> 48), .LSL48)
+      else
+        none
+
+def tryMovzOrMovn (w : Width) (val : BitVec w.bits) : Option (Bool × Int64 × MovShift w) :=
+  match tryMovz w val with
+  | some (imm16, shift) => some (false, imm16, shift)
+  | none =>
+    let invVal := ~~~val
+    match tryMovz w invVal with
+    | some (imm16, shift) => some (true, imm16, shift)
+    | none => none
+
+def parseMov : Parser Instr := do
+  let dstW ← parseAnyRegW
+  let w := dstW.1
+  parseComma
+  skipHWs
+  let nextC ← peek!
+  if nextC == '#' || nextC == '-' || nextC.isDigit then
+    let imm ← parseConstExpr
+    if let .int64 val := imm then
+      if !dstW.2.isSp then
+        let dstZr ← dstW.2.toRegOrZr
+        let valBitVec := BitVec.ofInt w.bits val.toInt
+        match tryMovzOrMovn w valBitVec with
+        | some (false, imm16, shift) => pure ⟨w, .MOVZ dstZr (.int64 imm16) shift⟩
+        | some (true, imm16, shift)  => pure ⟨w, .MOVN dstZr (.int64 imm16) shift⟩
+        | none =>
+          match checkLogicalImmediate w val with
+          | .ok _ =>
+            let dstSp ← dstW.2.toRegOrSp
+            pure ⟨w, .ORR_i dstSp (.low .XZR w) imm⟩
+          | .error _ => fail "immediate cannot be moved by a single instruction (requires MOVZ/MOVK sequence)"
+      else
+        let dstSp ← dstW.2.toRegOrSp
+        liftExcept (checkLogicalImmediate w val)
+        pure ⟨w, .ORR_i dstSp (.low .XZR w) imm⟩
+    else
+      let dstSp ← dstW.2.toRegOrSp
+      pure ⟨w, .ORR_i dstSp (.low .XZR w) imm⟩
+  else
+    let srcAny ← parseAnyReg w
+    if dstW.2.isSp || srcAny.isSp then
+      let dstSp ← dstW.2.toRegOrSp
+      let srcSp ← srcAny.toRegOrSp
+      pure ⟨w, .ADD_e dstSp srcSp (.imm { imm := 0, shift := .S0 })⟩
+    else
+      let dstZr ← dstW.2.toRegOrZr
+      let srcZr ← srcAny.toRegOrZr
+      pure ⟨w, .ORR_s dstZr (.low .XZR w) { reg := srcZr, amount := 0, shift := .LSL }⟩
+
+def parseMvn : Parser Instr := do
+  let dstW ← parseRegOrZrW
+  let w := dstW.w
+  parseComma
+  let shiftOp ← parseShiftRegExpr w true
+  pure ⟨w, .ORN_s dstW.reg (.low .XZR w) shiftOp⟩
+
+def parseMoveWide
+    (mk : {w : Width} → RegOrZr w → ConstExpr → MovShift w → Operation w) : Parser Instr := do
+  let dstW ← parseRegOrZrW
+  let w := dstW.w
+  parseComma
+  let imm ← parseConstExpr
+  if let .int64 val := imm then
+    if val.toInt < 0 || val.toInt > 0xFFFF then
+      fail s!"move wide immediate {val.toInt} out of range [0, 65535]"
+  let shift ← (attempt do
+    parseComma
+    skipHWs
+    let name ← parseName
+    if name.toLower != "lsl" then fail "only lsl shift supported for move wide"
+    let amt ← parseConstExpr
+    match amt with
+    | .int64 n => liftExcept (getMovShift w n.toBitVec.toNat)
+    | _ => liftExcept (getMovShift w 0)
+  ) <|> liftExcept (getMovShift w 0)
+  pure ⟨w, mk dstW.reg imm shift⟩
+
 -- ============================================================================
 -- Instruction Parsing
 -- ============================================================================
@@ -1123,6 +1224,12 @@ def parseInstr : Parser Instr := do
   | "cinc"  => parseCondAlias .CSINC true false
   | "cinv"  => parseCondAlias .CSINV true false
   | "cneg"  => parseCondAlias .CSNEG true false
+
+  | "mov"   => parseMov
+  | "mvn"   => parseMvn
+  | "movz"  => parseMoveWide .MOVZ
+  | "movk"  => parseMoveWide .MOVK
+  | "movn"  => parseMoveWide .MOVN
 
   | "adr" =>
     let dst ← parseRegOrZr .W64

--- a/Kraken/AArch64/Parser.lean
+++ b/Kraken/AArch64/Parser.lean
@@ -21,17 +21,18 @@ open Std.Internal.Parsec.String
 def skipHWs : Parser Unit := do
   let _ ← many (pchar ' ' <|> pchar '\t')
 
-/-- Skip a trailing line comment starting with `//`. -/
-def skipTrailingComment : Parser Unit := do
-  let _ ← pstring "//"
+/-- Consume characters until the end of the line (newline not consumed). -/
+def skipToNewline : Parser Unit := do
   let _ ← many (satisfy fun c => c != '\n')
   pure ()
 
+/-- Skip a trailing line comment starting with `//`. -/
+def skipTrailingComment : Parser Unit :=
+  pstring "//" *> skipToNewline
+
 /-- Skip a full-line comment starting with `#` or `//`. -/
-def skipFullLineComment : Parser Unit := do
-  let _ ← pchar '#' <|> (pstring "//" *> pure '/')
-  let _ ← many (satisfy fun c => c != '\n')
-  pure ()
+def skipFullLineComment : Parser Unit :=
+  (pchar '#' <|> (pstring "//" *> pure '/')) *> skipToNewline
 
 /-- Parse a single decimal digit. -/
 def digit : Parser Char := satisfy fun c => c >= '0' && c <= '9'
@@ -85,11 +86,10 @@ def parseInt64 : Parser Int64 := do
   let v ← parseInt
   if v < -9223372036854775808 || v >= 18446744073709551616 then
     fail s!"immediate {v} out of 64-bit range"
-  let i64 := if v > 9223372036854775807 then
+  pure (if v > 9223372036854775807 then
     Int64.ofInt (v - 18446744073709551616)
   else
-    Int64.ofInt v
-  pure i64
+    Int64.ofInt v)
 
 def parseLabelRaw : Parser Label := parseName
 
@@ -99,14 +99,14 @@ partial def parseConstExpr : Parser ConstExpr := do
   let _ ← optional (pchar '#')
   skipHWs
   let c ← peek!
-  if c == ':' then do
+  if c == ':' then
     let mod ← (pstring ":pg_hi21:" *> pure ConstExpr.pg_hi21) <|> (pstring ":lo12:" *> pure ConstExpr.lo12)
     let inner ← parseConstExpr
     pure (mod inner)
-  else if c == '-' || c == '+' || c.isDigit then do
+  else if c == '-' || c == '+' || c.isDigit then
     let i ← parseInt64
     pure (.int64 i)
-  else do
+  else
     let l ← parseLabelRaw
     pure (.label l)
 
@@ -216,6 +216,16 @@ def AnyReg.isXzr {w : Width} : AnyReg w → Bool
   | .xzr => true
   | _ => false
 
+/-- Extract the underlying `XReg` if this is a general-purpose register (and not `XZR`/`WZR`). -/
+def RegOrZr.toXReg? {w : Width} : RegOrZr w → Option XReg
+  | .low (.reg r) _ => some r
+  | _ => none
+
+/-- Extract the underlying `XReg` if this is a general-purpose register (and not `SP`/`WSP`). -/
+def RegOrSp.toXReg? {w : Width} : RegOrSp w → Option XReg
+  | .low (.reg r) _ => some r
+  | _ => none
+
 -- ============================================================================
 -- Operand Parsing
 -- ============================================================================
@@ -260,11 +270,9 @@ def getMemExtendType (extName : String) (w : Width) : Except String MemExtendTyp
   | "lsl",  .W32 => .ok MemExtendType.UXTW
   | ext,    _    => .error s!"unknown memory extension type: {ext}"
 
-def checkUnsignedOffset (w : Width) (imm : Int64) : Except String Unit :=
-  let (maxOff, align) := match w with | .W32 => (16380, 4) | .W64 => (32760, 8)
-  if imm.toInt < 0 || imm.toInt > maxOff || imm.toInt % align != 0 then
-    .error s!"unsigned offset {imm.toInt} out of range [0, {maxOff}] or not a multiple of {align}"
-  else .ok ()
+-- ============================================================================
+-- Validation Helpers
+-- ============================================================================
 
 def checkLoadStoreOffset (w : Width) (imm : Int64) (allowUnscaled : Bool) : Except String Unit :=
   let (maxOff, align) := match w with | .W32 => (16380, 4) | .W64 => (32760, 8)
@@ -427,6 +435,23 @@ def checkTbzBitPosition (instrName : String) (w : Width) (bit : Int) : Except St
   if bit < 0 || bit > maxBit then
     .error s!"{instrName} bit position {bit} out of range [0, {maxBit}] for {w.bits}-bit instruction"
   else .ok ()
+
+/-- Validates architectural constraints for `LDP` and `STP` instructions:
+    1. For `LDP`, `rt1` and `rt2` cannot be identical unless they are `XZR`/`WZR`.
+    2. If writeback (`!` pre-index or post-index) is used, the base register (`Rn`) cannot be one of the transfer registers (`rt1` or `rt2`). -/
+def checkLdpStpRegisters {w : Width} (isLdp : Bool) (reg1 : RegOrZr w) (reg2 : RegOrZr w) (mem : AddrExpr w) : Except String Unit := do
+  if isLdp && reg1 == reg2 && (RegOrZr.toXReg? reg1).isSome then
+    throw "unpredictable: identical destination registers in ldp instruction"
+  let hasWriteback := match mem.off with | .imm i => i.index.isSome | _ => false
+  if hasWriteback then
+    if let some baseReg := RegOrSp.toXReg? mem.base then
+      if RegOrZr.toXReg? reg1 == some baseReg || RegOrZr.toXReg? reg2 == some baseReg then
+        throw "unpredictable: writeback base register is also a transfer register"
+  pure ()
+
+-- ============================================================================
+-- Operand Parsing
+-- ============================================================================
 
 /-- Parses memory addressing operands for general load/store instructions (`LDR`/`STR`).
     Supports the following AArch64 addressing modes:
@@ -751,33 +776,6 @@ def parseCondArg : Parser CondCode := do
   | none => fail s!"unknown condition code: {name}"
 
 -- ============================================================================
--- Validation Helpers
--- ============================================================================
-
-/-- Extract the underlying `XReg` if this is a general-purpose register (and not `XZR`/`WZR`). -/
-def RegOrZr.toXReg? {w : Width} : RegOrZr w → Option XReg
-  | .low (.reg r) _ => some r
-  | _ => none
-
-/-- Extract the underlying `XReg` if this is a general-purpose register (and not `SP`/`WSP`). -/
-def RegOrSp.toXReg? {w : Width} : RegOrSp w → Option XReg
-  | .low (.reg r) _ => some r
-  | _ => none
-
-/-- Validates architectural constraints for `LDP` and `STP` instructions:
-    1. For `LDP`, `rt1` and `rt2` cannot be identical unless they are `XZR`/`WZR`.
-    2. If writeback (`!` pre-index or post-index) is used, the base register (`Rn`) cannot be one of the transfer registers (`rt1` or `rt2`). -/
-def checkLdpStpRegisters {w : Width} (isLdp : Bool) (reg1 : RegOrZr w) (reg2 : RegOrZr w) (mem : AddrExpr w) : Except String Unit := do
-  if isLdp && reg1 == reg2 && (RegOrZr.toXReg? reg1).isSome then
-    throw "unpredictable: identical destination registers in ldp instruction"
-  let hasWriteback := match mem.off with | .imm i => i.index.isSome | _ => false
-  if hasWriteback then
-    if let some baseReg := RegOrSp.toXReg? mem.base then
-      if RegOrZr.toXReg? reg1 == some baseReg || RegOrZr.toXReg? reg2 == some baseReg then
-        throw "unpredictable: writeback base register is also a transfer register"
-  pure ()
-
--- ============================================================================
 -- Instruction Parsing Helpers
 -- ============================================================================
 
@@ -1068,6 +1066,99 @@ def parseMoveWide
   ) <|> liftExcept (getMovShift w 0)
   pure ⟨w, mk dstW.reg imm shift⟩
 
+def parsePairMem
+    (mk : {w : Width} → RegOrZr w → RegOrZr w → AddrExpr w → Operation w)
+    (isLdp : Bool) : Parser Instr := do
+  let reg1W ← parseRegOrZrW
+  parseComma
+  let reg2 ← parseRegOrZr reg1W.w
+  parseComma
+  let mem ← parsePairAddr reg1W.w
+  liftExcept (checkLdpStpRegisters isLdp reg1W.reg reg2 mem)
+  pure ⟨reg1W.w, mk reg1W.reg reg2 mem⟩
+
+def parseThreeRegsW64
+    (mk : RegOrZr .W64 → RegOrZr .W64 → RegOrZr .W64 → Operation .W64) : Parser Instr := do
+  let dst ← parseRegOrZr .W64
+  parseComma
+  let src1 ← parseRegOrZr .W64
+  parseComma
+  let src2 ← parseRegOrZr .W64
+  pure ⟨.W64, mk dst src1 src2⟩
+
+def parseThreeRegsWithZr
+    (mk : {w : Width} → RegOrZr w → RegOrZr w → RegOrZr w → RegOrZr w → Operation w) : Parser Instr := do
+  let dstW ← parseRegOrZrW
+  let w := dstW.w
+  parseComma
+  let src1 ← parseRegOrZr w
+  parseComma
+  let src2 ← parseRegOrZr w
+  pure ⟨w, mk dstW.reg src1 src2 (.low .XZR w)⟩
+
+def parseNegAlias
+    (mk : {w : Width} → RegOrZr w → RegOrZr w → ShiftRegExpr w → Operation w) : Parser Instr := do
+  let dstW ← parseRegOrZrW
+  let w := dstW.w
+  parseComma
+  let src ← parseRegOrZr w
+  pure ⟨w, mk dstW.reg (.low .XZR w) { reg := src, amount := 0, shift := .LSL }⟩
+
+def parseTstAlias : Parser Instr := do
+  let src1W ← parseRegOrZrW
+  let w := src1W.w
+  parseComma
+  skipHWs
+  let nextC ← peek!
+  if nextC == '#' || nextC == '-' || nextC.isDigit then
+    let imm ← parseConstExpr
+    if let .int64 val := imm then
+      liftExcept (checkLogicalImmediate w val)
+    pure ⟨w, .ANDS_i (.low .XZR w) src1W.reg imm⟩
+  else
+    let src2 ← parseShiftRegExpr w true
+    pure ⟨w, .ANDS_s (.low .XZR w) src1W.reg src2⟩
+
+def parseAdr (checkOffset : Int64 → Except String Unit)
+    (mk : RegOrZr .W64 → ConstExpr → Operation .W64) : Parser Instr := do
+  let dst ← parseRegOrZr .W64
+  parseComma
+  let target ← parseConstExpr
+  if let .int64 imm := target then
+    liftExcept (checkOffset imm)
+  pure ⟨.W64, mk dst target⟩
+
+def parseBranch (mk : ConstExpr → Operation .W64) : Parser Instr := do
+  let target ← parseConstExpr
+  if let .int64 imm := target then
+    liftExcept (checkBOffset imm)
+  pure ⟨.W64, mk target⟩
+
+def parseBranchReg (mk : RegOrZr .W64 → Operation .W64) : Parser Instr := do
+  let target ← parseRegOrZr .W64
+  pure ⟨.W64, mk target⟩
+
+def parseCbz (name : String)
+    (mk : {w : Width} → RegOrZr w → ConstExpr → Operation w) : Parser Instr := do
+  let regW ← parseRegOrZrW
+  parseComma
+  let target ← parseConstExpr
+  if let .int64 imm := target then
+    liftExcept (checkCbzOffset name imm)
+  pure ⟨regW.w, mk regW.reg target⟩
+
+def parseTbz (name : String)
+    (mk : {w : Width} → RegOrZr w → Nat → ConstExpr → Operation w) : Parser Instr := do
+  let regW ← parseRegOrZrW
+  parseComma
+  let bit ← parseInt
+  liftExcept (checkTbzBitPosition name regW.w bit)
+  parseComma
+  let target ← parseConstExpr
+  if let .int64 imm := target then
+    liftExcept (checkTbzOffset name imm)
+  pure ⟨regW.w, mk regW.reg bit.toNat target⟩
+
 -- ============================================================================
 -- Instruction Parsing
 -- ============================================================================
@@ -1111,85 +1202,31 @@ def parseInstr : Parser Instr := do
     let dst ← parseUnscaledAddr
     pure ⟨srcW.w, .STUR srcW.reg dst⟩
 
-  | "ldp" =>
-    let dst1W ← parseRegOrZrW
-    parseComma
-    let dst2 ← parseRegOrZr dst1W.w
-    parseComma
-    let src ← parsePairAddr dst1W.w
-    liftExcept (checkLdpStpRegisters true dst1W.reg dst2 src)
-    pure ⟨dst1W.w, .LDP dst1W.reg dst2 src⟩
+  | "ldp"   => parsePairMem .LDP true
+  | "stp"   => parsePairMem .STP false
 
-  | "stp" =>
-    let src1W ← parseRegOrZrW
-    parseComma
-    let src2 ← parseRegOrZr src1W.w
-    parseComma
-    let dst ← parsePairAddr src1W.w
-    liftExcept (checkLdpStpRegisters false src1W.reg src2 dst)
-    pure ⟨src1W.w, .STP src1W.reg src2 dst⟩
+  | "add"   => parseArithNoFlags .ADD_e .ADD_s
+  | "adds"  => parseArithFlags "adds" .ADDS_e .ADDS_s
+  | "cmn"   => parseCompare .ADDS_e .ADDS_s
+  | "sub"   => parseArithNoFlags .SUB_e .SUB_s
+  | "subs"  => parseArithFlags "subs" .SUBS_e .SUBS_s
+  | "cmp"   => parseCompare .SUBS_e .SUBS_s
 
-  | "add"  => parseArithNoFlags .ADD_e .ADD_s
-  | "adds" => parseArithFlags "adds" .ADDS_e .ADDS_s
-  | "cmn"  => parseCompare .ADDS_e .ADDS_s
-  | "sub"  => parseArithNoFlags .SUB_e .SUB_s
-  | "subs" => parseArithFlags "subs" .SUBS_e .SUBS_s
-  | "cmp"  => parseCompare .SUBS_e .SUBS_s
-
-  | "adc"  => parseThreeRegs .ADC
-  | "adcs" => parseThreeRegs .ADCS
-  | "sbc"  => parseThreeRegs .SBC
-  | "sbcs" => parseThreeRegs .SBCS
+  | "adc"   => parseThreeRegs .ADC
+  | "adcs"  => parseThreeRegs .ADCS
+  | "sbc"   => parseThreeRegs .SBC
+  | "sbcs"  => parseThreeRegs .SBCS
 
   | "madd"  => parseFourRegs .MADD
   | "msub"  => parseFourRegs .MSUB
-  | "mneg"  => do -- Alias of MSUB _, _, _, ZR
-    let dstW ← parseRegOrZrW
-    let w := dstW.w
-    parseComma
-    let src1 ← parseRegOrZr w
-    parseComma
-    let src2 ← parseRegOrZr w
-    pure ⟨w, .MSUB dstW.reg src1 src2 (.low .XZR w)⟩
+  | "mneg"  => parseThreeRegsWithZr .MSUB
+  | "mul"   => parseThreeRegsWithZr .MADD
 
-  | "mul"   => do -- Alias of MADD _, _, _, ZR
-    let dstW ← parseRegOrZrW
-    let w := dstW.w
-    parseComma
-    let src1 ← parseRegOrZr w
-    parseComma
-    let src2 ← parseRegOrZr w
-    pure ⟨w, .MADD dstW.reg src1 src2 (.low .XZR w)⟩
+  | "neg"   => parseNegAlias .SUB_s
+  | "negs"  => parseNegAlias .SUBS_s
 
-  | "neg" => do -- Alias of SUB _, ZR, _, LSL #0
-    let dstW ← parseRegOrZrW
-    let w := dstW.w
-    parseComma
-    let src ← parseRegOrZr w
-    pure ⟨w, .SUB_s dstW.reg (.low .XZR w) { reg := src, amount := 0, shift := .LSL }⟩
-
-  | "negs" => do -- Alias of SUBS _, ZR, _, LSL #0
-    let dstW ← parseRegOrZrW
-    let w := dstW.w
-    parseComma
-    let src ← parseRegOrZr w
-    pure ⟨w, .SUBS_s dstW.reg (.low .XZR w) { reg := src, amount := 0, shift := .LSL }⟩
-
-  | "smulh" => do
-    let dst ← parseRegOrZr .W64
-    parseComma
-    let src1 ← parseRegOrZr .W64
-    parseComma
-    let src2 ← parseRegOrZr .W64
-    pure ⟨.W64, .SMULH dst src1 src2⟩
-
-  | "umulh" => do
-    let dst ← parseRegOrZr .W64
-    parseComma
-    let src1 ← parseRegOrZr .W64
-    parseComma
-    let src2 ← parseRegOrZr .W64
-    pure ⟨.W64, .UMULH dst src1 src2⟩
+  | "smulh" => parseThreeRegsW64 .SMULH
+  | "umulh" => parseThreeRegsW64 .UMULH
 
   | "and"   => parseLogicalNoFlags .AND_i .AND_s
   | "ands"  => parseLogicalFlags .ANDS_i .ANDS_s
@@ -1197,25 +1234,12 @@ def parseInstr : Parser Instr := do
   | "orn"   => parseLogical .ORN_s
   | "eor"   => parseLogicalNoFlags .EOR_i .EOR_s
   | "bic"   => parseLogical .BIC_s
-  | "tst"   => do  -- Alias of ANDS ZR, _, _
-    let src1W ← parseRegOrZrW
-    let w := src1W.w
-    parseComma
-    skipHWs
-    let nextC ← peek!
-    if nextC == '#' || nextC == '-' || nextC.isDigit then
-      let imm ← parseConstExpr
-      if let .int64 val := imm then
-        liftExcept (checkLogicalImmediate w val)
-      pure ⟨w, .ANDS_i (.low .XZR w) src1W.reg imm⟩
-    else
-      let src2 ← parseShiftRegExpr w true
-      pure ⟨w, .ANDS_s (.low .XZR w) src1W.reg src2⟩
+  | "tst"   => parseTstAlias
 
-  | "lsl"   => parseThreeRegs .LSLV -- Alias of LSLV
-  | "lsr"   => parseThreeRegs .LSRV -- Alias of LSRV
-  | "asr"   => parseThreeRegs .ASRV -- Alias of ASRV
-  | "ror"   => parseThreeRegs .RORV -- Alias of RORV
+  | "lsl"   => parseThreeRegs .LSLV
+  | "lsr"   => parseThreeRegs .LSRV
+  | "asr"   => parseThreeRegs .ASRV
+  | "ror"   => parseThreeRegs .RORV
   | "lslv"  => parseThreeRegs .LSLV
   | "lsrv"  => parseThreeRegs .LSRV
   | "asrv"  => parseThreeRegs .ASRV
@@ -1237,86 +1261,23 @@ def parseInstr : Parser Instr := do
   | "movk"  => parseMoveWide .MOVK
   | "movn"  => parseMoveWide .MOVN
 
-  | "adr" =>
-    let dst ← parseRegOrZr .W64
-    parseComma
-    let target ← parseConstExpr
-    if let .int64 imm := target then
-      liftExcept (checkAdrOffset imm)
-    pure ⟨.W64, .ADR dst target⟩
+  | "adr"   => parseAdr checkAdrOffset .ADR
+  | "adrp"  => parseAdr checkAdrpOffset .ADRP
 
-  | "adrp" =>
-    let dst ← parseRegOrZr .W64
-    parseComma
-    let target ← parseConstExpr
-    if let .int64 imm := target then
-      liftExcept (checkAdrpOffset imm)
-    pure ⟨.W64, .ADRP dst target⟩
-
-  | "b" =>
-    let target ← parseConstExpr
-    if let .int64 imm := target then
-      liftExcept (checkBOffset imm)
-    pure ⟨.W64, .B target⟩
-
-  | "bl" =>
-    let target ← parseConstExpr
-    if let .int64 imm := target then
-      liftExcept (checkBOffset imm)
-    pure ⟨.W64, .BL target⟩
-
-  | "blr" =>
-    let target ← parseRegOrZr .W64
-    pure ⟨.W64, .BLR target⟩
-
-  | "br" =>
-    let target ← parseRegOrZr .W64
-    pure ⟨.W64, .BR target⟩
-
-  | "ret" =>
+  | "b"     => parseBranch .B
+  | "bl"    => parseBranch .BL
+  | "blr"   => parseBranchReg .BLR
+  | "br"    => parseBranchReg .BR
+  | "ret"   => do
     let target ← parseOptionalOperand (parseRegOrZr .W64) RegOrZr.X30
     pure ⟨.W64, .RET target⟩
 
-  | "cbz" =>
-    let regW ← parseRegOrZrW
-    parseComma
-    let target ← parseConstExpr
-    if let .int64 imm := target then
-      liftExcept (checkCbzOffset "cbz" imm)
-    pure ⟨regW.w, .CBZ regW.reg target⟩
+  | "cbz"   => parseCbz "cbz" .CBZ
+  | "cbnz"  => parseCbz "cbnz" .CBNZ
+  | "tbz"   => parseTbz "tbz" .TBZ
+  | "tbnz"  => parseTbz "tbnz" .TBNZ
 
-  | "cbnz" =>
-    let regW ← parseRegOrZrW
-    parseComma
-    let target ← parseConstExpr
-    if let .int64 imm := target then
-      liftExcept (checkCbzOffset "cbnz" imm)
-    pure ⟨regW.w, .CBNZ regW.reg target⟩
-
-  | "tbz" =>
-    let regW ← parseRegOrZrW
-    parseComma
-    let bit ← parseInt
-    liftExcept (checkTbzBitPosition "tbz" regW.w bit)
-    parseComma
-    let target ← parseConstExpr
-    if let .int64 imm := target then
-      liftExcept (checkTbzOffset "tbz" imm)
-    pure ⟨regW.w, .TBZ regW.reg bit.toNat target⟩
-
-  | "tbnz" =>
-    let regW ← parseRegOrZrW
-    parseComma
-    let bit ← parseInt
-    liftExcept (checkTbzBitPosition "tbnz" regW.w bit)
-    parseComma
-    let target ← parseConstExpr
-    if let .int64 imm := target then
-      liftExcept (checkTbzOffset "tbnz" imm)
-    pure ⟨regW.w, .TBNZ regW.reg bit.toNat target⟩
-
-  | "nop" =>
-    pure ⟨.W64, .NOP⟩
+  | "nop"   => pure ⟨.W64, .NOP⟩
 
   | _ =>
     let condStr? :=
@@ -1336,34 +1297,28 @@ def parseInstr : Parser Instr := do
         fail s!"unsupported instruction: {mnemonic}"
 
 -- ============================================================================
--- Label Parsing
+-- Line and Program Parsing
 -- ============================================================================
 
 /-- Parse an optional label (name followed by colon).
     Uses attempt for proper backtracking if colon is not found. -/
 def parseLabelDecl : Parser Label := do
   skipHWs
-  (attempt do
+  attempt do
     let name ← parseName
     skipHWs
     let _ ← pchar ':'
-    pure name)
-
--- ============================================================================
--- Line and Program Parsing
--- ============================================================================
-
-def skipSpaceAndCheckLineEnd : Parser Bool := isAtLineEndOrComment
+    pure name
 
 def parseOptionalInstr : Parser (Option Directive) := do
-  if (← skipSpaceAndCheckLineEnd) then
+  if (← isAtLineEndOrComment) then
     pure none
   else
     let i ← parseInstr
     pure (some (Directive.instr i))
 
 def checkLineEnd : Parser Unit := do
-  if (← skipSpaceAndCheckLineEnd) then
+  if (← isAtLineEndOrComment) then
     pure ()
   else
     fail "unexpected trailing characters on line"

--- a/Kraken/AArch64/Parser.lean
+++ b/Kraken/AArch64/Parser.lean
@@ -318,6 +318,62 @@ def checkAdrOffset (offset : Int64) : Except String Unit :=
     .error s!"adr offset {intToHexStr val} out of range [-0x100000, 0xfffff]"
   else .ok ()
 
+def isContiguousOnes (v : Nat) (E : Nat) : Bool :=
+  v > 0 && v < ((1 <<< E) - 1) && ((v + 1) &&& v) == 0
+
+def isRotatedRunOfOnesAux (elem : Nat) (E : Nat) : Nat → Bool
+  | 0 => false
+  | n + 1 =>
+    if isContiguousOnes elem E then
+      true
+    else
+      let nextElem := (elem >>> 1) ||| ((elem &&& 1) <<< (E - 1))
+      isRotatedRunOfOnesAux nextElem E n
+
+def isRotatedRunOfOnes (elem : Nat) (E : Nat) : Bool :=
+  isRotatedRunOfOnesAux elem E E
+
+def repeatElement (pattern : Nat) (wBits : Nat) (E : Nat) : Nat :=
+  match wBits, E with
+  | 64, 64 => pattern
+  | 64, 32 => pattern * 0x0000000100000001
+  | 64, 16 => pattern * 0x0001000100010001
+  | 64, 8  => pattern * 0x0101010101010101
+  | 64, 4  => pattern * 0x1111111111111111
+  | 64, 2  => pattern * 0x5555555555555555
+  | 32, 32 => pattern
+  | 32, 16 => pattern * 0x00010001
+  | 32, 8  => pattern * 0x01010101
+  | 32, 4  => pattern * 0x11111111
+  | 32, 2  => pattern * 0x55555555
+  | _, _ => 0
+
+def isRepeatedPattern (val : Nat) (wBits : Nat) (E : Nat) : Bool :=
+  let pattern := val &&& ((1 <<< E) - 1)
+  val == repeatElement pattern wBits E
+
+def isValidLogicalImmediate (w : Width) (val : Int64) : Bool :=
+  let vNat := match w with
+    | .W32 => (val.toBitVec.toNat &&& 0xFFFFFFFF)
+    | .W64 => val.toBitVec.toNat
+  let wBits := w.bits
+  let maxVal := (1 <<< wBits) - 1
+  if vNat == 0 || vNat == maxVal then
+    false
+  else
+    let sizes := match w with
+      | .W32 => [2, 4, 8, 16, 32]
+      | .W64 => [2, 4, 8, 16, 32, 64]
+    sizes.any (fun E =>
+      isRepeatedPattern vNat wBits E &&
+      isRotatedRunOfOnes (vNat &&& ((1 <<< E) - 1)) E)
+
+def checkLogicalImmediate (w : Width) (imm : Int64) : Except String Unit :=
+  if isValidLogicalImmediate w imm then
+    .ok ()
+  else
+    .error s!"invalid logical immediate: {intToHexStr imm.toInt}"
+
 def checkAdrpOffset (offset : Int64) : Except String Unit :=
   let val := offset.toInt
   if val % 0x1000 != 0 then
@@ -822,6 +878,46 @@ def parseFourRegs
   let src3 ← parseRegOrZr w
   pure ⟨w, mk dstW.reg src1 src2 src3⟩
 
+def parseLogicalNoFlags
+    (mkI : {w : Width} → RegOrSp w → RegOrZr w → ConstExpr → Operation w)
+    (mkS : {w : Width} → RegOrZr w → RegOrZr w → ShiftRegExpr w → Operation w) : Parser Instr := do
+  let dstW ← parseAnyRegW
+  let w := dstW.1
+  parseComma
+  let src1 ← parseRegOrZr w
+  parseComma
+  skipHWs
+  let nextC ← peek!
+  if nextC == '#' || nextC == '-' || nextC.isDigit then
+    let dstSp ← dstW.2.toRegOrSp
+    let imm ← parseConstExpr
+    if let .int64 val := imm then
+      liftExcept (checkLogicalImmediate w val)
+    pure ⟨w, mkI dstSp src1 imm⟩
+  else
+    let dstZr ← dstW.2.toRegOrZr
+    let shiftOp ← parseShiftRegExpr w true
+    pure ⟨w, mkS dstZr src1 shiftOp⟩
+
+def parseLogicalFlags
+    (mkI : {w : Width} → RegOrZr w → RegOrZr w → ConstExpr → Operation w)
+    (mkS : {w : Width} → RegOrZr w → RegOrZr w → ShiftRegExpr w → Operation w) : Parser Instr := do
+  let dstW ← parseRegOrZrW
+  let w := dstW.w
+  parseComma
+  let src1 ← parseRegOrZr w
+  parseComma
+  skipHWs
+  let nextC ← peek!
+  if nextC == '#' || nextC == '-' || nextC.isDigit then
+    let imm ← parseConstExpr
+    if let .int64 val := imm then
+      liftExcept (checkLogicalImmediate w val)
+    pure ⟨w, mkI dstW.reg src1 imm⟩
+  else
+    let shiftOp ← parseShiftRegExpr w true
+    pure ⟨w, mkS dstW.reg src1 shiftOp⟩
+
 def parseLogical
     (mkS : {w : Width} → RegOrZr w → RegOrZr w → ShiftRegExpr w → Operation w) : Parser Instr := do
   let dstW ← parseRegOrZrW
@@ -988,18 +1084,26 @@ def parseInstr : Parser Instr := do
     let src2 ← parseRegOrZr .W64
     pure ⟨.W64, .UMULH dst src1 src2⟩
 
-  | "and"   => parseLogical .AND_s
-  | "ands"  => parseLogical .ANDS_s
-  | "orr"   => parseLogical .ORR_s
+  | "and"   => parseLogicalNoFlags .AND_i .AND_s
+  | "ands"  => parseLogicalFlags .ANDS_i .ANDS_s
+  | "orr"   => parseLogicalNoFlags .ORR_i .ORR_s
   | "orn"   => parseLogical .ORN_s
-  | "eor"   => parseLogical .EOR_s
+  | "eor"   => parseLogicalNoFlags .EOR_i .EOR_s
   | "bic"   => parseLogical .BIC_s
   | "tst"   => do  -- Alias of ANDS ZR, _, _
     let src1W ← parseRegOrZrW
     let w := src1W.w
     parseComma
-    let src2 ← parseShiftRegExpr w true
-    pure ⟨w, .ANDS_s (.low .XZR w) src1W.reg src2⟩
+    skipHWs
+    let nextC ← peek!
+    if nextC == '#' || nextC == '-' || nextC.isDigit then
+      let imm ← parseConstExpr
+      if let .int64 val := imm then
+        liftExcept (checkLogicalImmediate w val)
+      pure ⟨w, .ANDS_i (.low .XZR w) src1W.reg imm⟩
+    else
+      let src2 ← parseShiftRegExpr w true
+      pure ⟨w, .ANDS_s (.low .XZR w) src1W.reg src2⟩
 
   | "lsl"   => parseThreeRegs .LSLV -- Alias of LSLV
   | "lsr"   => parseThreeRegs .LSRV -- Alias of LSRV

--- a/Kraken/AArch64/Parser.lean
+++ b/Kraken/AArch64/Parser.lean
@@ -252,6 +252,50 @@ def checkUnsignedOffset (w : Width) (imm : Int64) : Except String Unit :=
     .error s!"unsigned offset {imm.toInt} out of range [0, {maxOff}] or not a multiple of {align}"
   else .ok ()
 
+def checkLoadStoreOffset (w : Width) (imm : Int64) (allowUnscaled : Bool) : Except String Unit :=
+  let (maxOff, align) := match w with | .W32 => (16380, 4) | .W64 => (32760, 8)
+  let isScaled := imm.toInt >= 0 && imm.toInt <= maxOff && imm.toInt % align == 0
+  let isUnscaled := allowUnscaled && imm.toInt >= -256 && imm.toInt <= 255
+  if isScaled || isUnscaled then
+    .ok ()
+  else if allowUnscaled then
+    .error s!"offset {imm.toInt} is neither a valid scaled offset [0, {maxOff}] (multiple of {align}) nor a valid unscaled offset [-256, 255]"
+  else
+    .error s!"unsigned offset {imm.toInt} out of range [0, {maxOff}] or not a multiple of {align}"
+
+def checkUnscaledOffset (imm : Int64) : Except String Unit :=
+  if imm.toInt < -256 || imm.toInt > 255 then
+    .error s!"unscaled offset {imm.toInt} out of range [-256, 255]"
+  else .ok ()
+
+def addrExprNeedsUnscaled {w : Width} (addr : AddrExpr w) : Bool :=
+  match addr.off with
+  | .imm i =>
+    match i.index, i.imm with
+    | none, .int64 imm =>
+      let (_, align) := match w with | .W32 => (16380, 4) | .W64 => (32760, 8)
+      imm.toInt < 0 || imm.toInt % align != 0
+    | _, _ => false
+  | _ => false
+
+def addrOrLitNeedsUnscaled {w : Width} (a : AddrOrLit w) : Bool :=
+  match a with
+  | .addr addr => addrExprNeedsUnscaled addr
+  | .lit _ => false
+
+def addrExprToUnscaled {w : Width} (addr : AddrExpr w) : Option UnscaledAddrExpr :=
+  match addr.off with
+  | .imm i =>
+    match i.index with
+    | none => some { base := addr.base, imm := i.imm }
+    | some _ => none
+  | _ => none
+
+def addrOrLitToUnscaled {w : Width} (a : AddrOrLit w) : Option UnscaledAddrExpr :=
+  match a with
+  | .addr addr => addrExprToUnscaled addr
+  | .lit _ => none
+
 def checkShiftAmount (w : Width) (amt : Int64) : Except String Unit :=
   let maxAmt := match w with | .W32 => 31 | .W64 => 63
   if amt.toInt < 0 || amt.toInt > maxAmt then
@@ -319,7 +363,7 @@ def checkTbzBitPosition (instrName : String) (w : Width) (bit : Int) : Except St
     1. **Base-only / Post-indexed**: `[base]` or `[base], #imm`
     2. **Immediate / Pre-indexed**: `[base, #imm]` or `[base, #imm]!` or `[base, #:lo12:label]`
     3. **Register offset with optional extension/shift**: `[base, Rm]` or `[base, Rm, ext #amount]` -/
-def parseAddr (w : Width) : Parser (AddrExpr w) := do
+def parseAddr (w : Width) (allowUnscaled : Bool := false) : Parser (AddrExpr w) := do
   skipHWs
   let _ ← pchar '['
   let base ← parseRegOrSp .W64
@@ -357,7 +401,7 @@ def parseAddr (w : Width) : Parser (AddrExpr w) := do
           if imm.toInt < -256 || imm.toInt > 255 then
             fail s!"pre-indexed offset {imm.toInt} out of range [-256, 255]"
         else do
-          liftExcept (checkUnsignedOffset w imm)
+          liftExcept (checkLoadStoreOffset w imm allowUnscaled)
       | _ =>
         if isPre.isSome then
           fail "pre-indexed / post-indexed offsets must be constant numeric immediates"
@@ -396,11 +440,37 @@ def parseAddr (w : Width) : Parser (AddrExpr w) := do
   else
     fail s!"expected ',' or ']' after base register in memory operand, got {c}"
 
-def parseAddrOrLit (w : Width) : Parser (AddrOrLit w) := do
+def parseUnscaledAddr : Parser UnscaledAddrExpr := do
+  skipHWs
+  let _ ← pchar '['
+  let base ← parseRegOrSp .W64
+  skipHWs
+  let c ← peek!
+  if c == ']' then do
+    skip
+    pure { base := base, imm := .int64 0 }
+  else if c == ',' then do
+    skip
+    skipHWs
+    let nextC ← peek!
+    if nextC == '#' || nextC == '-' || nextC.isDigit then do
+      let expr ← parseConstExpr
+      skipHWs
+      let _ ← pchar ']'
+      match expr with
+      | .int64 imm => liftExcept (checkUnscaledOffset imm)
+      | _ => pure ()
+      pure { base := base, imm := expr }
+    else
+      fail "expected immediate offset in unscaled address operand"
+  else
+    fail s!"expected ',' or ']' after base register in unscaled address operand, got {c}"
+
+def parseAddrOrLit (w : Width) (allowUnscaled : Bool := false) : Parser (AddrOrLit w) := do
   skipHWs
   let c ← peek!
   if c == '[' then do
-    let m ← parseAddr w
+    let m ← parseAddr w allowUnscaled
     pure (.addr m)
   else if c == '=' then do
     skip
@@ -764,14 +834,36 @@ def parseInstr : Parser Instr := do
   | "ldr" =>
     let dstW ← parseRegOrZrW
     parseComma
-    let src ← parseAddrOrLit dstW.w
-    pure ⟨dstW.w, .LDR dstW.reg src⟩
+    let src ← parseAddrOrLit dstW.w true
+    if addrOrLitNeedsUnscaled src then
+      match addrOrLitToUnscaled src with
+      | some uoff => pure ⟨dstW.w, .LDUR dstW.reg uoff⟩
+      | none => fail "unscaled load cannot be literal or register offset"
+    else
+      pure ⟨dstW.w, .LDR dstW.reg src⟩
 
   | "str" =>
     let srcW ← parseRegOrZrW
     parseComma
-    let dst ← parseAddr srcW.w
-    pure ⟨srcW.w, .STR srcW.reg dst⟩
+    let dst ← parseAddr srcW.w true
+    if addrExprNeedsUnscaled dst then
+      match addrExprToUnscaled dst with
+      | some uoff => pure ⟨srcW.w, .STUR srcW.reg uoff⟩
+      | none => fail "unscaled store cannot be register offset"
+    else
+      pure ⟨srcW.w, .STR srcW.reg dst⟩
+
+  | "ldur" =>
+    let dstW ← parseRegOrZrW
+    parseComma
+    let src ← parseUnscaledAddr
+    pure ⟨dstW.w, .LDUR dstW.reg src⟩
+
+  | "stur" =>
+    let srcW ← parseRegOrZrW
+    parseComma
+    let dst ← parseUnscaledAddr
+    pure ⟨srcW.w, .STUR srcW.reg dst⟩
 
   | "ldp" =>
     let dst1W ← parseRegOrZrW

--- a/Kraken/AArch64/ParserTests.lean
+++ b/Kraken/AArch64/ParserTests.lean
@@ -121,7 +121,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("add x0, x1, #0b1010")
 
--- Test: LDR with flexible sign ordering (-#16)
+-- Test: LDR with standard sign ordering (#-16)
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -130,7 +130,7 @@ info: [Directive.instr
           ↑{ base := ↑XRegOrSp.SP Width.W64, off := ↑{ imm := ↑(-16), index := some Index.Pre } } }] : List Directive
 -/
 #guard_msgs in
-#check parseAArch64("ldr x1, [sp, -#16]!")
+#check parseAArch64("ldr x1, [sp, #-16]!")
 
 -- Test: ADD_s with shifted register (lsl #2)
 /--
@@ -834,6 +834,20 @@ info: [Directive.instr { operation_size := Width.W64, operation := Operation.B_c
 #guard_msgs in
 #check parseAArch64("b.ne exit")
 
+-- Test: BEQ (undotted) with label
+/--
+info: [Directive.instr { operation_size := Width.W64, operation := Operation.B_cond CondCode.EQ ↑"loop" }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("beq loop")
+
+-- Test: BNE (undotted) with label
+/--
+info: [Directive.instr { operation_size := Width.W64, operation := Operation.B_cond CondCode.NE ↑"exit" }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("bne exit")
+
 -- Test: BL with label
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.BL ↑"foo" }] : List Directive
@@ -1072,6 +1086,26 @@ section error_reporting
 /-- error: line 1: invalid logical immediate: -0x1 -/
 #guard_msgs in
 #check parseAArch64("eor x0, x1, #-1")
+
+/-- error: line 1: UXTW extension requires a 32-bit index register (Wn) -/
+#guard_msgs in
+#check parseAArch64("ldr x0, [sp, x1, uxtw]")
+
+/-- error: line 1: SXTX extension requires a 64-bit index register (Xn) -/
+#guard_msgs in
+#check parseAArch64("ldr x0, [sp, w1, sxtx]")
+
+/-- error: line 1: unknown register, sp, or xzr: wlr -/
+#guard_msgs in
+#check parseAArch64("add w0, wlr, #1")
+
+/-- error: line 1: condition not satisfied -/
+#guard_msgs in
+#check parseAArch64("ldr x1, [sp, -#16]!")
+
+/-- error: line 1: unexpected trailing characters on line -/
+#guard_msgs in
+#check parseAArch64("add x0, x1, #1 # comment")
 
 end error_reporting
 

--- a/Kraken/AArch64/ParserTests.lean
+++ b/Kraken/AArch64/ParserTests.lean
@@ -656,6 +656,28 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("orr x0, x1, x2, ror #4")
 
+-- Test: Conditional select instructions and aliases
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.CSEL (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64) CondCode.EQ },
+  Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.CSINV (↑↑XReg.X3 Width.W64) (↑XRegOrXzr.XZR Width.W64) (↑XRegOrXzr.XZR Width.W64) CondCode.EQ },
+  Directive.instr
+    { operation_size := Width.W32,
+      operation :=
+        Operation.CSINC (↑↑XReg.X4 Width.W32) (↑↑XReg.X5 Width.W32) (↑↑XReg.X5 Width.W32)
+          CondCode.CS }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("
+  csel x0, x1, x2, eq
+  csetm x3, ne
+  cinc w4, w5, lo
+")
+
 -- Test: LDP with 64-bit registers and signed immediate offset
 /--
 info: [Directive.instr

--- a/Kraken/AArch64/ParserTests.lean
+++ b/Kraken/AArch64/ParserTests.lean
@@ -8,7 +8,11 @@ import Kraken.AArch64.Parser
 section Tests
 open Kraken.AArch64.Parser
 
--- Test: Simple LDR with base register
+-- ============================================================================
+-- 1. Memory Access: Loads and Stores (LDR, STR, LDUR, STUR, LDP, STP)
+-- ============================================================================
+
+-- Test: LDR 64-bit with base register only
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -19,7 +23,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("ldr x0, [sp]")
 
--- Test: Simple STR with 32-bit register and immediate offset
+-- Test: STR 32-bit with unsigned scaled immediate offset
 /--
 info: [Directive.instr
     { operation_size := Width.W32,
@@ -30,7 +34,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("str w0, [x1, #8]")
 
--- Test: Pre-indexed memory addressing
+-- Test: LDR 64-bit with pre-indexed immediate offset
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -41,7 +45,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("ldr x1, [sp, #-16]!")
 
--- Test: Post-indexed memory addressing
+-- Test: STR 64-bit with post-indexed immediate offset
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -52,7 +56,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("str x2, [x1], #16")
 
--- Test: Register offset with extension and shift in LDR
+-- Test: LDR 64-bit with register offset, extension, and shift
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -66,7 +70,82 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("ldr x0, [x1, x2, lsl #3]")
 
--- Test: ADD_e with immediate
+-- Test: LDUR 64-bit unscaled immediate offset
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.LDUR (↑↑XReg.X0 Width.W64) { base := ↑↑XReg.X1 Width.W64, imm := ↑(-8) } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("ldur x0, [x1, #-8]")
+
+-- Test: STUR 32-bit unscaled immediate offset
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation := Operation.STUR (↑↑XReg.X2 Width.W32) { base := ↑↑XReg.X3 Width.W64, imm := ↑13 } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("stur w2, [x3, #13]")
+
+-- Test: LDR automatic conversion to LDUR for negative unscaled offset
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.LDUR (↑↑XReg.X0 Width.W64) { base := ↑↑XReg.X1 Width.W64, imm := ↑(-8) } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("ldr x0, [x1, #-8]")
+
+-- Test: LDR automatic conversion to LDUR for unaligned unscaled offset
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.LDUR (↑↑XReg.X0 Width.W64) { base := ↑↑XReg.X1 Width.W64, imm := ↑13 } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("ldr x0, [x1, #13]")
+
+-- Test: LDP 64-bit load pair with signed immediate offset
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.LDP (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64)
+          { base := ↑XRegOrSp.SP Width.W64, off := ↑{ imm := ↑16, index := none } } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("ldp x0, x1, [sp, #16]")
+
+-- Test: STP 32-bit store pair with pre-indexed offset
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation :=
+        Operation.STP (↑↑XReg.X0 Width.W32) (↑↑XReg.X1 Width.W32)
+          { base := ↑XRegOrSp.SP Width.W64, off := ↑{ imm := ↑(-32), index := some Index.Pre } } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("stp w0, w1, [sp, #-32]!")
+
+-- Test: STP 64-bit store pair with zero registers and post-indexed offset
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.STP (↑XRegOrXzr.XZR Width.W64) (↑XRegOrXzr.XZR Width.W64)
+          { base := ↑XRegOrSp.SP Width.W64, off := ↑{ imm := ↑32, index := some Index.Post } } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("stp xzr, xzr, [sp], #32")
+
+-- ============================================================================
+-- 2. Arithmetic Instructions (ADD, ADDS, SUB, SUBS, CMP, CMN, NEG, NEGS)
+-- ============================================================================
+
+-- Test: ADD_e with immediate and shift 0
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -77,7 +156,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("add x0, x1, #42")
 
--- Test: ADD_e with immediate and shifted immediate (lsl #12)
+-- Test: ADD_e with immediate and shift 12
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -88,18 +167,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("add x0, x1, #42, lsl #12")
 
--- Test: ADD_e with immediate and shifted immediate (lsl #0)
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.ADD_e (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64)
-          ↑{ imm := ↑10, shift := ImmShift.S0 } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("add x0, x1, #10, lsl #0")
-
--- Test: ADD_e with SP as destination
+-- Test: ADD_e with SP operands
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -110,7 +178,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("add sp, sp, #16")
 
--- Test: ADD_e with binary immediate (#0b1010)
+-- Test: ADD_e with binary immediate literal (#0b1010)
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -121,18 +189,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("add x0, x1, #0b1010")
 
--- Test: LDR with standard sign ordering (#-16)
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.LDR (↑↑XReg.X1 Width.W64)
-          ↑{ base := ↑XRegOrSp.SP Width.W64, off := ↑{ imm := ↑(-16), index := some Index.Pre } } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("ldr x1, [sp, #-16]!")
-
--- Test: ADD_s with shifted register (lsl #2)
+-- Test: ADD_s with shifted register operand
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -143,7 +200,18 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("add x0, x1, x2, lsl #2")
 
--- Test: ADD_e with extended register (uxtw #2)
+-- Test: ADD_s with XZR destination
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.ADD_s (↑XRegOrXzr.XZR Width.W64) (↑↑XReg.X1 Width.W64)
+          { reg := ↑↑XReg.X2 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("add xzr, x1, x2")
+
+-- Test: ADD_e with extended register operand
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -155,7 +223,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("add x0, x1, w2, uxtw #2")
 
--- Test: ADDS_e with immediate
+-- Test: ADDS_e with immediate operand
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -166,7 +234,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("adds x0, x1, #42")
 
--- Test: ADDS_s with shifted register (lsl #2)
+-- Test: ADDS_s with shifted register operand
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -177,7 +245,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("adds x0, x1, x2, lsl #2")
 
--- Test: CMN with immediate (alias for adds xzr, x1, #10)
+-- Test: CMN alias for ADDS XZR, Xn, #imm
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -188,7 +256,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("cmn x1, #10")
 
--- Test: SUB_e with immediate
+-- Test: SUB_e with immediate operand
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -199,7 +267,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("sub x0, x1, #5")
 
--- Test: SUBS_e with immediate
+-- Test: SUBS_e with immediate operand
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -210,7 +278,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("subs x0, x1, #5")
 
--- Test: CMP with shifted register (alias for subs xzr, x1, x2)
+-- Test: CMP alias for SUBS XZR, Xn, Xm
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -221,7 +289,184 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("cmp x1, x2")
 
--- Test: AND_s with shifted register (lsr #4)
+-- Test: NEG alias for SUB Xd, XZR, Xm
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.SUB_s (↑↑XReg.X0 Width.W64) (↑XRegOrXzr.XZR Width.W64)
+          { reg := ↑↑XReg.X1 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("neg x0, x1")
+
+-- Test: NEGS alias for SUBS Xd, XZR, Xm
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.SUBS_s (↑↑XReg.X0 Width.W64) (↑XRegOrXzr.XZR Width.W64)
+          { reg := ↑↑XReg.X1 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("negs x0, x1")
+
+-- ============================================================================
+-- 3. Carry Arithmetic (ADC, ADCS, SBC, SBCS)
+-- ============================================================================
+
+-- Test: ADC 64-bit add with carry
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.ADC (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("adc x0, x1, x2")
+
+-- Test: ADCS 32-bit add with carry and set flags
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation := Operation.ADCS (↑↑XReg.X3 Width.W32) (↑↑XReg.X4 Width.W32) (↑↑XReg.X5 Width.W32) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("adcs w3, w4, w5")
+
+-- Test: SBC 64-bit subtract with carry
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.SBC (↑↑XReg.X6 Width.W64) (↑↑XReg.X7 Width.W64) (↑↑XReg.X8 Width.W64) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("sbc x6, x7, x8")
+
+-- Test: SBCS 32-bit subtract with carry and set flags
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation :=
+        Operation.SBCS (↑↑XReg.X9 Width.W32) (↑↑XReg.X10 Width.W32) (↑↑XReg.X11 Width.W32) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("sbcs w9, w10, w11")
+
+-- ============================================================================
+-- 4. Multiply Instructions (MADD, MSUB, MUL, MNEG, SMULH, UMULH)
+-- ============================================================================
+
+-- Test: MADD 64-bit multiply-add
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.MADD (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64)
+          (↑↑XReg.X3 Width.W64) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("madd x0, x1, x2, x3")
+
+-- Test: MADD 32-bit multiply-add
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation :=
+        Operation.MADD (↑↑XReg.X0 Width.W32) (↑↑XReg.X1 Width.W32) (↑↑XReg.X2 Width.W32)
+          (↑↑XReg.X3 Width.W32) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("madd w0, w1, w2, w3")
+
+-- Test: MUL 64-bit alias for MADD Xd, Xn, Xm, XZR
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.MADD (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64)
+          (↑XRegOrXzr.XZR Width.W64) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mul x0, x1, x2")
+
+-- Test: MUL 32-bit alias for MADD Wd, Wn, Wm, WZR
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation :=
+        Operation.MADD (↑↑XReg.X0 Width.W32) (↑↑XReg.X1 Width.W32) (↑↑XReg.X2 Width.W32)
+          (↑XRegOrXzr.XZR Width.W32) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mul w0, w1, w2")
+
+-- Test: MSUB 64-bit multiply-subtract
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.MSUB (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64)
+          (↑↑XReg.X3 Width.W64) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("msub x0, x1, x2, x3")
+
+-- Test: MSUB 32-bit multiply-subtract
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation :=
+        Operation.MSUB (↑↑XReg.X0 Width.W32) (↑↑XReg.X1 Width.W32) (↑↑XReg.X2 Width.W32)
+          (↑↑XReg.X3 Width.W32) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("msub w0, w1, w2, w3")
+
+-- Test: MNEG 64-bit alias for MSUB Xd, Xn, Xm, XZR
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.MSUB (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64)
+          (↑XRegOrXzr.XZR Width.W64) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mneg x0, x1, x2")
+
+-- Test: MNEG 32-bit alias for MSUB Wd, Wn, Wm, WZR
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation :=
+        Operation.MSUB (↑↑XReg.X0 Width.W32) (↑↑XReg.X1 Width.W32) (↑↑XReg.X2 Width.W32)
+          (↑XRegOrXzr.XZR Width.W32) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mneg w0, w1, w2")
+
+-- Test: SMULH signed multiply high 64-bit
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.SMULH (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("smulh x0, x1, x2")
+
+-- Test: UMULH unsigned multiply high 64-bit
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.UMULH (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("umulh x0, x1, x2")
+
+-- ============================================================================
+-- 5. Logical Instructions (AND, ANDS, TST, ORR, ORN, EOR, BIC)
+-- ============================================================================
+
+-- Test: AND_s with shifted register operand (lsr #4)
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -231,6 +476,55 @@ info: [Directive.instr
 -/
 #guard_msgs in
 #check parseAArch64("and x0, x1, x2, lsr #4")
+
+-- Test: AND_i with immediate bitmask
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.AND_i (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) ↑255 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("and x0, x1, #255")
+
+-- Test: ANDS_s 64-bit register logical AND with flags
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.ANDS_s (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64)
+          { reg := ↑↑XReg.X2 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("ands x0, x1, x2")
+
+-- Test: ANDS_i 32-bit immediate bitmask with flags
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation := Operation.ANDS_i (↑↑XReg.X5 Width.W32) (↑↑XReg.X6 Width.W32) ↑255 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("ands w5, w6, #255")
+
+-- Test: TST register alias for ANDS XZR, Xn, Xm
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.ANDS_s (↑XRegOrXzr.XZR Width.W64) (↑↑XReg.X1 Width.W64)
+          { reg := ↑↑XReg.X2 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("tst x1, x2")
+
+-- Test: TST immediate alias for ANDS XZR, Xn, #imm
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.ANDS_i (↑XRegOrXzr.XZR Width.W64) (↑↑XReg.X7 Width.W64) ↑255 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("tst x7, #255")
 
 -- Test: ORR_s 32-bit without shift
 /--
@@ -243,18 +537,27 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("orr w0, w1, w2")
 
--- Test: ANDS_s 64-bit
+-- Test: ORR_i 32-bit immediate bitmask
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation := Operation.ORR_i (↑↑XReg.X2 Width.W32) (↑↑XReg.X3 Width.W32) ↑255 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("orr w2, w3, #255")
+
+-- Test: ORR_s with ROR shift
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
       operation :=
-        Operation.ANDS_s (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64)
-          { reg := ↑↑XReg.X2 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
+        Operation.ORR_s (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64)
+          { reg := ↑↑XReg.X2 Width.W64, amount := 4, shift := ShiftType.ROR } }] : List Directive
 -/
 #guard_msgs in
-#check parseAArch64("ands x0, x1, x2")
+#check parseAArch64("orr x0, x1, x2, ror #4")
 
--- Test: ORN_s 64-bit
+-- Test: ORN_s 64-bit logical OR NOT
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -265,7 +568,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("orn x0, x1, x2")
 
--- Test: EOR_s 64-bit
+-- Test: EOR_s 64-bit logical XOR
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -276,7 +579,16 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("eor x0, x1, x2")
 
--- Test: BIC_s 64-bit
+-- Test: EOR_i 64-bit immediate bitmask with SP destination
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.EOR_i (↑XRegOrSp.SP Width.W64) (↑↑XReg.X4 Width.W64) ↑255 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("eor sp, x4, #255")
+
+-- Test: BIC_s 64-bit bit clear
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -287,40 +599,139 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("bic x0, x1, x2")
 
--- Test: TST 64-bit (alias for ANDS_s XZR, x1, x2)
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.ANDS_s (↑XRegOrXzr.XZR Width.W64) (↑↑XReg.X1 Width.W64)
-          { reg := ↑↑XReg.X2 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("tst x1, x2")
+-- ============================================================================
+-- 6. Move & Move Wide Immediate Family (MOV, MVN, MOVZ, MOVK, MOVN)
+-- ============================================================================
 
--- Test: NEG 64-bit (alias for SUB_s x0, xzr, x1)
+-- Test: MOV register alias for ORR Xd, XZR, Xm
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
       operation :=
-        Operation.SUB_s (↑↑XReg.X0 Width.W64) (↑XRegOrXzr.XZR Width.W64)
+        Operation.ORR_s (↑↑XReg.X0 Width.W64) (↑XRegOrXzr.XZR Width.W64)
           { reg := ↑↑XReg.X1 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
 -/
 #guard_msgs in
-#check parseAArch64("neg x0, x1")
+#check parseAArch64("mov x0, x1")
 
--- Test: NEGS 64-bit (alias for SUBS_s x0, xzr, x1)
+-- Test: MOV SP alias for ADD SP, Xn, #0
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
       operation :=
-        Operation.SUBS_s (↑↑XReg.X0 Width.W64) (↑XRegOrXzr.XZR Width.W64)
-          { reg := ↑↑XReg.X1 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
+        Operation.ADD_e (↑XRegOrSp.SP Width.W64) (↑↑XReg.X0 Width.W64)
+          ↑{ imm := ↑0, shift := ImmShift.S0 } }] : List Directive
 -/
 #guard_msgs in
-#check parseAArch64("negs x0, x1")
+#check parseAArch64("mov sp, x0")
 
--- Test: LSL 64-bit (alias for LSLV)
+-- Test: MVN register alias for ORN Xd, XZR, Xm
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.ORN_s (↑↑XReg.X2 Width.W64) (↑XRegOrXzr.XZR Width.W64)
+          { reg := ↑↑XReg.X3 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mvn x2, x3")
+
+-- Test: MOVZ move wide with zeroes (LSL #16)
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.MOVZ (↑↑XReg.X0 Width.W64) (↑1234) MovShift.LSL16 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("movz x0, #1234, lsl #16")
+
+-- Test: MOVK move wide with keep (LSL #0)
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation := Operation.MOVK (↑↑XReg.X1 Width.W32) (↑5678) MovShift.LSL0 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("movk w1, #5678, lsl #0")
+
+-- Test: MOVN move wide with NOT (LSL #48)
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.MOVN (↑↑XReg.X2 Width.W64) (↑65535) MovShift.LSL48 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("movn x2, #65535, lsl #48")
+
+-- Test: MOV immediate Priority 1 -> MOVZ (#0)
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.MOVZ (↑↑XReg.X0 Width.W64) (↑0) MovShift.LSL0 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mov x0, #0")
+
+-- Test: MOV immediate Priority 1 -> MOVZ shifted (#0x12340000)
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.MOVZ (↑↑XReg.X1 Width.W64) (↑4660) MovShift.LSL16 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mov x1, #0x12340000")
+
+-- Test: MOV immediate Priority 2 -> MOVN 64-bit (#0xfffffffffffffffe)
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.MOVN (↑↑XReg.X2 Width.W64) (↑1) MovShift.LSL0 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mov x2, #0xfffffffffffffffe")
+
+-- Test: MOV immediate Priority 2 -> MOVN 32-bit (#0xffffffff)
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation := Operation.MOVN (↑↑XReg.X3 Width.W32) (↑0) MovShift.LSL0 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mov w3, #0xffffffff")
+
+-- Test: MOV immediate Priority 3 -> ORR_i bitmask (#0x0101010101010101)
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.ORR_i (↑↑XReg.X4 Width.W64) (↑XRegOrXzr.XZR Width.W64) ↑72340172838076673 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mov x4, #0x0101010101010101")
+
+-- Test: MOV immediate negative 64-bit alias (#-1)
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.MOVN (↑↑XReg.X5 Width.W64) (↑0) MovShift.LSL0 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mov x5, #-1")
+
+-- Test: MOV immediate negative 32-bit alias (#-5)
+/--
+info: [Directive.instr
+    { operation_size := Width.W32,
+      operation := Operation.MOVN (↑↑XReg.X6 Width.W32) (↑4) MovShift.LSL0 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("mov w6, #-5")
+
+-- ============================================================================
+-- 7. Variable Shifts and Rotates (LSL, LSR, ASR, ROR, LSLV, LSRV, ASRV, RORV)
+-- ============================================================================
+
+-- Test: LSL register shift left (alias for LSLV)
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -329,7 +740,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("lsl x0, x1, x2")
 
--- Test: LSLV 32-bit
+-- Test: LSLV explicit mnemonic 32-bit
 /--
 info: [Directive.instr
     { operation_size := Width.W32,
@@ -338,7 +749,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("lslv w0, w1, w2")
 
--- Test: LSR 64-bit (alias for LSRV)
+-- Test: LSR register shift right (alias for LSRV)
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -347,7 +758,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("lsr x0, x1, x2")
 
--- Test: ASR 64-bit (alias for ASRV)
+-- Test: ASR arithmetic shift right (alias for ASRV)
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -356,7 +767,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("asr x0, x1, x2")
 
--- Test: ROR 64-bit (alias for RORV)
+-- Test: ROR rotate right (alias for RORV)
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -365,150 +776,111 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("ror x0, x1, x2")
 
+-- ============================================================================
+-- 8. Conditional Select Instructions & Aliases (CSEL, CSINC, CSINV, CSNEG, CSET, CSETM, CINC, CINV, CNEG)
+-- ============================================================================
 
--- Test: ADC 64-bit
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.ADC (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64) }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("adc x0, x1, x2")
-
--- Test: ADCS 32-bit
-/--
-info: [Directive.instr
-    { operation_size := Width.W32,
-      operation := Operation.ADCS (↑↑XReg.X3 Width.W32) (↑↑XReg.X4 Width.W32) (↑↑XReg.X5 Width.W32) }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("adcs w3, w4, w5")
-
--- Test: SBC 64-bit
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.SBC (↑↑XReg.X6 Width.W64) (↑↑XReg.X7 Width.W64) (↑↑XReg.X8 Width.W64) }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("sbc x6, x7, x8")
-
--- Test: SBCS 32-bit
-/--
-info: [Directive.instr
-    { operation_size := Width.W32,
-      operation :=
-        Operation.SBCS (↑↑XReg.X9 Width.W32) (↑↑XReg.X10 Width.W32) (↑↑XReg.X11 Width.W32) }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("sbcs w9, w10, w11")
-
--- Test: MADD 64-bit
+-- Test: CSEL conditional select
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
       operation :=
-        Operation.MADD (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64)
-          (↑↑XReg.X3 Width.W64) }] : List Directive
+        Operation.CSEL (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64) CondCode.EQ }] : List Directive
 -/
 #guard_msgs in
-#check parseAArch64("madd x0, x1, x2, x3")
+#check parseAArch64("csel x0, x1, x2, eq")
 
--- Test: MADD 32-bit
-/--
-info: [Directive.instr
-    { operation_size := Width.W32,
-      operation :=
-        Operation.MADD (↑↑XReg.X0 Width.W32) (↑↑XReg.X1 Width.W32) (↑↑XReg.X2 Width.W32)
-          (↑↑XReg.X3 Width.W32) }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("madd w0, w1, w2, w3")
-
--- Test: MUL 64-bit (alias for madd x0, x1, x2, xzr)
+-- Test: CSINC conditional select increment
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
       operation :=
-        Operation.MADD (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64)
-          (↑XRegOrXzr.XZR Width.W64) }] : List Directive
+        Operation.CSINC (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64)
+          CondCode.CS }] : List Directive
 -/
 #guard_msgs in
-#check parseAArch64("mul x0, x1, x2")
+#check parseAArch64("csinc x0, x1, x2, cs")
 
--- Test: MUL 32-bit (alias for madd w0, w1, w2, wzr)
+-- Test: CSINV conditional select invert
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.CSINV (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64)
+          CondCode.EQ }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("csinv x0, x1, x2, eq")
+
+-- Test: CSNEG conditional select negate
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.CSNEG (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64)
+          CondCode.MI }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("csneg x0, x1, x2, mi")
+
+-- Test: CSET alias for CSINC Xd, XZR, XZR, invert(cond)
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.CSINC (↑↑XReg.X0 Width.W64) (↑XRegOrXzr.XZR Width.W64) (↑XRegOrXzr.XZR Width.W64)
+          CondCode.NE }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("cset x0, eq")
+
+-- Test: CSETM alias for CSINV Xd, XZR, XZR, invert(cond)
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.CSINV (↑↑XReg.X3 Width.W64) (↑XRegOrXzr.XZR Width.W64) (↑XRegOrXzr.XZR Width.W64)
+          CondCode.EQ }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("csetm x3, ne")
+
+-- Test: CINC alias for CSINC Wd, Wn, Wn, invert(cond)
 /--
 info: [Directive.instr
     { operation_size := Width.W32,
       operation :=
-        Operation.MADD (↑↑XReg.X0 Width.W32) (↑↑XReg.X1 Width.W32) (↑↑XReg.X2 Width.W32)
-          (↑XRegOrXzr.XZR Width.W32) }] : List Directive
+        Operation.CSINC (↑↑XReg.X4 Width.W32) (↑↑XReg.X5 Width.W32) (↑↑XReg.X5 Width.W32)
+          CondCode.CS }] : List Directive
 -/
 #guard_msgs in
-#check parseAArch64("mul w0, w1, w2")
+#check parseAArch64("cinc w4, w5, lo")
 
--- Test: MSUB 64-bit
+-- Test: CINV alias for CSINV Xd, Xn, Xn, invert(cond)
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
       operation :=
-        Operation.MSUB (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64)
-          (↑↑XReg.X3 Width.W64) }] : List Directive
+        Operation.CSINV (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X1 Width.W64)
+          CondCode.MI }] : List Directive
 -/
 #guard_msgs in
-#check parseAArch64("msub x0, x1, x2, x3")
+#check parseAArch64("cinv x0, x1, pl")
 
--- Test: MSUB 32-bit
+-- Test: CNEG alias for CSNEG Wd, Wn, Wn, invert(cond)
 /--
 info: [Directive.instr
     { operation_size := Width.W32,
       operation :=
-        Operation.MSUB (↑↑XReg.X0 Width.W32) (↑↑XReg.X1 Width.W32) (↑↑XReg.X2 Width.W32)
-          (↑↑XReg.X3 Width.W32) }] : List Directive
+        Operation.CSNEG (↑↑XReg.X0 Width.W32) (↑↑XReg.X1 Width.W32) (↑↑XReg.X1 Width.W32)
+          CondCode.LE }] : List Directive
 -/
 #guard_msgs in
-#check parseAArch64("msub w0, w1, w2, w3")
+#check parseAArch64("cneg w0, w1, gt")
 
--- Test: MNEG 64-bit (alias for msub x0, x1, x2, xzr)
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.MSUB (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64)
-          (↑XRegOrXzr.XZR Width.W64) }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("mneg x0, x1, x2")
-
--- Test: MNEG 32-bit (alias for msub w0, w1, w2, wzr)
-/--
-info: [Directive.instr
-    { operation_size := Width.W32,
-      operation :=
-        Operation.MSUB (↑↑XReg.X0 Width.W32) (↑↑XReg.X1 Width.W32) (↑↑XReg.X2 Width.W32)
-          (↑XRegOrXzr.XZR Width.W32) }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("mneg w0, w1, w2")
-
-
--- Test: SMULH 64-bit
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.SMULH (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64) }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("smulh x0, x1, x2")
-
--- Test: UMULH 64-bit
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.UMULH (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64) }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("umulh x0, x1, x2")
+-- ============================================================================
+-- 9. PC-Relative Addressing & Relocation Modifiers (ADR, ADRP, :lo12:, :pg_hi21:)
+-- ============================================================================
 
 -- Test: ADR with label
 /--
@@ -518,7 +890,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("adr x0, main")
 
--- Test: ADR with immediate
+-- Test: ADR with immediate offset
 /--
 info: [Directive.instr
     { operation_size := Width.W64, operation := Operation.ADR (↑↑XReg.X1 Width.W64) ↑4096 }] : List Directive
@@ -534,7 +906,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("adrp x0, main")
 
--- Test: ADRP with immediate
+-- Test: ADRP with immediate offset
 /--
 info: [Directive.instr
     { operation_size := Width.W64, operation := Operation.ADRP (↑↑XReg.X1 Width.W64) ↑16384 }] : List Directive
@@ -542,7 +914,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("adrp x1, #0x4000")
 
--- Test: ADRP with :pg_hi21: modifier
+-- Test: ADRP with :pg_hi21: relocation modifier
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -551,7 +923,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("adrp x0, :pg_hi21:main")
 
--- Test: ADD_e with :lo12: modifier on label
+-- Test: ADD_e with :lo12: relocation modifier on label
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -562,7 +934,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("add x0, x0, :lo12:main")
 
--- Test: LDR with #:lo12: modifier on memory offset
+-- Test: LDR with #:lo12: relocation modifier on memory offset
 /--
 info: [Directive.instr
     { operation_size := Width.W64,
@@ -573,331 +945,95 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("ldr x1, [x0, #:lo12:main]")
 
--- Test: NOP
-/--
-info: [Directive.instr { operation_size := Width.W64, operation := Operation.NOP }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("nop")
+-- ============================================================================
+-- 10. Control Flow Instructions (B, B.cond, BL, BLR, BR, RET, CBZ, CBNZ, TBZ, TBNZ)
+-- ============================================================================
 
--- Test: Multi-line program with label
-/--
-info: [Directive.label "main",
-  Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.LDR (↑↑XReg.X1 Width.W64) ↑{ base := ↑XRegOrSp.SP Width.W64, off := ↑{ imm := ↑0, index := none } } },
-  Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.ADD_e (↑↑XReg.X1 Width.W64) (↑↑XReg.X1 Width.W64) ↑{ imm := ↑16, shift := ImmShift.S0 } },
-  Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.STR (↑↑XReg.X1 Width.W64)
-          { base := ↑XRegOrSp.SP Width.W64, off := ↑{ imm := ↑0, index := none } } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("
-main:
-  ldr x1, [sp]
-  add x1, x1, #16
-  str x1, [sp]
-")
-
--- Test: LDUR and STUR explicit mnemonics
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.LDUR (↑↑XReg.X0 Width.W64) { base := ↑↑XReg.X1 Width.W64, imm := ↑(-8) } },
-  Directive.instr
-    { operation_size := Width.W32,
-      operation := Operation.STUR (↑↑XReg.X2 Width.W32) { base := ↑↑XReg.X3 Width.W64, imm := ↑13 } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("
-  ldur x0, [x1, #-8]
-  stur w2, [x3, #13]
-")
-
--- Test: LDR/STR automatic conversion to LDUR/STUR for negative or unaligned offsets
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.LDUR (↑↑XReg.X0 Width.W64) { base := ↑↑XReg.X1 Width.W64, imm := ↑(-8) } },
-  Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.LDUR (↑↑XReg.X0 Width.W64) { base := ↑↑XReg.X1 Width.W64, imm := ↑13 } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("
-  ldr x0, [x1, #-8]
-  ldr x0, [x1, #13]
-")
-
--- Test: ADD_s with XZR destination
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.ADD_s (↑XRegOrXzr.XZR Width.W64) (↑↑XReg.X1 Width.W64)
-          { reg := ↑↑XReg.X2 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("add xzr, x1, x2")
-
--- Test: Logical instruction with ROR shift
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.ORR_s (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64)
-          { reg := ↑↑XReg.X2 Width.W64, amount := 4, shift := ShiftType.ROR } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("orr x0, x1, x2, ror #4")
-
--- Test: Conditional select instructions and aliases
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.CSEL (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) (↑↑XReg.X2 Width.W64) CondCode.EQ },
-  Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.CSINV (↑↑XReg.X3 Width.W64) (↑XRegOrXzr.XZR Width.W64) (↑XRegOrXzr.XZR Width.W64) CondCode.EQ },
-  Directive.instr
-    { operation_size := Width.W32,
-      operation :=
-        Operation.CSINC (↑↑XReg.X4 Width.W32) (↑↑XReg.X5 Width.W32) (↑↑XReg.X5 Width.W32)
-          CondCode.CS }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("
-  csel x0, x1, x2, eq
-  csetm x3, ne
-  cinc w4, w5, lo
-")
-
--- Test: Logical immediate instructions and TST immediate alias
-/--
-info: [Directive.instr
-    { operation_size := Width.W64, operation := Operation.AND_i (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) ↑255 },
-  Directive.instr
-    { operation_size := Width.W32, operation := Operation.ORR_i (↑↑XReg.X2 Width.W32) (↑↑XReg.X3 Width.W32) ↑255 },
-  Directive.instr
-    { operation_size := Width.W64, operation := Operation.EOR_i (↑XRegOrSp.SP Width.W64) (↑↑XReg.X4 Width.W64) ↑255 },
-  Directive.instr
-    { operation_size := Width.W32, operation := Operation.ANDS_i (↑↑XReg.X5 Width.W32) (↑↑XReg.X6 Width.W32) ↑255 },
-  Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.ANDS_i (↑XRegOrXzr.XZR Width.W64) (↑↑XReg.X7 Width.W64) ↑255 }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("
-  and x0, x1, #255
-  orr w2, w3, #255
-  eor sp, x4, #255
-  ands w5, w6, #255
-  tst x7, #255
-")
-
--- Test: MOV and MVN aliases
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.ORR_s (↑↑XReg.X0 Width.W64) (↑XRegOrXzr.XZR Width.W64)
-          { reg := ↑↑XReg.X1 Width.W64, amount := 0, shift := ShiftType.LSL } },
-  Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.ADD_e (↑XRegOrSp.SP Width.W64) (↑↑XReg.X0 Width.W64) ↑{ imm := ↑0, shift := ImmShift.S0 } },
-  Directive.instr { operation_size := Width.W64, operation := Operation.MOVZ (↑↑XReg.X0 Width.W64) (↑0) MovShift.LSL0 },
-  Directive.instr
-    { operation_size := Width.W64, operation := Operation.MOVZ (↑↑XReg.X0 Width.W64) (↑255) MovShift.LSL0 },
-  Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.ORN_s (↑↑XReg.X2 Width.W64) (↑XRegOrXzr.XZR Width.W64)
-          { reg := ↑↑XReg.X3 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("
-  mov x0, x1
-  mov sp, x0
-  mov x0, #0
-  mov x0, #255
-  mvn x2, x3
-")
-
--- Test: Move Wide Immediate family (MOVZ, MOVK, MOVN)
-/--
-info: [Directive.instr
-    { operation_size := Width.W64, operation := Operation.MOVZ (↑↑XReg.X0 Width.W64) (↑1234) MovShift.LSL16 },
-  Directive.instr
-    { operation_size := Width.W32, operation := Operation.MOVK (↑↑XReg.X1 Width.W32) (↑5678) MovShift.LSL0 },
-  Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.MOVN (↑↑XReg.X2 Width.W64) (↑65535) MovShift.LSL48 }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("
-  movz x0, #1234, lsl #16
-  movk w1, #5678, lsl #0
-  movn x2, #65535, lsl #48
-")
-
--- Test: MOV immediate Priority 1 (MOVZ) -> Priority 2 (MOVN) -> Priority 3 (ORR_i)
-/--
-info: [Directive.instr { operation_size := Width.W64, operation := Operation.MOVZ (↑↑XReg.X0 Width.W64) (↑0) MovShift.LSL0 },
-  Directive.instr
-    { operation_size := Width.W64, operation := Operation.MOVZ (↑↑XReg.X1 Width.W64) (↑4660) MovShift.LSL16 },
-  Directive.instr { operation_size := Width.W64, operation := Operation.MOVN (↑↑XReg.X2 Width.W64) (↑1) MovShift.LSL0 },
-  Directive.instr { operation_size := Width.W32, operation := Operation.MOVN (↑↑XReg.X3 Width.W32) (↑0) MovShift.LSL0 },
-  Directive.instr
-    { operation_size := Width.W64,
-      operation := Operation.ORR_i (↑↑XReg.X4 Width.W64) (↑XRegOrXzr.XZR Width.W64) ↑72340172838076673 },
-  Directive.instr { operation_size := Width.W64, operation := Operation.MOVN (↑↑XReg.X5 Width.W64) (↑0) MovShift.LSL0 },
-  Directive.instr
-    { operation_size := Width.W32,
-      operation := Operation.MOVN (↑↑XReg.X6 Width.W32) (↑4) MovShift.LSL0 }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("
-  mov x0, #0
-  mov x1, #0x12340000
-  mov x2, #0xfffffffffffffffe
-  mov w3, #0xffffffff
-  mov x4, #0x0101010101010101
-  mov x5, #-1
-  mov w6, #-5
-")
-
--- Test: LDP with 64-bit registers and signed immediate offset
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.LDP (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64)
-          { base := ↑XRegOrSp.SP Width.W64, off := ↑{ imm := ↑16, index := none } } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("ldp x0, x1, [sp, #16]")
-
--- Test: STP with 32-bit registers and pre-indexed offset
-/--
-info: [Directive.instr
-    { operation_size := Width.W32,
-      operation :=
-        Operation.STP (↑↑XReg.X0 Width.W32) (↑↑XReg.X1 Width.W32)
-          { base := ↑XRegOrSp.SP Width.W64, off := ↑{ imm := ↑(-32), index := some Index.Pre } } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("stp w0, w1, [sp, #-32]!")
-
--- Test: STP with zero registers and post-indexed offset
-/--
-info: [Directive.instr
-    { operation_size := Width.W64,
-      operation :=
-        Operation.STP (↑XRegOrXzr.XZR Width.W64) (↑XRegOrXzr.XZR Width.W64)
-          { base := ↑XRegOrSp.SP Width.W64, off := ↑{ imm := ↑32, index := some Index.Post } } }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("stp xzr, xzr, [sp], #32")
-
--- Test: B with label
+-- Test: B unconditional branch with label
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.B ↑"main" }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("b main")
 
--- Test: B with immediate offset
+-- Test: B unconditional branch with immediate offset
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.B ↑16 }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("b #16")
 
--- Test: B.eq with label
+-- Test: B.eq conditional branch with dotted syntax
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.B_cond CondCode.EQ ↑"loop" }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("b.eq loop")
 
--- Test: B.ne with label
+-- Test: B.ne conditional branch with dotted syntax
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.B_cond CondCode.NE ↑"exit" }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("b.ne exit")
 
--- Test: BEQ (undotted) with label
+-- Test: BEQ conditional branch with undotted syntax
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.B_cond CondCode.EQ ↑"loop" }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("beq loop")
 
--- Test: BNE (undotted) with label
+-- Test: BNE conditional branch with undotted syntax
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.B_cond CondCode.NE ↑"exit" }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("bne exit")
 
--- Test: BL with label
+-- Test: BL branch with link
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.BL ↑"foo" }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("bl foo")
 
--- Test: BLR with register
+-- Test: BLR branch with link to register
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.BLR (↑↑XReg.X16 Width.W64) }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("blr x16")
 
--- Test: BR with register
+-- Test: BR branch to register
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.BR (↑↑XReg.X30 Width.W64) }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("br x30")
 
--- Test: RET without operand (defaults to X30)
+-- Test: RET return without operand (defaults to X30)
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.RET (↑↑XReg.X30 Width.W64) }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("ret")
 
--- Test: RET with explicit register (x19)
+-- Test: RET return with explicit register (X19)
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.RET (↑↑XReg.X19 Width.W64) }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("ret x19")
 
--- Test: RET with lr alias
+-- Test: RET return with LR alias
 /--
 info: [Directive.instr { operation_size := Width.W64, operation := Operation.RET (↑↑XReg.X30 Width.W64) }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("ret lr")
 
--- Test: RET followed by line comment //
-/--
-info: [Directive.instr { operation_size := Width.W64, operation := Operation.RET (↑↑XReg.X30 Width.W64) }] : List Directive
--/
-#guard_msgs in
-#check parseAArch64("ret // return to caller")
-
--- Test: CBZ 64-bit
+-- Test: CBZ compare and branch if zero 64-bit
 /--
 info: [Directive.instr
     { operation_size := Width.W64, operation := Operation.CBZ (↑↑XReg.X0 Width.W64) ↑"target" }] : List Directive
@@ -905,7 +1041,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("cbz x0, target")
 
--- Test: CBNZ 32-bit
+-- Test: CBNZ compare and branch if non-zero 32-bit
 /--
 info: [Directive.instr
     { operation_size := Width.W32, operation := Operation.CBNZ (↑↑XReg.X1 Width.W32) ↑"loop" }] : List Directive
@@ -913,7 +1049,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("cbnz w1, loop")
 
--- Test: TBZ 64-bit
+-- Test: TBZ test bit and branch if zero 64-bit
 /--
 info: [Directive.instr
     { operation_size := Width.W64, operation := Operation.TBZ (↑↑XReg.X2 Width.W64) 5 ↑"label" }] : List Directive
@@ -921,7 +1057,7 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("tbz x2, #5, label")
 
--- Test: TBNZ 32-bit
+-- Test: TBNZ test bit and branch if non-zero 32-bit
 /--
 info: [Directive.instr
     { operation_size := Width.W32, operation := Operation.TBNZ (↑↑XReg.X3 Width.W32) 31 ↑"exit" }] : List Directive
@@ -929,6 +1065,39 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("tbnz w3, #31, exit")
 
+-- ============================================================================
+-- 11. Miscellaneous & Directives (NOP, Labels, Comments)
+-- ============================================================================
+
+-- Test: NOP no-operation
+/--
+info: [Directive.instr { operation_size := Width.W64, operation := Operation.NOP }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("nop")
+
+-- Test: Label definition with instruction on a single line
+/--
+info: [Directive.label "main",
+  Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.LDR (↑↑XReg.X1 Width.W64)
+          ↑{ base := ↑XRegOrSp.SP Width.W64, off := ↑{ imm := ↑0, index := none } } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("main: ldr x1, [sp]")
+
+-- Test: Instruction followed by line comment
+/--
+info: [Directive.instr { operation_size := Width.W64, operation := Operation.RET (↑↑XReg.X30 Width.W64) }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("ret // return to caller")
+
+-- ============================================================================
+-- 12. Error Reporting
+-- ============================================================================
 section error_reporting
 
 /-- error: line 1: unknown register or xzr: x31 -/
@@ -994,10 +1163,6 @@ section error_reporting
 /-- error: line 1: register offsets are not supported for ldp/stp instructions -/
 #guard_msgs in
 #check parseAArch64("ldp x0, x1, [sp, x2]")
-
-/-- error: line 1: expected w64 register, got w32 -/
-#guard_msgs in
-#check parseAArch64("ldp x0, w1, [sp, #16]")
 
 /-- error: line 1: unpredictable: identical destination registers in ldp instruction -/
 #guard_msgs in
@@ -1102,6 +1267,14 @@ section error_reporting
 /-- error: line 1: condition not satisfied -/
 #guard_msgs in
 #check parseAArch64("ldr x1, [sp, -#16]!")
+
+/-- error: line 1: condition not satisfied -/
+#guard_msgs in
+#check parseAArch64("add x0, x1, -#16")
+
+/-- error: line 1: condition not satisfied -/
+#guard_msgs in
+#check parseAArch64("ldur x0, [x1, -#8]")
 
 /-- error: line 1: unexpected trailing characters on line -/
 #guard_msgs in

--- a/Kraken/AArch64/ParserTests.lean
+++ b/Kraken/AArch64/ParserTests.lean
@@ -645,6 +645,17 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("add xzr, x1, x2")
 
+-- Test: Logical instruction with ROR shift
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.ORR_s (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64)
+          { reg := ↑↑XReg.X2 Width.W64, amount := 4, shift := ShiftType.ROR } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("orr x0, x1, x2, ror #4")
+
 -- Test: LDP with 64-bit registers and signed immediate offset
 /--
 info: [Directive.instr
@@ -820,6 +831,10 @@ section error_reporting
 /-- error: line 1: invalid extend amount: 33 -/
 #guard_msgs in
 #check parseAArch64("add w0, w1, w2, lsl #33")
+
+/-- error: line 1: unknown extension type: ror -/
+#guard_msgs in
+#check parseAArch64("add x0, x1, x2, ror #4")
 
 /-- error: line 1: pre-indexed offset 300 out of range [-256, 255] -/
 #guard_msgs in

--- a/Kraken/AArch64/ParserTests.lean
+++ b/Kraken/AArch64/ParserTests.lean
@@ -604,6 +604,36 @@ main:
   str x1, [sp]
 ")
 
+-- Test: LDUR and STUR explicit mnemonics
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.LDUR (↑↑XReg.X0 Width.W64) { base := ↑↑XReg.X1 Width.W64, imm := ↑(-8) } },
+  Directive.instr
+    { operation_size := Width.W32,
+      operation := Operation.STUR (↑↑XReg.X2 Width.W32) { base := ↑↑XReg.X3 Width.W64, imm := ↑13 } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("
+  ldur x0, [x1, #-8]
+  stur w2, [x3, #13]
+")
+
+-- Test: LDR/STR automatic conversion to LDUR/STUR for negative or unaligned offsets
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.LDUR (↑↑XReg.X0 Width.W64) { base := ↑↑XReg.X1 Width.W64, imm := ↑(-8) } },
+  Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.LDUR (↑↑XReg.X0 Width.W64) { base := ↑↑XReg.X1 Width.W64, imm := ↑13 } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("
+  ldr x0, [x1, #-8]
+  ldr x0, [x1, #13]
+")
+
 -- Test: ADD_s with XZR destination
 /--
 info: [Directive.instr
@@ -799,9 +829,9 @@ section error_reporting
 #guard_msgs in
 #check parseAArch64("str x2, [x1], #-300")
 
-/-- error: line 1: unsigned offset 13 out of range [0, 32760] or not a multiple of 8 -/
+/-- error: line 1: offset 257 is neither a valid scaled offset [0, 32760] (multiple of 8) nor a valid unscaled offset [-256, 255] -/
 #guard_msgs in
-#check parseAArch64("ldr x0, [x1, #13]")
+#check parseAArch64("ldr x0, [x1, #257]")
 
 /-- error: line 1: condition not satisfied -/
 #guard_msgs in

--- a/Kraken/AArch64/ParserTests.lean
+++ b/Kraken/AArch64/ParserTests.lean
@@ -678,6 +678,29 @@ info: [Directive.instr
   cinc w4, w5, lo
 ")
 
+-- Test: Logical immediate instructions and TST immediate alias
+/--
+info: [Directive.instr
+    { operation_size := Width.W64, operation := Operation.AND_i (↑↑XReg.X0 Width.W64) (↑↑XReg.X1 Width.W64) ↑255 },
+  Directive.instr
+    { operation_size := Width.W32, operation := Operation.ORR_i (↑↑XReg.X2 Width.W32) (↑↑XReg.X3 Width.W32) ↑255 },
+  Directive.instr
+    { operation_size := Width.W64, operation := Operation.EOR_i (↑XRegOrSp.SP Width.W64) (↑↑XReg.X4 Width.W64) ↑255 },
+  Directive.instr
+    { operation_size := Width.W32, operation := Operation.ANDS_i (↑↑XReg.X5 Width.W32) (↑↑XReg.X6 Width.W32) ↑255 },
+  Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.ANDS_i (↑XRegOrXzr.XZR Width.W64) (↑↑XReg.X7 Width.W64) ↑255 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("
+  and x0, x1, #255
+  orr w2, w3, #255
+  eor sp, x4, #255
+  ands w5, w6, #255
+  tst x7, #255
+")
+
 -- Test: LDP with 64-bit registers and signed immediate offset
 /--
 info: [Directive.instr
@@ -910,7 +933,7 @@ section error_reporting
 #guard_msgs in
 #check parseAArch64("stp x0, x1, [x0, #16]!")
 
-/-- error: line 1: unknown register or xzr: sp -/
+/-- error: line 1: sp/wsp not allowed in shifted register instruction (xzr expected) -/
 #guard_msgs in
 #check parseAArch64("and sp, x1, x2")
 
@@ -965,6 +988,18 @@ section error_reporting
 /-- error: line 1: tbz offset 0x10000 out of range [-0x8000, 0x7fc] or not a multiple of 4 -/
 #guard_msgs in
 #check parseAArch64("tbz x0, #10, #0x10000")
+
+/-- error: line 1: invalid logical immediate: 0x1f4 -/
+#guard_msgs in
+#check parseAArch64("and x0, x1, #500")
+
+/-- error: line 1: invalid logical immediate: 0x0 -/
+#guard_msgs in
+#check parseAArch64("orr x0, x1, #0")
+
+/-- error: line 1: invalid logical immediate: -0x1 -/
+#guard_msgs in
+#check parseAArch64("eor x0, x1, #-1")
 
 end error_reporting
 

--- a/Kraken/AArch64/ParserTests.lean
+++ b/Kraken/AArch64/ParserTests.lean
@@ -701,6 +701,78 @@ info: [Directive.instr
   tst x7, #255
 ")
 
+-- Test: MOV and MVN aliases
+/--
+info: [Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.ORR_s (↑↑XReg.X0 Width.W64) (↑XRegOrXzr.XZR Width.W64)
+          { reg := ↑↑XReg.X1 Width.W64, amount := 0, shift := ShiftType.LSL } },
+  Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.ADD_e (↑XRegOrSp.SP Width.W64) (↑↑XReg.X0 Width.W64) ↑{ imm := ↑0, shift := ImmShift.S0 } },
+  Directive.instr { operation_size := Width.W64, operation := Operation.MOVZ (↑↑XReg.X0 Width.W64) (↑0) MovShift.LSL0 },
+  Directive.instr
+    { operation_size := Width.W64, operation := Operation.MOVZ (↑↑XReg.X0 Width.W64) (↑255) MovShift.LSL0 },
+  Directive.instr
+    { operation_size := Width.W64,
+      operation :=
+        Operation.ORN_s (↑↑XReg.X2 Width.W64) (↑XRegOrXzr.XZR Width.W64)
+          { reg := ↑↑XReg.X3 Width.W64, amount := 0, shift := ShiftType.LSL } }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("
+  mov x0, x1
+  mov sp, x0
+  mov x0, #0
+  mov x0, #255
+  mvn x2, x3
+")
+
+-- Test: Move Wide Immediate family (MOVZ, MOVK, MOVN)
+/--
+info: [Directive.instr
+    { operation_size := Width.W64, operation := Operation.MOVZ (↑↑XReg.X0 Width.W64) (↑1234) MovShift.LSL16 },
+  Directive.instr
+    { operation_size := Width.W32, operation := Operation.MOVK (↑↑XReg.X1 Width.W32) (↑5678) MovShift.LSL0 },
+  Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.MOVN (↑↑XReg.X2 Width.W64) (↑65535) MovShift.LSL48 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("
+  movz x0, #1234, lsl #16
+  movk w1, #5678, lsl #0
+  movn x2, #65535, lsl #48
+")
+
+-- Test: MOV immediate Priority 1 (MOVZ) -> Priority 2 (MOVN) -> Priority 3 (ORR_i)
+/--
+info: [Directive.instr { operation_size := Width.W64, operation := Operation.MOVZ (↑↑XReg.X0 Width.W64) (↑0) MovShift.LSL0 },
+  Directive.instr
+    { operation_size := Width.W64, operation := Operation.MOVZ (↑↑XReg.X1 Width.W64) (↑4660) MovShift.LSL16 },
+  Directive.instr { operation_size := Width.W64, operation := Operation.MOVN (↑↑XReg.X2 Width.W64) (↑1) MovShift.LSL0 },
+  Directive.instr { operation_size := Width.W32, operation := Operation.MOVN (↑↑XReg.X3 Width.W32) (↑0) MovShift.LSL0 },
+  Directive.instr
+    { operation_size := Width.W64,
+      operation := Operation.ORR_i (↑↑XReg.X4 Width.W64) (↑XRegOrXzr.XZR Width.W64) ↑72340172838076673 },
+  Directive.instr { operation_size := Width.W64, operation := Operation.MOVN (↑↑XReg.X5 Width.W64) (↑0) MovShift.LSL0 },
+  Directive.instr
+    { operation_size := Width.W32,
+      operation := Operation.MOVN (↑↑XReg.X6 Width.W32) (↑4) MovShift.LSL0 }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("
+  mov x0, #0
+  mov x1, #0x12340000
+  mov x2, #0xfffffffffffffffe
+  mov w3, #0xffffffff
+  mov x4, #0x0101010101010101
+  mov x5, #-1
+  mov w6, #-5
+")
+
 -- Test: LDP with 64-bit registers and signed immediate offset
 /--
 info: [Directive.instr

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -525,18 +525,33 @@ def Operation.interp [Labels]
     let prod := val1.toNat * val2.toNat
     let res := BitVec.ofNat 64 (prod >>> 64)
     s.setRegOrZr dst res next
+  | .AND_i dst src1 imm =>
+    let val1 := s.regs.getRegOrZr src1
+    let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
+    let res := val1 &&& val2
+    s.setRegOrSp dst res next
   | .AND_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 &&& val2
     s.setRegOrZr dst res next
+  | .ANDS_i dst src1 imm =>
+    let val1 := s.regs.getRegOrZr src1
+    let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
+    let res := val1 &&& val2
+    let flags := StatusFlags.from_result res { c := false, v := false }
+    { s with status := flags }.setRegOrZr dst res next
   | .ANDS_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 &&& val2
     let flags := StatusFlags.from_result res { c := false, v := false }
-    let s' := { s with status := flags }
-    s'.setRegOrZr dst res next
+    { s with status := flags }.setRegOrZr dst res next
+  | .ORR_i dst src1 imm =>
+    let val1 := s.regs.getRegOrZr src1
+    let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
+    let res := val1 ||| val2
+    s.setRegOrSp dst res next
   | .ORR_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
@@ -547,6 +562,11 @@ def Operation.interp [Labels]
     let val2 := src2.interp s.regs p
     let res := val1 ||| ~~~val2
     s.setRegOrZr dst res next
+  | .EOR_i dst src1 imm =>
+    let val1 := s.regs.getRegOrZr src1
+    let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
+    let res := val1 ^^^ val2
+    s.setRegOrSp dst res next
   | .EOR_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -577,6 +577,20 @@ def Operation.interp [Labels]
     let val2 := src2.interp s.regs p
     let res := val1 &&& ~~~val2
     s.setRegOrZr dst res next
+  | .MOVZ dst imm shift =>
+    let val16 := (BitVec.ofInt w.bits (Int64.toInt (imm.interp p))) &&& (0xFFFF : BitVec w.bits)
+    let res := val16 <<< shift.toNat
+    s.setRegOrZr dst res next
+  | .MOVK dst imm shift =>
+    let oldVal := s.regs.getRegOrZr dst
+    let mask := ~~~((0xFFFF : BitVec w.bits) <<< shift.toNat)
+    let val16 := (BitVec.ofInt w.bits (Int64.toInt (imm.interp p))) &&& (0xFFFF : BitVec w.bits)
+    let res := (oldVal &&& mask) ||| (val16 <<< shift.toNat)
+    s.setRegOrZr dst res next
+  | .MOVN dst imm shift =>
+    let val16 := (BitVec.ofInt w.bits (Int64.toInt (imm.interp p))) &&& (0xFFFF : BitVec w.bits)
+    let res := ~~~(val16 <<< shift.toNat)
+    s.setRegOrZr dst res next
   | .LSLV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -281,6 +281,7 @@ def ShiftRegExpr.interp {w} (expr : ShiftRegExpr w) (s : Reg64s) (_ : Std.Rco In
   | .LSL => base <<< amount
   | .LSR => base.ushiftRight amount
   | .ASR => base.sshiftRight amount
+  | .ROR => base.rotateRight amount
 
 def AddrExpr.eval [Labels] {w} (mem : AddrExpr w) (s : MachineData) (p : Std.Rco Int64) : BitVec 64 × MachineData :=
   let base := (s.regs.getRegOrSp mem.base).signed

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -313,6 +313,25 @@ def AddrExpr.interp [Labels] {w} (mem : AddrExpr w) (s : MachineData) (p : Std.R
     let (addr, s') := mem.eval s p
     s'.load addr w ret)
 
+def UnscaledAddrExpr.eval [Labels] (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64) : BitVec 64 :=
+  let base := (s.regs.getRegOrSp mem.base).toInt
+  let off := Int64.toInt (mem.imm.interp p)
+  BitVec.ofInt 64 (base + off)
+
+def UnscaledAddrExpr.checkSPAlignment (mem : UnscaledAddrExpr) (s : MachineData) (ok : Unit → Effects) : Effects :=
+  match mem.base with
+  | .SP =>
+    if s.regs.getRegOrSp .SP % 16#64 != 0#64 then
+      .unimplemented s!"Unimplemented: SP is required to be 16-byte aligned"
+    else
+      ok ()
+  | _ => ok ()
+
+def UnscaledAddrExpr.interp [Labels] {w : Width} (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects) :=
+  mem.checkSPAlignment s (fun _unit =>
+    let addr := mem.eval s p
+    s.load addr w ret)
+
 def Literal.interp [Labels] {w} (expr : Literal w) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects) : Effects :=
   match expr with
   | .addr addr_expr => -- Load from address.
@@ -385,6 +404,12 @@ def Operation.interp [Labels]
       let val := s.regs.getRegOrZr src
       let (addr, s') := dst.eval s p
       s'.store addr val next)
+  | .LDUR dst src => src.interp s p (fun val s => s.setRegOrZr dst val next)
+  | .STUR src dst =>
+    dst.checkSPAlignment s (fun _unit =>
+      let val := s.regs.getRegOrZr src
+      let addr := dst.eval s p
+      s.store addr val next)
   -- TODO: Architecturally, the memory access ordering of LDP/STP is UNORDERED and can occur
   -- simultaneously as a 128-bit transaction or in any order on hardware. Here we model a specific
   -- sequential order (lower address first, then higher address), which does not necessarily reflect

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -581,6 +581,18 @@ def Operation.interp [Labels]
     let shift := val2.toNat % w.bits
     let res := val1.rotateRight shift
     s.setRegOrZr dst res next
+  | .CSEL dst src1 src2 cond =>
+    let val := if cond.interp s.status then s.regs.getRegOrZr src1 else s.regs.getRegOrZr src2
+    s.setRegOrZr dst val next
+  | .CSINC dst src1 src2 cond =>
+    let val := if cond.interp s.status then s.regs.getRegOrZr src1 else s.regs.getRegOrZr src2 + 1#w.bits
+    s.setRegOrZr dst val next
+  | .CSINV dst src1 src2 cond =>
+    let val := if cond.interp s.status then s.regs.getRegOrZr src1 else ~~~(s.regs.getRegOrZr src2)
+    s.setRegOrZr dst val next
+  | .CSNEG dst src1 src2 cond =>
+    let val := if cond.interp s.status then s.regs.getRegOrZr src1 else -(s.regs.getRegOrZr src2)
+    s.setRegOrZr dst val next
   | .ADR dst target =>
     let val := match target with
       | .int64 imm => BitVec.ofInt 64 (Int64.toInt p.lower + Int64.toInt imm)

--- a/Kraken/AArch64/Syntax.lean
+++ b/Kraken/AArch64/Syntax.lean
@@ -164,6 +164,16 @@ inductive CondCode | EQ | NE | CS | CC | MI | PL | VS | VC | HI | LS | GE | LT |
 abbrev CondCode.HS := CondCode.CS
 abbrev CondCode.LO := CondCode.CC
 
+def CondCode.invert : CondCode → CondCode
+  | .EQ => .NE | .NE => .EQ
+  | .CS => .CC | .CC => .CS
+  | .MI => .PL | .PL => .MI
+  | .VS => .VC | .VC => .VS
+  | .HI => .LS | .LS => .HI
+  | .GE => .LT | .LT => .GE
+  | .GT => .LE | .LE => .GT
+  | .AL => .NV | .NV => .AL
+
 inductive AddrOff w | imm (_ : ImmAddrExpr w) | reg (_ : MemExtRegExpr w)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 instance {w} : Coe (ImmAddrExpr w) (AddrOff w) where coe := .imm
@@ -267,6 +277,12 @@ inductive Operation : Width → Type
   | LSRV {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : RegOrZr w) : Operation w
   | ASRV {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : RegOrZr w) : Operation w
   | RORV {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : RegOrZr w) : Operation w
+  --
+  -- Conditional Select.
+  | CSEL {w} (dst : RegOrZr w) (src1 src2 : RegOrZr w) (cond : CondCode) : Operation w
+  | CSINC {w} (dst : RegOrZr w) (src1 src2 : RegOrZr w) (cond : CondCode) : Operation w
+  | CSINV {w} (dst : RegOrZr w) (src1 src2 : RegOrZr w) (cond : CondCode) : Operation w
+  | CSNEG {w} (dst : RegOrZr w) (src1 src2 : RegOrZr w) (cond : CondCode) : Operation w
   --
   -- Addressing.
   | ADR (dst : RegOrZr .W64) (target : ConstExpr) : Operation .W64

--- a/Kraken/AArch64/Syntax.lean
+++ b/Kraken/AArch64/Syntax.lean
@@ -190,6 +190,11 @@ structure AddrExpr (w : Width) where
   off : AddrOff w
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+structure UnscaledAddrExpr where
+  base : RegOrSp .W64 -- Memory base register is always Xn|SP.
+  imm : ConstExpr
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
+
 inductive AddrOrLit w | addr (_ : AddrExpr w) | lit (_ : Literal w)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 instance {w} : Coe (AddrExpr w) (AddrOrLit w) where coe := .addr
@@ -218,6 +223,8 @@ inductive Operation : Width → Type
   -- Loads and Stores.
   | LDR {w} (dst : RegOrZr w) (src : AddrOrLit w) : Operation w
   | STR {w} (src : RegOrZr w) (dst : AddrExpr w) : Operation w
+  | LDUR {w} (dst : RegOrZr w) (src : UnscaledAddrExpr) : Operation w
+  | STUR {w} (src : RegOrZr w) (dst : UnscaledAddrExpr) : Operation w
   | LDP {w} (dst1 : RegOrZr w) (dst2 : RegOrZr w) (src : AddrExpr w) : Operation w
   | STP {w} (src1 : RegOrZr w) (src2 : RegOrZr w) (dst : AddrExpr w) : Operation w
   --

--- a/Kraken/AArch64/Syntax.lean
+++ b/Kraken/AArch64/Syntax.lean
@@ -99,7 +99,8 @@ inductive MemExtendAmount : Width → Type
   | E3 : MemExtendAmount .W64
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
-inductive ShiftType | LSL | LSR | ASR
+-- Note: ROR is only valid for logic instructions, invalid for arithmetic instructions.
+inductive ShiftType | LSL | LSR | ASR | ROR
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 inductive ImmShift | S0 | S12

--- a/Kraken/AArch64/Syntax.lean
+++ b/Kraken/AArch64/Syntax.lean
@@ -1,6 +1,11 @@
 import Lean
 import Std
 
+/--
+Architectural operand and register width for AArch64 instructions.
+- `W32`: 32-bit register (`W0`-`W30`, `WSP`, `WZR`) or 32-bit operation.
+- `W64`: 64-bit register (`X0`-`X30`, `SP`, `XZR`) or 64-bit operation.
+-/
 inductive Width | W32 | W64 deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 instance : ToString Width where
@@ -20,7 +25,9 @@ unif_hint (w : Width) where
 unif_hint (w : Width) where
   w =?= Width.W64 |- Width.type w =?= BitVec 64
 
--- General purpose registers (GPR) X0 to X30.
+/--
+AArch64 General Purpose Registers (GPRs) `X0` through `X30`.
+-/
 inductive XReg
   |  X0 |  X1 |  X2 |  X3 |  X4 |  X5 |  X6 |  X7
   |  X8 |  X9 | X10 | X11 | X12 | X13 | X14 | X15
@@ -28,13 +35,17 @@ inductive XReg
   | X24 | X25 | X26 | X27 | X28 | X29 | X30
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
--- GPR or stack pointer.
+/--
+GPR or Stack Pointer (`SP`/`WSP`), used in contexts where index 31 means SP.
+-/
 inductive XRegOrSp
   | reg (_ : XReg)
   | SP
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
--- GPR or zero register.
+/--
+GPR or Zero Register (`XZR`/`WZR`), used in contexts where index 31 means ZR.
+-/
 inductive XRegOrXzr
   | reg (_ : XReg)
   | XZR
@@ -82,30 +93,65 @@ structure RegOrSpW where (w : Width) (reg : RegOrSp w)
 structure RegOrZrW where (w : Width) (reg : RegOrZr w)
   deriving Repr, DecidableEq, Hashable, Lean.ToExpr
 
--- Note: LSL is another name for UXTW or UXTX, depending on whether it is a 32-bit or a 64-bit instruction.
+/--
+Architectural extension types for arithmetic instructions.
+- Supports unsigned/signed byte (`UXTB`, `SXTB`), halfword (`UXTH`, `SXTH`),
+  word (`UXTW`, `SXTW`), and doubleword (`UXTX`, `SXTX`). `UXTW` and `UXTX` are
+  also aliased as `LSL`, respectively, depending on operand width.
+-/
 inductive ExtendType | UXTB | SXTB | UXTH | SXTH | UXTW | SXTW | UXTX | SXTX
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
--- Note: LSL is another name for UXTX.
+/--
+Architectural extension types for memory addressing index registers.
+- Supports `UXTW`, `SXTW`, `UXTX`, `SXTX`, `LSL` alias.
+- `UXTW`/`SXTW` require a 32-bit index register `Wn`.
+- `SXTX`/`UXTX` require a 64-bit index register `Xn`.
+-/
 inductive MemExtendType | UXTW | SXTW | UXTX | SXTX
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+/--
+Shift amount applied after extension in arithmetic instructions.
+-/
 inductive ExtendAmount | E0 | E1 | E2 | E3 | E4
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+/--
+Shift amount applied to index registers in memory addressing.
+- Restricted to either unshifted (`E0`, shift `#0` / omitted)
+  or scaled by log2 of the access size in bytes:
+  - `E2` (`#2`) for 32-bit (`.W32`, 4-byte) operations.
+  - `E3` (`#3`) for 64-bit (`.W64`, 8-byte) operations.
+-/
 inductive MemExtendAmount : Width → Type
   | E0 {w} : MemExtendAmount w
   | E2 : MemExtendAmount .W32
   | E3 : MemExtendAmount .W64
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
--- Note: ROR is only valid for logic instructions, invalid for arithmetic instructions.
+/--
+Shift types for shifted-register operands.
+- `LSL`, `LSR`, `ASR` are allowed in both logical and arithmetic instructions.
+- `ROR` (rotate right) is only valid in logical instructions.
+-/
 inductive ShiftType | LSL | LSR | ASR | ROR
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+/--
+Optional shift for immediate operands in arithmetic instructions.
+- Immediate values can only be unshifted (`S0`, `LSL #0` / omitted)
+  or shifted left by 12 bits (`S12`, `LSL #12`).
+-/
 inductive ImmShift | S0 | S12
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+/--
+Allowed shift amounts for move wide immediate instructions.
+- For 32-bit registers (`.W32`): Can shift by `#0` (`LSL0`) or `#16` (`LSL16`).
+- For 64-bit registers (`.W64`): Can shift by `#0` (`LSL0`), `#16` (`LSL16`),
+  `#32` (`LSL32`), or `#48` (`LSL48`).
+-/
 inductive MovShift : Width → Type
   | LSL0 {w}  : MovShift w
   | LSL16 {w} : MovShift w
@@ -119,45 +165,70 @@ def MovShift.toNat {w} : MovShift w → Nat
   | .LSL32 => 32
   | .LSL48 => 48
 
+/--
+Addressing indexing mode for immediate memory offsets.
+- `Pre`: Pre-indexed writeback (`[Xn, #imm]!`). Base updated before access.
+- `Post`: Post-indexed writeback (`[Xn], #imm`). Base updated after access.
+- `none` (Option.none): Offset addressing (`[Xn, #imm]`) without base writeback.
+-/
 inductive Index | Pre | Post
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+/-- Combined extension type and shift amount for arithmetic instructions. -/
 structure Extend where
   type : ExtendType
   amount : ExtendAmount
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+/-- Combined extension type and shift amount for memory index registers. -/
 structure MemExtend (w : Width) where
   type : MemExtendType
   amount : MemExtendAmount w
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+/-- Register operand with extension and shift for arithmetic instructions (`Xm, <extend> #<amount>`). -/
 structure ExtRegExpr where
   reg : RegOrZrW
   ext : Extend
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+/-- Register operand with extension and shift for memory addressing (`[Xn, Xm, <extend> #<amount>]`). -/
 structure MemExtRegExpr (w : Width) where
   reg : RegOrZrW
   ext : MemExtend w
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+/--
+12-bit unsigned immediate operand with optional `LSL #0` or `LSL #12` shift for arithmetic instructions.
+- The unsigned immediate `imm` must be in range $[0, 4095]$.
+-/
 structure ImmExpr (w : Width) where
   imm : ConstExpr -- 12-bit unsigned immediate value, must be in [0, 4095] when evaluated.
   shift : ImmShift
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+/--
+Shifted register operand for logical and arithmetic instructions (`Xm, <shift> #<amount>`).
+- Shift amount `amount` must be in $[0, 31]$ for 32-bit (`.W32`) operations
+  and $[0, 63]$ for 64-bit (`.W64`) operations.
+-/
 structure ShiftRegExpr (w : Width) where
   reg : RegOrZr w
   amount : Int64 -- Must be in the range $[0, 31]$ for 32-bit instructions and [0, 63] for 64-bit instructions.
   shift : ShiftType
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+/--
+Memory access byte offset. Valid architectural ranges depend on the addressing mode and access size:
+- **Unsigned scaled offset (`index = none`)**: A multiple of 4 in [0, 16380]
+  for 32-bit operations and a multiple of 8 in [0, 32760] for 64-bit operations.
+- **Signed unscaled / pre / post-indexed offset**: A 9-bit signed integer in
+  $[-256, 255]$ (`index = some .Pre | some .Post` or unscaled `LDUR/STUR`).
+- **Load/Store Pair (`LDP/STP`)**: A 7-bit signed integer scaled by instruction
+  size, giving $[-256, 252]$ (multiples of 4) for 32-bit and $[-512, 504]$
+  (multiples of 8) for 64-bit.
+-/
 structure ImmAddrExpr (w : Width) where
-  /-- Memory access byte offset. Valid architectural ranges depend on the addressing mode and access size:
-      - **Unsigned scaled offset (`index = none`)**: A multiple of 4 in [0, 16380] for 32-bit operations and a multiple of 8 in [0, 32760] for 64-bit operations.
-      - **Signed unscaled / pre-indexed / post-indexed offset (`index = some .Pre | some .Post` or unscaled `LDUR/STUR`)**: A 9-bit signed integer in $[-256, 255]$.
-      - **Load/Store Pair (`LDP/STP`)**: A 7-bit signed integer scaled by instruction size, giving $[-256, 252]$ (multiples of 4) for 32-bit and $[-512, 504]$ (multiples of 8) for 64-bit. -/
   imm : ConstExpr
   index : Option Index
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
@@ -216,7 +287,7 @@ structure AddrExpr (w : Width) where
 
 structure UnscaledAddrExpr where
   base : RegOrSp .W64 -- Memory base register is always Xn|SP.
-  imm : ConstExpr
+  imm : ConstExpr -- Literal `imm` must be a 9-bit signed unscaled integer in [-256, 255].
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 inductive AddrOrLit w | addr (_ : AddrExpr w) | lit (_ : Literal w)

--- a/Kraken/AArch64/Syntax.lean
+++ b/Kraken/AArch64/Syntax.lean
@@ -106,6 +106,19 @@ inductive ShiftType | LSL | LSR | ASR | ROR
 inductive ImmShift | S0 | S12
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
+inductive MovShift : Width → Type
+  | LSL0 {w}  : MovShift w
+  | LSL16 {w} : MovShift w
+  | LSL32     : MovShift .W64
+  | LSL48     : MovShift .W64
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
+
+def MovShift.toNat {w} : MovShift w → Nat
+  | .LSL0  => 0
+  | .LSL16 => 16
+  | .LSL32 => 32
+  | .LSL48 => 48
+
 inductive Index | Pre | Post
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
@@ -272,6 +285,11 @@ inductive Operation : Width → Type
   | EOR_i  {w} (dst : RegOrSp w) (src1 : RegOrZr w) (imm : ConstExpr) : Operation w
   | EOR_s  {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
   | BIC_s  {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
+  --
+  -- Move Wide Immediates.
+  | MOVZ {w} (dst : RegOrZr w) (imm : ConstExpr) (shift : MovShift w) : Operation w
+  | MOVK {w} (dst : RegOrZr w) (imm : ConstExpr) (shift : MovShift w) : Operation w
+  | MOVN {w} (dst : RegOrZr w) (imm : ConstExpr) (shift : MovShift w) : Operation w
   --
   -- Variable Shifts / Rotates.
   | LSLV {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : RegOrZr w) : Operation w

--- a/Kraken/AArch64/Syntax.lean
+++ b/Kraken/AArch64/Syntax.lean
@@ -262,15 +262,16 @@ inductive Operation : Width → Type
   | UMULH (dst : RegOrZr .W64) (src1 : RegOrZr .W64) (src2 : RegOrZr .W64) : Operation .W64
   --
   -- Logic (instructions have an immediate (_i) and shifted reg (_s) form).
-  -- TODO: The immediate form has a weird bitmask encoding.
-  --| AND_i {w} (dst : RegOrSp w) (src1 : RegOrSp w) (src2 : Int64) : Operation w
-  | AND_s {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
+  | AND_i  {w} (dst : RegOrSp w) (src1 : RegOrZr w) (imm : ConstExpr) : Operation w
+  | AND_s  {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
+  | ANDS_i {w} (dst : RegOrZr w) (src1 : RegOrZr w) (imm : ConstExpr) : Operation w
   | ANDS_s {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
-  --| ORR_i {w} (dst : RegOrSp w) (src1 : RegOrSp w) (src2 : Int64) : Operation w
-  | ORR_s {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
-  | ORN_s {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
-  | EOR_s {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
-  | BIC_s {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
+  | ORR_i  {w} (dst : RegOrSp w) (src1 : RegOrZr w) (imm : ConstExpr) : Operation w
+  | ORR_s  {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
+  | ORN_s  {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
+  | EOR_i  {w} (dst : RegOrSp w) (src1 : RegOrZr w) (imm : ConstExpr) : Operation w
+  | EOR_s  {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
+  | BIC_s  {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : ShiftRegExpr w) : Operation w
   --
   -- Variable Shifts / Rotates.
   | LSLV {w} (dst : RegOrZr w) (src1 : RegOrZr w) (src2 : RegOrZr w) : Operation w

--- a/Kraken/AArch64/Test/asm/test_and_imm.S
+++ b/Kraken/AArch64/Test/asm/test_and_imm.S
@@ -1,0 +1,6 @@
+# Undefined flags: n, z, c, v
+and x0, x1, #255
+and w2, w3, #65535
+and sp, x4, #15
+tst x0, #255
+tst w1, #15

--- a/Kraken/AArch64/Test/asm/test_ands_imm.S
+++ b/Kraken/AArch64/Test/asm/test_ands_imm.S
@@ -1,0 +1,3 @@
+# Undefined flags: n, z, c, v
+ands x0, x1, #255
+ands w2, w3, #65535

--- a/Kraken/AArch64/Test/asm/test_b_cond.S
+++ b/Kraken/AArch64/Test/asm/test_b_cond.S
@@ -30,3 +30,12 @@ _ge_target:
 b.le _le_target
 add x7, x7, #600
 _le_target:
+
+// undotted aliases: beq / bne
+cmp x0, x0
+beq _undotted_eq_taken
+add x8, x8, #1
+_undotted_eq_taken:
+bne _undotted_ne_taken
+add x9, x9, #10
+_undotted_ne_taken:

--- a/Kraken/AArch64/Test/asm/test_csel.S
+++ b/Kraken/AArch64/Test/asm/test_csel.S
@@ -1,0 +1,7 @@
+# Undefined flags: n, z, c, v
+# Set Z flag (EQ is true, NE is false)
+cmp xzr, xzr
+csel x0, x1, x2, eq
+csel x3, x1, x2, ne
+csel w4, w1, w2, eq
+csel w5, w1, w2, ne

--- a/Kraken/AArch64/Test/asm/test_csinc.S
+++ b/Kraken/AArch64/Test/asm/test_csinc.S
@@ -1,0 +1,11 @@
+# Undefined flags: n, z, c, v
+# Set Z flag (EQ is true, NE is false)
+cmp xzr, xzr
+csinc x0, x1, x2, eq
+csinc x3, x1, x2, ne
+cset x4, eq
+cset x5, ne
+cinc x6, x1, eq
+cinc x7, x1, ne
+cset w8, eq
+cinc w9, w1, ne

--- a/Kraken/AArch64/Test/asm/test_csinv.S
+++ b/Kraken/AArch64/Test/asm/test_csinv.S
@@ -1,0 +1,11 @@
+# Undefined flags: n, z, c, v
+# Set Z flag (EQ is true, NE is false)
+cmp xzr, xzr
+csinv x0, x1, x2, eq
+csinv x3, x1, x2, ne
+csetm x4, eq
+csetm x5, ne
+cinv x6, x1, eq
+cinv x7, x1, ne
+csetm w8, eq
+cinv w9, w1, ne

--- a/Kraken/AArch64/Test/asm/test_csneg.S
+++ b/Kraken/AArch64/Test/asm/test_csneg.S
@@ -1,0 +1,9 @@
+# Undefined flags: n, z, c, v
+# Set Z flag (EQ is true, NE is false)
+cmp xzr, xzr
+csneg x0, x1, x2, eq
+csneg x3, x1, x2, ne
+cneg x4, x1, eq
+cneg x5, x1, ne
+cneg w6, w1, eq
+cneg w7, w1, ne

--- a/Kraken/AArch64/Test/asm/test_eor_imm.S
+++ b/Kraken/AArch64/Test/asm/test_eor_imm.S
@@ -1,0 +1,4 @@
+# Undefined flags: n, z, c, v
+eor x0, x1, #255
+eor w2, w3, #65535
+eor sp, x4, #15

--- a/Kraken/AArch64/Test/asm/test_ldur_stur.S
+++ b/Kraken/AArch64/Test/asm/test_ldur_stur.S
@@ -1,0 +1,19 @@
+# Undefined flags: n, z, c, v
+
+// Allocate 32 bytes on stack: SP = SP - 32 (16-byte aligned SP)
+str x1, [sp, #-32]!
+
+// 1. Explicit LDUR and STUR mnemonics with positive offsets
+stur x1, [sp, #8]
+ldur x2, [sp, #8]
+
+// 2. Explicit LDUR and STUR mnemonics with negative offsets
+stur x1, [sp, #-8]
+ldur x3, [sp, #-8]
+
+// 3. Automatic STR -> STUR and LDR -> LDUR conversion with negative offsets
+str x1, [sp, #-16]
+ldr x4, [sp, #-16]
+
+// Restore SP: SP = SP + 32
+ldr xzr, [sp], #32

--- a/Kraken/AArch64/Test/asm/test_mov_reg.S
+++ b/Kraken/AArch64/Test/asm/test_mov_reg.S
@@ -1,0 +1,12 @@
+# Undefined flags: n, z, c, v
+mov x0, x1
+mov w2, w3
+mov sp, x0
+mov x1, sp
+mov x0, xzr
+mov w2, wzr
+mov x0, #0
+mov w1, #0
+mov x0, #255
+mov w1, #65535
+mov sp, #15

--- a/Kraken/AArch64/Test/asm/test_movk.S
+++ b/Kraken/AArch64/Test/asm/test_movk.S
@@ -1,0 +1,15 @@
+# Undefined flags: n, z, c, v
+# Construct a full 64-bit constant 0x123456789abcdef0 in x0:
+movz x0, #0xdef0, lsl #0
+movk x0, #0x9abc, lsl #16
+movk x0, #0x5678, lsl #32
+movk x0, #0x1234, lsl #48
+
+# Construct a 32-bit constant 0xdeadbeef in w1:
+movz w1, #0xbeef, lsl #0
+movk w1, #0xdead, lsl #16
+
+# Construct a 64-bit constant with inverted base and movk overrides in x2:
+movn x2, #0, lsl #0
+movk x2, #0x0000, lsl #16
+movk x2, #0x1234, lsl #32

--- a/Kraken/AArch64/Test/asm/test_movn.S
+++ b/Kraken/AArch64/Test/asm/test_movn.S
@@ -1,0 +1,9 @@
+# Undefined flags: n, z, c, v
+movn x0, #0, lsl #0
+movn x1, #0x0000, lsl #16
+movn x2, #0x1234, lsl #0
+movn x3, #0x5678, lsl #16
+movn x4, #0x9abc, lsl #32
+movn x5, #0xdef0, lsl #48
+movn w6, #0, lsl #0
+movn w7, #0x1234, lsl #16

--- a/Kraken/AArch64/Test/asm/test_movz.S
+++ b/Kraken/AArch64/Test/asm/test_movz.S
@@ -1,0 +1,8 @@
+# Undefined flags: n, z, c, v
+movz x0, #0, lsl #0
+movz x1, #0x1234, lsl #0
+movz x2, #0x5678, lsl #16
+movz x3, #0x9abc, lsl #32
+movz x4, #0xdef0, lsl #48
+movz w5, #0x1234, lsl #0
+movz w6, #0x5678, lsl #16

--- a/Kraken/AArch64/Test/asm/test_mvn.S
+++ b/Kraken/AArch64/Test/asm/test_mvn.S
@@ -1,0 +1,4 @@
+# Undefined flags: n, z, c, v
+mvn x0, x1
+mvn w2, w3
+mvn x4, x5, lsl #4

--- a/Kraken/AArch64/Test/asm/test_orr.S
+++ b/Kraken/AArch64/Test/asm/test_orr.S
@@ -2,3 +2,5 @@
 orr x4, x1, x2
 orr x5, x1, x2, lsr #1
 orr w6, w1, w2
+orr x7, x1, x2, ror #4
+orr w8, w1, w2, ror #4

--- a/Kraken/AArch64/Test/asm/test_orr_imm.S
+++ b/Kraken/AArch64/Test/asm/test_orr_imm.S
@@ -1,0 +1,4 @@
+# Undefined flags: n, z, c, v
+orr x0, x1, #255
+orr w2, w3, #65535
+orr sp, x4, #15


### PR DESCRIPTION
This adds some missing instructions, adds more comments to the parser and syntax, and restricts the parser to better align it with official assembler behaviour.