### PR TITLE
feat(x64): movaps, subps, addps

### DIFF
--- a/Kraken/X64/Examples/IncrementMMIO.lean
+++ b/Kraken/X64/Examples/IncrementMMIO.lean
@@ -91,6 +91,7 @@ def handleEffects (ds : IncrementerState) (es : Effects)
   match es with
   | .done ms => ok (.mk ms ds)
   | .unimplemented msg => .error msg
+  | .gp_unaligned addr w => .error s!"#GP: Memory op at {repr addr} did not have mandatory alignment of {w}"
   | .require_read_access _ _ cont => handleEffects ds (cont ()) ok
   | .require_write_access _ _ cont => handleEffects ds (cont ()) ok
   | .require_exec_access _ cont => handleEffects ds (cont ()) ok

--- a/Kraken/X64/OmniSemantics.lean
+++ b/Kraken/X64/OmniSemantics.lean
@@ -17,6 +17,7 @@ abbrev Post {State : Type} := State → Prop
 def Effects.All (post : MachineState → Prop) : Effects → Prop
   | .done a => post a
   | .unimplemented _ => False
+  | .gp_unaligned .. => False
   | .nonmem_load .. => False
   | .nonmem_store .. => False
   | @Effects.undefined α _ cont => ∀ v: α, (cont v).All post

--- a/Kraken/X64/Parser.lean
+++ b/Kraken/X64/Parser.lean
@@ -774,6 +774,15 @@ def parseInstr : Parser Instr := do
   | "vmovups" =>
     commaSeparatedAvx .none parseAvxRegOrMem parseAvxRegOrMem .vmovups
 
+  | "movaps" =>
+    commaSeparatedAvx .none parseAvxRegOrMem parseAvxRegOrMem .movaps
+
+  | "addps" =>
+    commaSeparatedAvx .none parseAvxRegOrMem parseAvxRegOrMem .addps
+
+  | "subps" =>
+    commaSeparatedAvx .none parseAvxRegOrMem parseAvxRegOrMem .subps
+
   -- Bitwise - 64-bit
   | "xor" =>
     commaSeparated .none parseOperand parseRegOrMem .xor

--- a/Kraken/X64/PrintIntel.lean
+++ b/Kraken/X64/PrintIntel.lean
@@ -167,6 +167,9 @@ instance {w} : ToString (Operation w) where toString op := op.toStr
 def AvxOperation.toStr {w} (op : AvxOperation w) (addr_w : Width := .W64) : String := match op with
   | .movups dst src => s!"movups {dst.toStr addr_w}, {src.toStr addr_w}"
   | .vmovups dst src => s!"vmovups {dst.toStr addr_w}, {src.toStr addr_w}"
+  | .movaps dst src => s!"movaps {dst.toStr addr_w}, {src.toStr addr_w}"
+  | .subps dst src => s!"subps {dst.toStr addr_w}, {src.toStr addr_w}"
+  | .addps dst src => s!"addps {dst.toStr addr_w}, {src.toStr addr_w}"
 instance {w} : ToString (Operation w) where toString op := op.toStr
 
 instance : ToString Instr where

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -272,10 +272,19 @@ def MachineData.load
     | .some i => ret (.ofInt _ i) s
     | .none => nonmem_load s.dmem addr w (fun v dmem => ret v { s with dmem }))
 
+-- Alternatively, we could define this in terms of BitVecs without %:
+-- (addr &&& BitVec.ofNat 64 (bytes - 1)) == 0#64
+def isAligned (bytes : Nat) (addr : BitVec 64) : Bool :=
+  addr.toNat % bytes == 0
+
+-- Legacy SSE instructions are generally stricter about alignment requirements,
+-- while AVX (VEX-encoded) instructions can mostly deal with unaligned
+-- addresses (https://discourse.llvm.org/t/memory-alignment-model-on-avx-avx2-and-avx-512-targets/34705).
+-- For this reason we default checkAlign to false.
 def MachineData.loadAvx
   (s : MachineData) (addr : BitVec 64) (w : AvxWidth)
   (ret : w.type → MachineData → Effects) (checkAlign : Bool := false) : Effects :=
-  if checkAlign && (addr &&& BitVec.ofNat 64 (w.bytes - 1)) != 0#64 then
+  if checkAlign && !(isAligned w.bytes addr) then
     .gp_unaligned addr w.bytes
   else
     require_read_access addr .W64 (fun _unit =>
@@ -291,7 +300,7 @@ def MachineData.store (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.ty
     | .none => nonmem_store s.dmem addr v (fun dmem' => ret { s with dmem := dmem' }))
 
 def MachineData.storeAvx (s : MachineData) (addr : BitVec 64) {w : AvxWidth} (v : w.type) (ret: MachineData → Effects) (checkAlign : Bool := false) : Effects :=
-  if checkAlign && (addr &&& BitVec.ofNat 64 (w.bytes - 1)) != 0#64 then
+  if checkAlign && !(isAligned w.bytes addr) then
     .gp_unaligned addr w.bytes
   else
     require_write_access addr .W64 (fun _unit =>

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -169,6 +169,31 @@ def RegZmms.setLegacy (s : RegZmms) {w} (r : AvxReg w) (v : w.type) : RegZmms :=
 def BitVec.toAddressSize [address_size: AddressSize] (w: BitVec 64): BitVec address_size.address_size.bits :=
   w.take address_size.address_size.bits
 
+def BitVec.packedBinOp {w : Nat} (c : Nat) (op : BitVec c → BitVec c → BitVec c) (a b : BitVec w) : BitVec w :=
+  if _ : c = 0 ∨ w < c then
+    a -- Fallback/Base case (w = 0 or invalid chunk size)
+  else
+    -- Extract the lowest chunk
+    let a_low := a.take c
+    let b_low := b.take c
+    let res_low := op a_low b_low
+
+    -- Recursively process the remaining high bits
+    let a_high := a.drop c
+    let b_high := b.drop c
+    let res_high := BitVec.packedBinOp c op a_high b_high
+
+    -- Recombine: res_high is the high part, res_low is the low part
+    (BitVec.append res_high res_low).setWidth _
+termination_by w
+decreasing_by omega
+
+def BitVec.toFloat32 (v : BitVec 32) : Float32 :=
+  Float32.ofBits (UInt32.ofBitVec v)
+
+def Float32.toBitVec (f : Float32) : BitVec 32 :=
+  UInt32.toBitVec (Float32.toBits f)
+
 structure StatusFlags where
   cf : Bool
   pf : Bool
@@ -209,6 +234,7 @@ instance : NondetSupportingType StatusFlags := .statusFlags
 inductive Effects
   | done (a : MachineData × Int64)
   | unimplemented (msg : String)
+  | gp_unaligned (addr : BitVec 64) (w : Nat)
   -- loads and stores *outside* the data memory, eg. MMIO, might still affect the data memory:
   -- for instance, MMIO reads/writes at certain device register addresses might change what
   -- data memory the process logically owns vs what memory is owned by devices
@@ -248,11 +274,14 @@ def MachineData.load
 
 def MachineData.loadAvx
   (s : MachineData) (addr : BitVec 64) (w : AvxWidth)
-  (ret : w.type → MachineData → Effects): Effects :=
-  require_read_access addr .W64 (fun _unit =>
-match Mem.loadInt s.dmem addr w.bytes with
-    | .some i => ret (.ofInt _ i) s
-    | .none => unimplemented "AVX nonmem load not supported")
+  (ret : w.type → MachineData → Effects) (checkAlign : Bool := false) : Effects :=
+  if checkAlign && (addr &&& BitVec.ofNat 64 (w.bytes - 1)) != 0#64 then
+    .gp_unaligned addr w.bytes
+  else
+    require_read_access addr .W64 (fun _unit =>
+  match Mem.loadInt s.dmem addr w.bytes with
+      | .some i => ret (.ofInt _ i) s
+      | .none => unimplemented "AVX nonmem load not supported")
 
 def MachineData.store (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.type) (ret: MachineData → Effects) : Effects :=
   require_write_access addr w (fun _unit =>
@@ -261,12 +290,15 @@ def MachineData.store (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.ty
         ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
     | .none => nonmem_store s.dmem addr v (fun dmem' => ret { s with dmem := dmem' }))
 
-def MachineData.storeAvx (s : MachineData) (addr : BitVec 64) {w : AvxWidth} (v : w.type) (ret: MachineData → Effects) : Effects :=
-  require_write_access addr .W64 (fun _unit =>
-match Mem.loadInt s.dmem addr w.bytes with
-    | .some _ =>
-        ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
-    | .none => unimplemented "AVX nonmem store not supported")
+def MachineData.storeAvx (s : MachineData) (addr : BitVec 64) {w : AvxWidth} (v : w.type) (ret: MachineData → Effects) (checkAlign : Bool := false) : Effects :=
+  if checkAlign && (addr &&& BitVec.ofNat 64 (w.bytes - 1)) != 0#64 then
+    .gp_unaligned addr w.bytes
+  else
+    require_write_access addr .W64 (fun _unit =>
+  match Mem.loadInt s.dmem addr w.bytes with
+      | .some _ =>
+          ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
+      | .none => unimplemented "AVX nonmem store not supported")
 
 class Labels where label : Label → Int64
 export Labels (label)
@@ -298,10 +330,10 @@ match o with
 
 def AvxRegOrMem.interp {w} [Labels] [AddressSize]
   (o : AvxRegOrMem w) (s : MachineData) (p : Std.Rco Int64)
-  (ret : w.type → MachineData → Effects) :=
+  (ret : w.type → MachineData → Effects) (checkAlign : Bool := false) :=
 match o with
   | .avx r => ret (s.zmms.get r) s
-  | .mem a => s.loadAvx ((a.interp s.regs p).zeroExtend _) w ret
+  | .mem a => s.loadAvx ((a.interp s.regs p).zeroExtend _) w ret checkAlign
 
 def MachineData.setReg (s : MachineData) {w} (r : Reg w) (v : w.type) : MachineData :=
   { s with regs := s.regs.set r v }
@@ -317,15 +349,15 @@ def MachineData.set {w} [Labels] [AddressSize] (s : MachineData) (d : Dst w) (v 
   | .reg r => ret (s.setReg r v)
   | .mem a => s.store ((a.interp s.regs p).zeroExtend _) v ret
 
-def MachineData.setAvx {aw} [Labels] [AddressSize] (s : MachineData) (d : AvxDst aw) (v : aw.type) (p : Std.Rco Int64) (ret : MachineData → Effects) : Effects :=
+def MachineData.setAvx {aw} [Labels] [AddressSize] (s : MachineData) (d : AvxDst aw) (v : aw.type) (p : Std.Rco Int64) (ret : MachineData → Effects) (checkAlign : Bool := false) : Effects :=
 match d with
   | .avx r => ret (s.setAvxReg r v)
-  | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v ret
+  | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v ret checkAlign
 
-def MachineData.setAvxLegacy {w} [Labels] [AddressSize] (s : MachineData) (d : AvxDst w) (v : w.type) (p : Std.Rco Int64) (ret : MachineData → Effects) : Effects :=
+def MachineData.setAvxLegacy {w} [Labels] [AddressSize] (s : MachineData) (d : AvxDst w) (v : w.type) (p : Std.Rco Int64) (ret : MachineData → Effects) (checkAlign : Bool := false) : Effects :=
 match d with
   | .avx r => ret (s.setAvxLegacyReg r v)
-  | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v ret
+  | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v ret checkAlign
 
 def Operand.interp {w} [Labels] [AddressSize]
   (o : Operand w) (s : MachineData) (p : Std.Rco Int64)
@@ -337,9 +369,9 @@ def Operand.interp {w} [Labels] [AddressSize]
 
 def AvxOperand.interp {aw} [Labels] [AddressSize]
   (o : AvxOperand aw) (s : MachineData) (p : Std.Rco Int64)
-  (ret : aw.type → MachineData → Effects) :=
+  (ret : aw.type → MachineData → Effects) (checkAlign : Bool := false) :=
 match o with
-  | regOrMem rm => rm.interp s p ret
+  | regOrMem rm => rm.interp s p ret checkAlign
 
 def CondCode.interp (cc : CondCode) (s : StatusFlags) : Bool := match cc with
   | .z  => s.zf | .nz => !s.zf | .c  => s.cf | .nc => !s.cf
@@ -671,6 +703,28 @@ def AvxOperation.interp [Labels] [address_size : AddressSize]
 match i with
   | .movups dst src => src.interp s p (fun val s => s.setAvxLegacy dst val p next)
   | .vmovups dst src => src.interp s p (fun val s => s.setAvx dst val p next)
+  | .movaps dst src =>
+    src.interp s p (checkAlign := true)
+      (fun val s => s.setAvxLegacy dst val p (checkAlign := true) next)
+  -- TODO: MXCSR
+  | .subps dst src =>
+    src.interp s p (checkAlign := true) (fun a s =>
+    dst.interp s p (fun b s =>
+      let v := BitVec.packedBinOp 32 (fun dst_chunk src_chunk =>
+        let f_dst := BitVec.toFloat32 dst_chunk
+        let f_src := BitVec.toFloat32 src_chunk
+        Float32.toBitVec (f_dst - f_src)
+      ) b a
+      s.setAvxLegacy dst v p next))
+  | .addps dst src =>
+    src.interp s p (checkAlign := true) (fun a s =>
+    dst.interp s p (fun b s =>
+      let v := BitVec.packedBinOp 32 (fun dst_chunk src_chunk =>
+        let f_dst := BitVec.toFloat32 dst_chunk
+        let f_src := BitVec.toFloat32 src_chunk
+        Float32.toBitVec (f_dst + f_src)
+      ) b a
+      s.setAvxLegacy dst v p next))
 
 def Instr.interp [Labels]
   (i : Instr) (s : MachineData) (p : Std.Rco Int64)
@@ -751,6 +805,7 @@ where
     match es with
     | .done s => eval e s until_
     | .unimplemented msg => .error msg
+    | .gp_unaligned addr w => .error s!"#GP: Memory op at {repr addr} did not have mandatory alignment of {w}"
     | .require_read_access _ _ ok => handleEffects (ok ())
     | .require_write_access _ _ ok => handleEffects (ok ())
     | .require_exec_access _ ok => handleEffects (ok ())

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -169,6 +169,8 @@ def RegZmms.setLegacy (s : RegZmms) {w} (r : AvxReg w) (v : w.type) : RegZmms :=
 def BitVec.toAddressSize [address_size: AddressSize] (w: BitVec 64): BitVec address_size.address_size.bits :=
   w.take address_size.address_size.bits
 
+-- TODO: consider adding a `split` helper to switch representations between
+-- u128, 4xu32, etc.
 def BitVec.packedBinOp {w : Nat} (c : Nat) (op : BitVec c → BitVec c → BitVec c) (a b : BitVec w) : BitVec w :=
   if _ : c = 0 ∨ w < c then
     a -- Fallback/Base case (w = 0 or invalid chunk size)

--- a/Kraken/X64/Syntax.lean
+++ b/Kraken/X64/Syntax.lean
@@ -234,9 +234,14 @@ inductive Operation (w : Width)
   | nopalign (alignment : Nat) (pad : Option Nat)
   deriving Repr, DecidableEq, Hashable, Lean.ToExpr
 
+-- The non-v* variants take SSE registers only.
+-- TODO: AVX512 extensions (write-masking, ...)
 inductive AvxOperation (w : AvxWidth)
-  | movups (_ : AvxDst w) (src : AvxRegOrMem w) -- sse regs only (TODO: constrain to .W128)
+  | movups (_ : AvxDst w) (src : AvxRegOrMem w)
   | vmovups (_ : AvxDst w) (src : AvxRegOrMem w)
+  | movaps (_ : AvxDst w) (src : AvxRegOrMem w)
+  | subps (_ : AvxDst w) (src : AvxRegOrMem w)
+  | addps (_ : AvxDst w) (src : AvxRegOrMem w)
   deriving Repr, DecidableEq, Hashable, Lean.ToExpr
 
 inductive Instr

--- a/Kraken/X64/Test/asm/test_sse_math.S
+++ b/Kraken/X64/Test/asm/test_sse_math.S
@@ -1,0 +1,24 @@
+# Test: SSE legacy math insns
+
+# The stack should be dqword-aligned (so all m128 ops are OK)
+subq $0x20, %rsp
+movl $0xbf800000, 28(%rsp)  # -1.0f
+movl $0x3f800000, 24(%rsp)  # 1.0f
+movl $0x3f800000, 20(%rsp)  # 1.0f
+movl $0xbf800000, 16(%rsp)  # -1.0f  <-1.0f, 1.0f, 1.0f, -1.0f>
+movl $0x3f800000, 12(%rsp)  # 1.0f
+movl $0x40000000, 8(%rsp)   # 2.0f
+movl $0x3fc00000, 4(%rsp)   # 1.5f
+movl $0x3f000000, 0(%rsp)   # 0.5f   <0.5f, 1.5f, 2.0f, 1.0f>
+
+movaps 0(%rsp), %xmm0
+movaps 0(%rsp), %xmm1
+movaps 16(%rsp), %xmm2
+addps %xmm1, %xmm2
+
+movaps 0(%rsp), %xmm3
+movaps 0(%rsp), %xmm4
+movaps 16(%rsp), %xmm5
+subps %xmm1, %xmm2
+
+addq $0x20, %rsp

--- a/Kraken/X64/Test/asm/test_sse_math.S
+++ b/Kraken/X64/Test/asm/test_sse_math.S
@@ -19,6 +19,6 @@ addps %xmm1, %xmm2
 movaps 0(%rsp), %xmm3
 movaps 0(%rsp), %xmm4
 movaps 16(%rsp), %xmm5
-subps %xmm1, %xmm2
+subps %xmm4, %xmm5
 
 addq $0x20, %rsp


### PR DESCRIPTION
Implement more legacy SSE insns with varying alignment requirements;
implement alignment checks as effects.

It is a little confusing to work out the tolerance (eg) ADDPS has for
unaligned m128s. The Intel SDM page for ADDPS only lists Table 2-19 ("Type
2 Class Exception Conditions") as a reference for VEX-encoded insns (which
legacy ADDPS is not), but section 2.5 ("Intel AVX and Intel SSE
Instruction Exception Classification"), which actually uses ADDPS as an
example, reads that ADDPS 'contains the entry "See Exceptions Type 2"',
leading with 'To look up the exceptions of legacy 128-bit SIMD
instructions...'. This shows that ADDPS raises #GP(0) for unaligned
addresses. (Curiously, the AVX variants do *not* require alignment.)

Note that ADDPS/SUBPS do not allow m128 dest ops.