### PR TITLE
Fix what seems to be some confusion in the computation of start addresses of instructions

### DIFF
--- a/Kraken/X64/OmniSemantics.lean
+++ b/Kraken/X64/OmniSemantics.lean
@@ -77,8 +77,16 @@ theorem reg_dec_loop {State : Type} (trans : State → Post → Prop) (post : Po
         (hnz initial n h hinv) fun s hs =>
           reg_dec_loop trans post s invariant (n - 1) ⟨hs, hzero, hnz⟩
 
-def step1 [Layout] (p: Executable) (s: MachineState) (post: @Post MachineState) : Prop :=
-  (Executable.step p s .done).All post
+def step1 [Layout] (e: Executable) (s: MachineState) (post: @Post MachineState) : Prop :=
+  (Executable.step e s .done).All post
 
-def straightlineStep [Layout] (p: Executable) (s: MachineState) (post: @Post MachineState) : Prop :=
-  (Executable.straightline p s .done).All post
+def straightlineStep [Layout] (e: Executable) (s: MachineState) (post: @Post MachineState) : Prop :=
+  (Executable.straightline e s .done).All post
+
+theorem directivesAtFromPrefix (e: Executable) (a: Int64):
+  ∃ rest, e.directivesFromAddress a = e.directivesAtAddress a ++ rest
+:= by
+  dsimp [Executable.directivesFromAddress, Executable.directivesAtAddress]
+  refine ⟨((e.withAddresses.dropWhile (·.1 ≠ a)).dropWhile (·.1 = a)).map (·.2), ?_⟩
+  rw [← List.map_append]
+  rw [List.takeWhile_append_dropWhile]

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -700,14 +700,23 @@ def Directives.interp [Labels]
     d.interp s (.mk pc (pc+.ofNat sz)) (jmp:=ret) (next := (fun s =>
     interp ds s (pc+.ofNat sz) ret))
 
+-- JP: why is `size` not `Directive → Nat`?
 class Layout where (start : Int64) (size : Nat → Nat)
 def Layout.apply (l : Layout) (prog : Program) : Executable :=
   (l.start, prog.mapIdx (fun i d => (d, l.size i)))
 instance : CoeFun Layout (fun _ => Program → Executable) where coe := Layout.apply
 
-def Executable.withAddresses (e : Executable)  : List (Int64 × Directive × Nat) :=
-  (List.scanl (fun (p, _, _) (d, z) => (p+.ofNat z, d, z)) (e.1, .byteArray (.mk #[]), 0) e.2)
+-- Returns each directive paired with its start address and size.
+-- TODO: tail-recursive version for efficiency?
+def Executable.withAddresses (e : Executable): List (Int64 × Directive × Nat) :=
+  let (start_addr, ds) := e
+  match ds with
+  | [] => []
+  | (instr, instr_sz) :: ds =>
+    (start_addr, instr, instr_sz) :: Executable.withAddresses (start_addr + .ofNat instr_sz, ds)
+termination_by e.2
 
+@[reducible]
 def Executable.labels (e : Executable) : Labels :=
   { label l := (e.withAddresses.findSome?
       (fun (p, d, _) => if d = .label l then .some p else .none)).getD (-1) }

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -722,10 +722,12 @@ def Executable.labels (e : Executable) : Labels :=
       (fun (p, d, _) => if d = .label l then .some p else .none)).getD (-1) }
 
 def Executable.directivesAtAddress (e : Executable) (a : Int64) : List (Directive × Nat) :=
-  (e.withAddresses.filter (·.1 = a)).map (·.2)
+  let starts_at_a := e.withAddresses.dropWhile (·.1 ≠ a)
+  (starts_at_a.takeWhile (·.1 = a)).map (·.2)
 
 def Executable.directivesFromAddress (e : Executable) (a : Int64) : List (Directive × Nat) :=
-  e.2.drop (((e.withAddresses).map (·.1)).idxOf a)
+  let starts_at_a := e.withAddresses.dropWhile (·.1 ≠ a)
+  starts_at_a.map (·.2)
 
 def Executable.directivesFromLabel (e : Executable) (l : Label) : List (Directive × Nat) :=
   e.2.dropWhile (·.1 != .label l)

--- a/Kraken/X64/Tactics.lean
+++ b/Kraken/X64/Tactics.lean
@@ -2,11 +2,34 @@ import Kraken.X64.Syntax
 import Kraken.X64.Semantics
 import Kraken.X64.OmniSemantics
 
+theorem Executable.withAddresses_map_snd (ds : List (Directive × Nat)) (a : Int64) :
+    (Executable.withAddresses (a, ds)).map (·.2) = ds := by
+  induction ds generalizing a with
+  | nil =>
+    unfold Executable.withAddresses
+    rfl
+  | cons d ds ih =>
+    unfold Executable.withAddresses
+    dsimp
+    rw [ih (a + .ofNat d.2)]
+
+theorem Executable.withAddresses_dropWhile_start (ds : List (Directive × Nat)) (a : Int64) :
+    (Executable.withAddresses (a, ds)).dropWhile (fun x => x.1 ≠ a) =
+      Executable.withAddresses (a, ds) := by
+  cases ds with
+  | nil =>
+    unfold Executable.withAddresses
+    rfl
+  | cons d ds =>
+    unfold Executable.withAddresses
+    simp [List.dropWhile]
+
 theorem Executable.directivesFromStart [layout : Layout] prog :
     (layout prog).directivesFromAddress layout.start =
       prog.mapIdx (fun i d => (d, layout.size i)) := by
-  induction prog <;>
-    simp [Executable.directivesFromAddress, Executable.withAddresses, Layout.apply]
+  dsimp [Executable.directivesFromAddress, Layout.apply]
+  rw [Executable.withAddresses_dropWhile_start]
+  rw [Executable.withAddresses_map_snd]
 
 macro "kprologue" p:ident : tactic =>
   `(tactic|


### PR DESCRIPTION
As I was trying to write a lemma that relates step1 and straightlineStep, I found myself trying to prove some basic properties, namely that directivesAt returns a prefix of directivesFrom.

I then bottomed out on the `withAddresses` function. My understanding is that `withAddresses` means: pair each instruction with its start address. I believe it is a start address because:
- directivesAtAddress returns all instructions located at that address
- furthermore, in Instruction.interp, we compute a Rco (range closed-open) that starts at pc (i.e. where the instruction was found) and ends at the "end" of the instruction (computed by adding the instruction size to the pc).

In short, it definitely looks like withAddresses really means withStartAddresses. But that's not what happens.

Here's a concrete example:

```
#eval
  let exe := Program.fakeLayout [
    .label "main",
    .instr (.mk .W64 .W64 (.lea (.low .rax .W64) (.mk .none .none (.int64 41)))),
    .instr (.mk .W64 .W64 (.inc (.reg (.low .rax .W64)))),
    .instr (.mk .W64 .W64 .ret) ]
  exe.withAddresses
```

By that logic, I would expect the `lea` to be located at the same address as the label. After all, labels have no size. But we get this:

```
 633:1-633:6: information:
[(4075551246440333312, Directive.byteArray { data := #[] }, 0), (4075551246440333312, Directive.label "main", 0),
  (4075551246440333320,
    Directive.instr
      { address_size := Width.W64, operation_size := Width.W64,
        operation := Operation.lea (Reg.low Reg64.rax Width.W64) { base := none, idx := none, disp := ↑41 } },
    8),
  (4075551246440333326,
    Directive.instr
      { address_size := Width.W64, operation_size := Width.W64,
        operation := Operation.inc ↑(Reg.low Reg64.rax Width.W64) },
    6),
  (4075551246440333333,
    Directive.instr { address_size := Width.W64, operation_size := Width.W64, operation := Operation.ret }, 7)]
```

In short, the `lea` and the label are located at different addresses. I believe this is incorrect.

This patch:
- fixes the issue by rewriting withAddresses using custom logic (perhaps this function ought to be rewritten as a tail-recursive one, let's see if this blocks us)
- rewrites directivesAt and directivesFrom to be more obvious
- leverages the rewritten definitions to state that one is a prefix of the other (likely needed for the lemma I'm trying to write)
- fixes the helper that relates layout and directivesFromStart
