### PR TITLE
fix(x64): properly parse + print displacements for rip-relative mem operands

### DIFF
--- a/Kraken/X64/Parser.lean
+++ b/Kraken/X64/Parser.lean
@@ -367,6 +367,12 @@ def parseMemory : Parser (Width × AddrExpr) := do
     | w1, .none =>
       .pure w1
   let idx := Option.map (fun (_, idx) => ⟨idx, scale⟩) idx
+
+  -- Handle rip-relative addressing (like parseRelRegOrMem below).
+  let disp := match base, disp with
+    | .rip, .label l => .sub (.label l) .after_current_instruction
+    | _, _ => disp
+
   pure (w, { base, idx, disp })
 
 def parseImm w : Parser (Operand w) := do

--- a/Kraken/X64/PrintIntel.lean
+++ b/Kraken/X64/PrintIntel.lean
@@ -64,11 +64,17 @@ def ConstExpr.toStr : ConstExpr → String
   | .sub e1 e2 => s!"({e1.toStr} - {e2.toStr})"
 instance : ToString ConstExpr where toString := ConstExpr.toStr
 
-def AddrExpr.toStr (a : AddrExpr) (addr_w : Width := .W64) : String := "["++ "+".intercalate (
-  (match a.base with | .some b => [b.toStr addr_w] | _ => [])
-  ++(match a.idx with | .some ⟨r, s⟩ => [s!"{Reg.low r addr_w}*{s.bytes}"] | _ => [])
-  ++[toString a.disp]) ++ "]"
-instance : ToString AddrExpr where toString a := a.toStr
+def AddrExpr.toStr (a : AddrExpr) (addr_w : Width := .W64) : String :=
+  let dispStr := match a.base, a.disp with
+    -- Unwrap RIP-relative displacements back to just the label for printing
+    -- (like RelRegOrMem.toStr below)
+    | .some .rip, .sub e .after_current_instruction => toString e
+    | _, _ => toString a.disp
+  "[" ++ "+".intercalate (
+    (match a.base with | .some b => [b.toStr addr_w] | _ => [])
+    ++ (match a.idx with | .some ⟨r, s⟩ => [s!"{Reg.low r addr_w}*{s.bytes}"] | _ => [])
+    ++ [dispStr]
+  ) ++ "]"
 
 def RegOrMem.toStr {w} (rm : RegOrMem w) (addr_w : Width := .W64) : String := match rm with
   | .reg r => ToString.toString r

--- a/Kraken/X64/Test/asm/test_rip_offset.S
+++ b/Kraken/X64/Test/asm/test_rip_offset.S
@@ -1,0 +1,5 @@
+  lea (%rip), %rax
+next:
+  lea next(%rip), %rcx
+  subq %rcx, %rax
+  movl $0, %ecx


### PR DESCRIPTION
We were correctly handling this in parseRelRegOrMem, but not in parseMemory.

Why didn't the roundtrip test catch this?

Consider this test program:

```asm
  lea (%rip), %rax
next:
  lea next(%rip), %rcx
  subq %rcx, %rax
  movl $0, %ecx
```

Prior to the parser fix, this is the Intel syntax we emit:

```asm
.intel_syntax noprefix
lea rax, [rip+0]
next:
lea rcx, [rip+next]
sub rax, rcx
mov ecx, 0
```

Unfortunately, `[rip+next]` happens to be the GNU assembler version of `next(%rip)`, so we generate an equivalent program despite not having built the proper representation. (side note: I'm pretty certain this logic does belong in the parser, not in Semantics.)

After the parser fix, we instead generate:

```asm
.intel_syntax noprefix
lea rax, [rip+0]
next:
lea rcx, [rip+(next - .)]
sub rax, rcx
mov ecx, 0
```

Now it doesn't roundtrip! The second `lea` changes from:

`-0x7(%rip),%rcx`

to

`0x0(%rip),%rcx`

It turns out that we also need to make a symmetrical fix in PrintIntel, where we also special-case `.rel (.sub e .after_current_instruction)`.