### PR TITLE
Add named registers to kprologue

### DIFF
--- a/Kraken/X64/Examples/Examples.lean
+++ b/Kraken/X64/Examples/Examples.lean
@@ -23,7 +23,7 @@ def p1 := parse("start: mov $1, %rax")
 
 -- Super-simple example to debug tactics
 example [layout : Layout] s : straightlineStep (layout p1) (s, layout.start) (fun s => s.1.regs.rax = 1) := by
-  kprologue p1
+  kprologue p1 with s
   sym => kstep; tactic =>
   decide
   /- simp [Instr.interp,Operation.interp,Operand.interp,MachineData.set] -/
@@ -43,7 +43,7 @@ theorem swap_correct [layout : Layout] (d : MachineData) :
           s'.1.regs.get Reg.rbx = d.regs.get Reg.rax)
       (d, layout.start) := by
   apply step_cps
-  kprologue swap
+  kprologue swap with d
   sym => kstep; tactic =>
   apply Eventually.done
   grind
@@ -59,7 +59,7 @@ start:
 -- Example 2: stepping through both straightline and control instructions
 example [layout : Layout] (s : MachineData): Eventually (straightlineStep (layout p2)) (fun s => s.1.regs.rax = 2) (s, layout.start) := by
   apply step_cps
-  kprologue p2 
+  kprologue p2 with s
   sym =>
   kstep
   tactic =>
@@ -99,7 +99,7 @@ theorem p3_correct [layout: Layout] (s: MachineData):
   by
     intros h_bounds
     apply step_cps
-    kprologue p3
+    kprologue p3 with s
 
     sym =>
     -- kstep 3
@@ -194,14 +194,7 @@ dec %rax")
 
 -- Super-simple example to debug tactics
 example [layout : Layout] s : straightlineStep (layout p4) (s, layout.start) (fun s => s.1.regs.rax = 1) := by
-  -- Refine the state to make registers apparent -- note that `cases` consumes
-  -- the hypothesis, and substitutes it, so we make a copy of it to have a
-  -- refined state in the hypotheses, not the goal.
-  let ss := s
-  change (straightlineStep _ (ss, _) _)
-  cases s with | mk regs flags mem =>
-  cases regs with | mk rax =>
-  kprologue p4
+  kprologue p4 with s
   sym =>
   kstep
   -- intros
@@ -220,14 +213,7 @@ set_option pp.rawOnError true
 /- set_option pp.all true -/
 
 example [layout : Layout] s : straightlineStep (layout p5) (s, layout.start) (fun s => s.1.regs.rax = 0) := by
-  -- Refine the state to make registers apparent -- note that `cases` consumes
-  -- the hypothesis, and substitutes it, so we make a copy of it to have a
-  -- refined state in the hypotheses, not the goal.
-  let ss := s
-  change (straightlineStep _ (ss, _) _)
-  cases s with | mk regs flags mem =>
-  cases regs with | mk rax =>
-  kprologue p5
+  kprologue p5 with s
   sym => kstep; tactic =>
   bv_decide
 
@@ -272,12 +258,8 @@ theorem p6_correct [layout : Layout] (s₀ : MachineData)
       (fun s' => s'.1.regs.rax = s₀.regs.rax ∧ s'.1.regs.rsp = s₀.regs.rsp)
       (s₀, layout.start) := by
   apply step_cps
-  let ss := s₀
-  change (straightlineStep _ (ss, _) _)
-  cases s₀ with | mk regs zmms flags mem =>
-  cases regs with | mk rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15 =>
+  kprologue p6 with s₀
   have h_bs : stack.length = 8 := h_len
-  kprologue p6
   have h_mem1 := Mem.storeInt_sep (rsp.toBitVec - 8#64) 8 stack R mem ⟨h_mem, h_bs⟩ rax.toBitVec.toInt
   sym =>
   kstep
@@ -336,9 +318,7 @@ theorem move_2_regs_to_heap_correct [layout : Layout] (s₀ : MachineData)
         s'.1.regs.rdi = s₀.regs.rdi)
       (s₀, layout.start) := by
   apply step_cps
-  cases s₀ with | mk regs zmms flags mem =>
-  cases regs with | mk rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15 =>
-  kprologue move_2_regs_to_heap
+  kprologue move_2_regs_to_heap with s₀
 
   have h_bs1 : v1.toBytes.length = 8 := UInt64.toBytes_length v1
   have h_bs2 : v2.toBytes.length = 8 := UInt64.toBytes_length v2
@@ -387,10 +367,8 @@ theorem sib_example_correct [layout : Layout] (s₀ : MachineData)
       (fun s' => s'.1.regs.rax = 42)
       (s₀, layout.start) := by
   apply step_cps
-  cases s₀ with | mk regs zmms flags mem =>
-  cases regs with | mk rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15 =>
+  kprologue sib_example with s₀
   have h_bs : v.toBytes.length = 8 := UInt64.toBytes_length v
-  kprologue sib_example
   simp at h_mem
   have h_mem' := Mem.storeInt_sep (rdi.toBitVec + BitVec.ofInt 64 (r15.toBitVec.toInt * 8)) 8 v.toBytes R mem ⟨h_mem, h_bs⟩ 42
   sym =>
@@ -419,10 +397,8 @@ theorem alu_mem_example_correct [layout : Layout] (s₀ : MachineData)
       (fun s' => s'.1.regs.rcx = 142)
       (s₀, layout.start) := by
   apply step_cps
-  cases s₀ with | mk regs zmms flags mem =>
-  cases regs with | mk rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15 =>
+  kprologue alu_mem_example with s₀
   have h_bs : v.toBytes.length = 8 := UInt64.toBytes_length v
-  kprologue alu_mem_example
   have h_mem1 := Mem.storeInt_sep (rdx.toBitVec + 136#64) 8 v.toBytes R mem ⟨h_mem, h_bs⟩ 42
   sym =>
   kstep
@@ -459,10 +435,7 @@ theorem dynamic_stack_example_correct [layout : Layout] (s₀ : MachineData)
       (fun s' => s'.1.regs.rax = 42 ∧ s'.1.regs.rbx = 99 ∧ s'.1.regs.rsp = s₀.regs.rsp)
       (s₀, layout.start) := by
   apply step_cps
-  let ss := s₀
-  change (straightlineStep _ (ss, _) _)
-  cases s₀ with | mk regs zmms flags mem =>
-  cases regs with | mk rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15 =>
+  kprologue dynamic_stack_example with s₀
   have h_bs : stack.length = 1024 := lstack
   have h_take_drop : stack = stack.take 1016 ++ stack.drop 1016 := by exact (List.take_append_drop 1016 stack).symm
   rw [h_take_drop] at h_mem
@@ -479,7 +452,6 @@ theorem dynamic_stack_example_correct [layout : Layout] (s₀ : MachineData)
   change (Eq ((stack.take 1016 ++ stack.drop 1016).At (rsp.toBitVec - 1024#64)) ⋆ R) mem at h_mem
   rw [h_At_append] at h_mem
   rw [sep_assoc] at h_mem
-  kprologue dynamic_stack_example
   have h_addr_eq : rsp.toBitVec - 1024#64 + BitVec.ofNat 64 (stack.take 1016).length = rsp.toBitVec + BitVec.ofNat 64 (2^64 - 8) := by
     rw [h_len_take]
     change rsp.toBitVec - 1024#64 + 1016#64 = rsp.toBitVec + BitVec.ofNat 64 (2^64 - 8)

--- a/Kraken/X64/Tactics.lean
+++ b/Kraken/X64/Tactics.lean
@@ -31,12 +31,82 @@ theorem Executable.directivesFromStart [layout : Layout] prog :
   rw [Executable.withAddresses_dropWhile_start]
   rw [Executable.withAddresses_map_snd]
 
-macro "kprologue" p:ident : tactic =>
-  `(tactic|
-    (delta $p
-     dsimp only [straightlineStep, Executable.straightline]
-     rw [Executable.directivesFromStart]
-     simp [List.mapIdx, List.mapIdx.go]))
+/-- Set up a straight-line proof for `p` from `s`, naming the state fields and
+general-purpose registers. `status` and `dmem` are called `flags` and `mem`. -/
+syntax (name := kprologue) "kprologue" ident "with" ident : tactic
+
+private def kprologueBinderName (field : Lean.Name) : Lean.Name :=
+  if field == `status then `flags
+  else if field == `dmem then `mem
+  else field
+
+open Lean Meta Elab Tactic in
+elab_rules : tactic
+  | `(tactic| kprologue $p:ident with $s:ident) => withMainContext do
+      let env ← getEnv
+      let state ← Term.elabTerm s none
+      let stateType ← whnf (← inferType state)
+      let some stateName := stateType.getAppFn.constName?
+        | throwErrorAt s "kprologue: expected a state with a structure type"
+      let some _ := getStructureInfo? env stateName
+        | throwErrorAt s "kprologue: `{stateName}` is not a structure"
+
+      let stateFields := getStructureFields env stateName
+      let some regsInfo := getFieldInfo? env stateName `regs
+        | throwErrorAt s "kprologue: `{stateName}` has no `regs` field"
+      let regs ← mkAppM regsInfo.projFn #[state]
+      let regsType ← whnf (← inferType regs)
+      let some regsName := regsType.getAppFn.constName?
+        | throwErrorAt s "kprologue: `{stateName}.regs` does not have a structure type"
+      let some _ := getStructureInfo? env regsName
+        | throwErrorAt s "kprologue: `{stateName}.regs` is not a structure"
+
+      let regFields := getStructureFields env regsName
+      let stateBinderNames :=
+        (stateFields.filter (· != `regs)).map kprologueBinderName
+      let binderNames := regFields ++ stateBinderNames
+
+      let mut seen : NameSet := {}
+      let mut duplicateNames := #[]
+      for name in binderNames do
+        if seen.contains name then
+          unless duplicateNames.contains name do
+            duplicateNames := duplicateNames.push name
+        else
+          seen := seen.insert name
+      unless duplicateNames.isEmpty do
+        let names := String.intercalate ", " (duplicateNames.toList.map (·.toString))
+        throwErrorAt s "kprologue: duplicate local names: {names}"
+
+      let lctx ← getLCtx
+      let collisions := binderNames.filter fun name =>
+        (lctx.findFromUserName? name).isSome
+      unless collisions.isEmpty do
+        let names := String.intercalate ", " (collisions.toList.map (·.toString))
+        throwErrorAt s
+          "kprologue: refusing to shadow existing locals: {names}"
+
+      -- These binders must remain visible after the tactic, so give them no macro scopes.
+      let regPats ← regFields.mapM fun field =>
+        let id := mkIdentFrom s field
+        `(rcasesPat| $id:ident)
+      let regsPat ← `(rcasesPat| ⟨$[$regPats],*⟩)
+      let statePats ← stateFields.mapM fun field =>
+        if field == `regs then
+          pure regsPat
+        else
+          let id := mkIdentFrom s (kprologueBinderName field)
+          `(rcasesPat| $id:ident)
+      let statePat ← `(rcasesPat| ⟨$[$statePats],*⟩)
+
+      evalTactic (← `(tactic|
+        (let ss := $s
+         change (straightlineStep _ (ss, _) _)
+         obtain $statePat:rcasesPat := $s
+         delta $p
+         dsimp only [straightlineStep, Executable.straightline]
+         rw [Executable.directivesFromStart]
+         simp [List.mapIdx, List.mapIdx.go])))
 
 --------------------------------------------------------------------------------
 

--- a/Kraken/X64/TacticsTests.lean
+++ b/Kraken/X64/TacticsTests.lean
@@ -1,0 +1,22 @@
+import Kraken.X64.Tactics
+
+private def kprologueTestProgram : Program := []
+
+-- The hygienic state alias must not capture an existing `ss`.
+example [layout : Layout] (P : Prop) (ss : Nat) (s : MachineData) (hP : P) :
+    straightlineStep (layout kprologueTestProgram) (s, layout.start) (fun _ => P) := by
+  kprologue kprologueTestProgram with s
+  have _ : Nat := ss
+  have _ : UInt64 := r15
+  have _ : RegZmms := zmms
+  have _ : StatusFlags := flags
+  have _ : DataMem := mem
+  exact hP
+
+/--
+error: kprologue: refusing to shadow existing locals: rax
+-/
+#guard_msgs in
+example [layout : Layout] (rax : UInt64) (s : MachineData) :
+    straightlineStep (layout kprologueTestProgram) (s, layout.start) (fun _ => True) := by
+  kprologue kprologueTestProgram with s


### PR DESCRIPTION
Closes #145.

I figured it is nicer if this is robust to changes in the underlying machine architecture, so I did it in this way. There is a simpler way of course, where we enumerate the registers by hand, but it could introduce annoying migration issues down the line if it isn't updated appropriately.