### PR TITLE
Return control flow as data: relate step1 to straightline, prove p3

### DIFF
--- a/Kraken/AArch64/OmniSemantics.lean
+++ b/Kraken/AArch64/OmniSemantics.lean
@@ -155,8 +155,7 @@ def Executable.ResolvesFallthroughAt (e : Executable) (pc : Int64) : Prop :=
         (Kraken.Directives.takeBlock (e.directivesFromAddress pc)) pc)
 
 /-- A straight-line run executes the block at the current address, then
-continues only on fall-through. A jump ends the run at its target. This is the
-sound form of the step/straightline relation PR #140 was after. -/
+continues only on fall-through. A jump ends the run at its target. -/
 theorem Executable.straightline_eq_step {α : Type}
     (e : Executable) (st : MachineState)
     (h : e.ResolvesFallthroughAt st.2)
@@ -191,8 +190,18 @@ private theorem takeBlock_ne_nil {Directive : Type} {ds : List (Directive × Nat
     by_cases hz : entry.2 = 0 <;>
       simp [Kraken.Directives.takeBlock, hz]
 
+/-- A listing of zero-sized directives is one block. -/
+private theorem takeBlock_of_all_zero {Directive : Type} :
+    ∀ {ds : List (Directive × Nat)}, (∀ d ∈ ds, d.2 = 0) →
+      Kraken.Directives.takeBlock ds = ds
+  | [], _ => rfl
+  | entry :: rest, h => by
+    simp [Kraken.Directives.takeBlock, h entry (List.mem_cons_self ..),
+      takeBlock_of_all_zero (fun d hd => h d (List.mem_cons_of_mem _ hd))]
+
 private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executable)
-    (hres : ∀ pc, e.ResolvesFallthroughAt pc) (post : @Post MachineState) :
+    (hres : ∀ pc, e.ResolvesFallthroughAt pc ∨
+      ∀ d ∈ e.directivesFromAddress pc, d.2 = 0) (post : @Post MachineState) :
     ∀ (n : Nat) (s : MachineState), (e.directivesFromAddress s.2).length ≤ n →
       straightlineStep e s post → Eventually (step1 e) post s := by
   intro n
@@ -216,17 +225,27 @@ private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executabl
       simp only [straightlineStep, Executable.straightline, hnil, Directives.interp,
         Effects.bind, Effects.All] at h
       exact h
-    · -- Peel one block; every fall-through lands at the static address, whose
+    · rcases hres s.2 with hA | hz
+      case inr =>
+        -- Every remaining directive is zero-sized: one step runs the whole
+        -- suffix, which is exactly the straight-line run.
+        apply step_cps
+        unfold straightlineStep at h
+        simp only [Executable.straightline] at h
+        simp only [step1, Executable.step, Executable.stepWithExit]
+        rw [takeBlock_of_all_zero hz]
+        exact Effects.All.imp (fun mid hm => Eventually.done mid hm) h
+      -- Peel one block; every fall-through lands at the static address, whose
       -- fetched suffix is strictly shorter by address coherence.
       apply step_cps
       unfold straightlineStep at h
-      rw [e.straightline_eq_step s (hres s.2)] at h
+      rw [e.straightline_eq_step s hA] at h
       simp only [step1, Executable.step, Executable.stepWithExit] at h ⊢
       rw [@Directives.interp_fallthrough_pc e.labels _ _ _ _ _] at h ⊢
       rw [Effects.all_bind] at h ⊢
       have hdec : (e.directivesFromAddress (Kraken.Directives.fallthroughPC
           (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)) s.2)).length ≤ n := by
-        have hsplit := hres s.2
+        have hsplit := hA
         unfold Executable.ResolvesFallthroughAt at hsplit
         have hblock : Kraken.Directives.takeBlock (e.directivesFromAddress s.2) ≠ [] :=
           takeBlock_ne_nil hnil
@@ -244,14 +263,109 @@ private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executabl
 
 /-- Block-level proofs transfer to the single-step semantics: on an executable
 whose fetches are address-coherent, a spec proved against `straightlineStep`
-holds along `step1` execution. Completes the theorem deferred in #104 and
-resolves the question of #140 with a true statement. -/
+holds along `step1` execution. -/
 theorem Executable.eventually_step1_of_straightlineStep [Layout] (e : Executable)
-    (hres : ∀ pc, e.ResolvesFallthroughAt pc) (s : MachineState)
+    (hres : ∀ pc, e.ResolvesFallthroughAt pc ∨
+      ∀ d ∈ e.directivesFromAddress pc, d.2 = 0) (s : MachineState)
     (post : @Post MachineState) (h : straightlineStep e s post) :
     Eventually (step1 e) post s :=
   eventually_step1_of_straightlineStep_aux e hres post
     (e.directivesFromAddress s.2).length s (Nat.le_refl _) h
+
+/-- Binds push through branches: the canonical form keeps the branch at the
+tree top, where `all_ite` can split it. -/
+theorem Effects.ite_bind {α β : Type} {c : Prop} [Decidable c]
+    (a b : Effects α) (k : α → Effects β) :
+    (if c then a else b).bind k = if c then a.bind k else b.bind k := by
+  by_cases hc : c <;> simp [hc]
+
+attribute [ksimp] Effects.ite_bind
+
+theorem all_ite {α : Type} {c : Prop} [Decidable c] (Q : α → Prop) (a b : Effects α) :
+    (c → Effects.All Q a) → (¬ c → Effects.All Q b) → Effects.All Q (if c then a else b) := by
+  intro ha hb
+  by_cases hc : c
+  · simp [hc]; exact ha hc
+  · simp [hc]; exact hb hc
+
+/-- Every address either fetches coherently (the block there is followed by
+the fetch at its fall-through address) or reaches only zero-sized directives,
+a terminal stutter that a single step runs in full. Concrete sane layouts
+satisfy this, including programs that end in labels; an adversarial
+`Layout.size` (aliasing, wraparound) need not. -/
+def Executable.Resolves (e : Executable) : Prop :=
+  ∀ pc, e.ResolvesFallthroughAt pc ∨
+    ∀ d ∈ e.directivesFromAddress pc, d.2 = 0
+
+instance (e : Executable) (pc : Int64) :
+    Decidable (Executable.ResolvesFallthroughAt e pc) :=
+  inferInstanceAs (Decidable (e.directivesFromAddress pc =
+    Kraken.Directives.takeBlock (e.directivesFromAddress pc) ++
+      e.directivesFromAddress (Kraken.Directives.fallthroughPC
+        (Kraken.Directives.takeBlock (e.directivesFromAddress pc)) pc)))
+
+private theorem dropWhile_ne_eq_nil {α : Type} (p : α → Bool) :
+    ∀ (l : List α), (∀ x ∈ l, p x = true) → l.dropWhile p = []
+  | [], _ => rfl
+  | x :: xs, h => by
+    simp only [List.dropWhile, h x (List.mem_cons_self ..)]
+    exact dropWhile_ne_eq_nil p xs (fun y hy => h y (List.mem_cons_of_mem _ hy))
+
+/-- At an address where nothing starts, the fetch is empty and coherence is
+trivial, so `Resolves` reduces to a check over the finitely many start
+addresses of the executable. -/
+theorem Executable.resolves_of_members (e : Executable)
+    (h : ∀ p ∈ e.withAddresses.map (·.1), e.ResolvesFallthroughAt p ∨
+      ∀ d ∈ e.directivesFromAddress p, d.2 = 0) :
+    Executable.Resolves e := by
+  intro pc
+  by_cases hmem : pc ∈ e.withAddresses.map (·.1)
+  · exact h pc hmem
+  · refine Or.inl ?_
+    have hnil : e.directivesFromAddress pc = [] := by
+      unfold Kraken.Executable.directivesFromAddress
+      have : e.withAddresses.dropWhile (·.1 ≠ pc) = [] := by
+        apply dropWhile_ne_eq_nil
+        intro x hx
+        simp only [ne_eq, decide_eq_true_eq]
+        intro heq
+        exact hmem (List.mem_map.mpr ⟨x, hx, heq⟩)
+      rw [this]
+      rfl
+    unfold Executable.ResolvesFallthroughAt
+    rw [hnil]
+    show ([] : List (Directive × Nat)) = [] ++ e.directivesFromAddress
+        (Kraken.Directives.fallthroughPC [] pc)
+    have : Kraken.Directives.fallthroughPC ([] : List (Directive × Nat)) pc = pc := rfl
+    rw [this, List.nil_append, hnil]
+
+/-- The Eventually-level transfer: a block-granular execution proof yields a
+single-step one on a coherently-laid-out executable. -/
+theorem Executable.eventually_step1_of_eventually_straightlineStep [Layout]
+    (e : Executable) (hres : Executable.Resolves e) (post : @Post MachineState) :
+    ∀ s, Eventually (straightlineStep e) post s → Eventually (step1 e) post s := by
+  intro s h
+  induction h with
+  | done s hp => exact .done s hp
+  | step s mid_p ht _ ih =>
+    exact eventually_trans _ _ _ _
+      (e.eventually_step1_of_straightlineStep hres s mid_p ht)
+      (fun s' hs' => ih s' hs')
+
+-- A trailing zero-sized label is a terminal stutter: coherence holds through
+-- the second disjunct of `Resolves`.
+private def nopThenLabel : Executable :=
+  (0, [(.instr ⟨.W64, .NOP⟩, 4), (.label "end", 0)])
+
+example : Executable.Resolves nopThenLabel := by
+  apply Executable.resolves_of_members
+  intro p hp
+  simp only [nopThenLabel, Kraken.Executable.withAddresses, List.map,
+    List.mem_cons, List.not_mem_nil, or_false] at hp
+  rcases hp with rfl | rfl <;>
+    simp [Executable.ResolvesFallthroughAt, nopThenLabel,
+      Kraken.Executable.directivesFromAddress, Kraken.Executable.withAddresses,
+      List.dropWhile, Kraken.Directives.takeBlock, Kraken.Directives.fallthroughPC]
 
 private def twoNops : Executable :=
   (0, [

--- a/Kraken/AArch64/OmniSemantics.lean
+++ b/Kraken/AArch64/OmniSemantics.lean
@@ -20,16 +20,7 @@ import Kraken.OmniSemantics
 /-- `All` is monotone in its postcondition. -/
 theorem Effects.All.imp {α : Type} {post₁ post₂ : α → Prop} {m : Effects α}
     (h : ∀ a, post₁ a → post₂ a) : m.All post₁ → m.All post₂ := by
-  induction m <;> simp only [Effects.All] <;> intro hall
-  case done a => exact h a hall
-  case unimplemented => exact hall
-  case unaligned_sp => exact hall
-  case nonmem_load => exact hall
-  case nonmem_store => exact hall
-  case undefined ret ih => exact fun v => ih v (hall v)
-  case require_read_access _ _ _ ih => exact ih () hall
-  case require_write_access _ _ _ ih => exact ih () hall
-  case require_exec_access _ _ ih => exact ih () hall
+  induction m <;> simp_all [Effects.All]
 
 /-- Universal interpretation turns effect sequencing into nested `All`. -/
 theorem Effects.all_bind {α β : Type} {m : Effects α} {k : α → Effects β}
@@ -40,16 +31,7 @@ theorem Effects.all_bind {α β : Type} {m : Effects α} {k : α → Effects β}
 /-- `Effects.exec` chooses one of the outcomes described by `Effects.All`. -/
 theorem Effects.exec_ok {α : Type} {post : α → Prop} {m : Effects α} {entropy : UInt64} {a : α}
     (hall : m.All post) (hexec : m.exec entropy = .ok a) : post a := by
-  induction m with
-  | done b => cases hexec; exact hall
-  | unimplemented _ => exact absurd hexec (by simp [Effects.exec])
-  | unaligned_sp _ => exact absurd hexec (by simp [Effects.exec])
-  | nonmem_load _ _ _ _ _ => exact absurd hexec (by simp [Effects.exec])
-  | nonmem_store _ _ _ _ _ => exact absurd hexec (by simp [Effects.exec])
-  | undefined ret ih => exact ih _ (hall _) hexec
-  | require_read_access _ _ _ ih => exact ih () hall hexec
-  | require_write_access _ _ _ ih => exact ih () hall hexec
-  | require_exec_access _ _ ih => exact ih () hall hexec
+  induction m <;> simp_all [Effects.All, Effects.exec] <;> grind
 
 /-- Appending directives extends only the fall-through path; a jump from the
 prefix bypasses the suffix. -/
@@ -171,12 +153,10 @@ theorem Executable.straightlineStep_cut [Layout] (e : Executable)
   unfold straightlineStep Executable.straightline
   dsimp only
   rw [key]
-  simp only [Effects.bind_eq, Effects.bind_assoc]
+  simp only [Effects.bind_assoc]
   rw [Effects.all_bind]
   refine Effects.All.imp (fun ⟨s', ex⟩ hex => ?_) h
-  cases ex with
-  | jump t => exact hex
-  | fallthrough pc' => exact hex
+  cases ex <;> exact hex
 
 /-- The fetched suffix at `pc` decomposes as the block at `pc` followed by the
 fetch at the block's fall-through address. This is the address-coherence fact
@@ -209,28 +189,10 @@ theorem Executable.straightline_eq_step {α : Type}
   rw [← h] at key
   simp only [Executable.straightline, Executable.stepWithExit]
   rw [key]
-  simp only [Effects.bind_eq, Effects.bind_assoc]
+  simp only [Effects.bind_assoc]
   congr 1
   funext ⟨s', ex⟩
   cases ex <;> rfl
-
-/-- A nonempty listing yields a nonempty block. -/
-private theorem takeBlock_ne_nil {Directive : Type} {ds : List (Directive × Nat)}
-    (h : ds ≠ []) : Kraken.Directives.takeBlock ds ≠ [] := by
-  cases ds with
-  | nil => exact absurd rfl h
-  | cons entry rest =>
-    by_cases hz : entry.2 = 0 <;>
-      simp [Kraken.Directives.takeBlock, hz]
-
-/-- A listing of zero-sized directives is one block. -/
-private theorem takeBlock_of_all_zero {Directive : Type} :
-    ∀ {ds : List (Directive × Nat)}, (∀ d ∈ ds, d.2 = 0) →
-      Kraken.Directives.takeBlock ds = ds
-  | [], _ => rfl
-  | entry :: rest, h => by
-    simp [Kraken.Directives.takeBlock, h entry (List.mem_cons_self ..),
-      takeBlock_of_all_zero (fun d hd => h d (List.mem_cons_of_mem _ hd))]
 
 private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executable)
     (hres : ∀ pc, e.ResolvesFallthroughAt pc ∨
@@ -266,7 +228,7 @@ private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executabl
         unfold straightlineStep at h
         simp only [Executable.straightline] at h
         simp only [step1, Executable.step, Executable.stepWithExit]
-        rw [takeBlock_of_all_zero hz]
+        rw [Kraken.Directives.takeBlock_of_all_zero hz]
         exact Effects.All.imp (fun mid hm => Eventually.done mid hm) h
       -- Peel one block; every fall-through lands at the static address, whose
       -- fetched suffix is strictly shorter by address coherence.
@@ -280,14 +242,9 @@ private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executabl
           (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)) s.2)).length ≤ n := by
         have hsplit := hA
         unfold Executable.ResolvesFallthroughAt at hsplit
-        have hblock : Kraken.Directives.takeBlock (e.directivesFromAddress s.2) ≠ [] :=
-          takeBlock_ne_nil hnil
         have hlens := congrArg List.length hsplit
         simp only [List.length_append] at hlens
-        have hpos : 0 < (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)).length := by
-          cases hblk : Kraken.Directives.takeBlock (e.directivesFromAddress s.2) with
-          | nil => exact absurd hblk hblock
-          | cons a l => simp
+        have hpos := Kraken.Directives.takeBlock_length_pos hnil
         omega
       refine Effects.All.imp (fun ⟨s', ex⟩ hex => ?_) h
       cases ex with
@@ -316,10 +273,7 @@ attribute [ksimp] Effects.ite_bind
 
 theorem all_ite {α : Type} {c : Prop} [Decidable c] (Q : α → Prop) (a b : Effects α) :
     (c → Effects.All Q a) → (¬ c → Effects.All Q b) → Effects.All Q (if c then a else b) := by
-  intro ha hb
-  by_cases hc : c
-  · simp [hc]; exact ha hc
-  · simp [hc]; exact hb hc
+  by_cases hc : c <;> simp_all
 
 /-- Every address either fetches coherently (the block there is followed by
 the fetch at its fall-through address) or reaches only zero-sized directives,
@@ -338,11 +292,9 @@ instance (e : Executable) (pc : Int64) :
         (Kraken.Directives.takeBlock (e.directivesFromAddress pc)) pc)))
 
 private theorem dropWhile_ne_eq_nil {α : Type} (p : α → Bool) :
-    ∀ (l : List α), (∀ x ∈ l, p x = true) → l.dropWhile p = []
-  | [], _ => rfl
-  | x :: xs, h => by
-    simp only [List.dropWhile, h x (List.mem_cons_self ..)]
-    exact dropWhile_ne_eq_nil p xs (fun y hy => h y (List.mem_cons_of_mem _ hy))
+    ∀ (l : List α), (∀ x ∈ l, p x = true) → l.dropWhile p = [] := by
+  intro l h
+  induction l <;> simp_all [List.dropWhile]
 
 /-- At an address where nothing starts, the fetch is empty and coherence is
 trivial, so `Resolves` reduces to a check over the finitely many start
@@ -357,20 +309,13 @@ theorem Executable.resolves_of_members (e : Executable)
   · refine Or.inl ?_
     have hnil : e.directivesFromAddress pc = [] := by
       unfold Kraken.Executable.directivesFromAddress
-      have : e.withAddresses.dropWhile (·.1 ≠ pc) = [] := by
-        apply dropWhile_ne_eq_nil
-        intro x hx
-        simp only [ne_eq, decide_eq_true_eq]
-        intro heq
-        exact hmem (List.mem_map.mpr ⟨x, hx, heq⟩)
-      rw [this]
-      rfl
-    unfold Executable.ResolvesFallthroughAt
-    rw [hnil]
-    show ([] : List (Directive × Nat)) = [] ++ e.directivesFromAddress
-        (Kraken.Directives.fallthroughPC [] pc)
-    have : Kraken.Directives.fallthroughPC ([] : List (Directive × Nat)) pc = pc := rfl
-    rw [this, List.nil_append, hnil]
+      rw [dropWhile_ne_eq_nil]
+      · rfl
+      · intro x hx
+        simpa only [ne_eq, decide_eq_true_eq] using
+          fun heq => hmem (List.mem_map.mpr ⟨x, hx, heq⟩)
+    simp [Executable.ResolvesFallthroughAt, hnil, Kraken.Directives.takeBlock,
+      Kraken.Directives.fallthroughPC]
 
 /-- The Eventually-level transfer: a block-granular execution proof yields a
 single-step one on a coherently-laid-out executable. -/

--- a/Kraken/AArch64/OmniSemantics.lean
+++ b/Kraken/AArch64/OmniSemantics.lean
@@ -37,6 +37,93 @@ theorem Effects.all_bind {α β : Type} {m : Effects α} {k : α → Effects β}
     (m.bind k).All post ↔ m.All fun a => (k a).All post := by
   induction m <;> simp [Effects.bind, Effects.All, *]
 
+/-- `Effects.exec` chooses one of the outcomes described by `Effects.All`. -/
+theorem Effects.exec_ok {α : Type} {post : α → Prop} {m : Effects α} {entropy : UInt64} {a : α}
+    (hall : m.All post) (hexec : m.exec entropy = .ok a) : post a := by
+  induction m with
+  | done b => cases hexec; exact hall
+  | unimplemented _ => exact absurd hexec (by simp [Effects.exec])
+  | unaligned_sp _ => exact absurd hexec (by simp [Effects.exec])
+  | nonmem_load _ _ _ _ _ => exact absurd hexec (by simp [Effects.exec])
+  | nonmem_store _ _ _ _ _ => exact absurd hexec (by simp [Effects.exec])
+  | undefined ret ih => exact ih _ (hall _) hexec
+  | require_read_access _ _ _ ih => exact ih () hall hexec
+  | require_write_access _ _ _ ih => exact ih () hall hexec
+  | require_exec_access _ _ ih => exact ih () hall hexec
+
+/-- Appending directives extends only the fall-through path; a jump from the
+prefix bypasses the suffix. -/
+theorem Directives.interp_append [Labels] (ds₁ ds₂ : List (Directive × Nat))
+    (s : MachineData) (pc : Int64) :
+    Directives.interp (ds₁ ++ ds₂) s pc =
+      (Directives.interp ds₁ s pc).bind fun se =>
+        match se with
+        | (s', .fallthrough pc') => Directives.interp ds₂ s' pc'
+        | (s', .jump t) => .done (s', .jump t) := by
+  induction ds₁ generalizing s pc with
+  | nil => rfl
+  | cons hd rest ih =>
+    obtain ⟨d, sz⟩ := hd
+    simp only [List.cons_append, Directives.interp, Effects.bind_eq, Effects.bind_assoc]
+    congr 1
+    funext ⟨s', c⟩
+    cases c with
+    | next => exact ih ..
+    | jmp t => rfl
+
+/-- The append law when the suffix is obtained by fetching at the prefix's
+fall-through address. -/
+theorem Directives.interp_append_from [Labels]
+    (ds rest : List (Directive × Nat))
+    (fetch : Int64 → List (Directive × Nat))
+    (s : MachineData) (pc : Int64)
+    (hrest : fetch (Kraken.Directives.fallthroughPC ds pc) = rest) :
+    Directives.interp (ds ++ rest) s pc =
+      (Directives.interp ds s pc).bind fun se =>
+        match se with
+        | (s', .fallthrough pc') => Directives.interp (fetch pc') s' pc'
+        | (s', .jump t) => .done (s', .jump t) := by
+  induction ds generalizing s pc with
+  | nil =>
+    change fetch pc = rest at hrest
+    simp [Directives.interp, Effects.bind, hrest]
+  | cons hd ds ih =>
+    obtain ⟨d, sz⟩ := hd
+    simp only [List.cons_append, Directives.interp, Effects.bind_eq, Effects.bind_assoc]
+    congr 1
+    funext ⟨s', c⟩
+    cases c with
+    | next =>
+      have hrest' :
+          fetch (Kraken.Directives.fallthroughPC ds (pc + Int64.ofNat sz)) = rest := by
+        simpa [Kraken.Directives.fallthroughPC] using hrest
+      exact ih (s := s') (pc := pc + Int64.ofNat sz) hrest'
+    | jmp t => rfl
+
+/-- Inside a block, every fall-through exit lands at the statically computed
+fall-through address, so a continuation may assume that pc. -/
+theorem Directives.interp_fallthrough_pc [Labels] {α : Type}
+    (ds : List (Directive × Nat)) (s : MachineData) (pc : Int64)
+    (k : MachineData × BlockExit → Effects α) :
+    (Directives.interp ds s pc).bind k =
+      (Directives.interp ds s pc).bind (fun (s', ex) =>
+        match ex with
+        | .fallthrough _ => k (s', .fallthrough (Kraken.Directives.fallthroughPC ds pc))
+        | .jump target => k (s', .jump target)) := by
+  induction ds generalizing s pc with
+  | nil => rfl
+  | cons hd rest ih =>
+    obtain ⟨d, size⟩ := hd
+    simp only [Directives.interp, Effects.bind_eq, Effects.bind_assoc]
+    congr 1
+    funext se
+    obtain ⟨s', ctrl⟩ := se
+    cases ctrl with
+    | next =>
+      simpa [Kraken.Directives.fallthroughPC, List.foldl] using
+        ih s' (pc + Int64.ofNat size)
+    | jmp target => rfl
+
 def step1 [Layout] (e: Executable) (s: MachineState) (post: @Post MachineState) : Prop :=
   (Executable.step e s .done).All post
 
@@ -58,6 +145,114 @@ theorem Executable.runSteps_all_eventually [Layout] (e : Executable) (n : Nat)
       apply step_cps
       exact Effects.All.imp (fun mid hmid => ih mid hmid) (Effects.all_bind.mp h)
 
+/-- The fetched suffix at `pc` decomposes as the block at `pc` followed by the
+fetch at the block's fall-through address. This is the address-coherence fact
+an honest layout provides; `Layout.size` alone does not guarantee it. -/
+def Executable.ResolvesFallthroughAt (e : Executable) (pc : Int64) : Prop :=
+  e.directivesFromAddress pc =
+    Kraken.Directives.takeBlock (e.directivesFromAddress pc) ++
+      e.directivesFromAddress (Kraken.Directives.fallthroughPC
+        (Kraken.Directives.takeBlock (e.directivesFromAddress pc)) pc)
+
+/-- A straight-line run executes the block at the current address, then
+continues only on fall-through. A jump ends the run at its target. This is the
+sound form of the step/straightline relation PR #140 was after. -/
+theorem Executable.straightline_eq_step {α : Type}
+    (e : Executable) (st : MachineState)
+    (h : e.ResolvesFallthroughAt st.2)
+    (ret : MachineState → Effects α) :
+    e.straightline st ret =
+      e.stepWithExit st fun s exit =>
+        match exit with
+        | .fallthrough pc => e.straightline (s, pc) ret
+        | .jump target => ret (s, target) := by
+  obtain ⟨s, pc⟩ := st
+  unfold Executable.ResolvesFallthroughAt at h
+  dsimp only at h
+  have key := @Directives.interp_append_from e.labels
+    (Kraken.Directives.takeBlock (e.directivesFromAddress pc))
+    (e.directivesFromAddress (Kraken.Directives.fallthroughPC
+      (Kraken.Directives.takeBlock (e.directivesFromAddress pc)) pc))
+    e.directivesFromAddress s pc rfl
+  rw [← h] at key
+  simp only [Executable.straightline, Executable.stepWithExit]
+  rw [key]
+  simp only [Effects.bind_eq, Effects.bind_assoc]
+  congr 1
+  funext ⟨s', ex⟩
+  cases ex <;> rfl
+
+/-- A nonempty listing yields a nonempty block. -/
+private theorem takeBlock_ne_nil {Directive : Type} {ds : List (Directive × Nat)}
+    (h : ds ≠ []) : Kraken.Directives.takeBlock ds ≠ [] := by
+  cases ds with
+  | nil => exact absurd rfl h
+  | cons entry rest =>
+    by_cases hz : entry.2 = 0 <;>
+      simp [Kraken.Directives.takeBlock, hz]
+
+private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executable)
+    (hres : ∀ pc, e.ResolvesFallthroughAt pc) (post : @Post MachineState) :
+    ∀ (n : Nat) (s : MachineState), (e.directivesFromAddress s.2).length ≤ n →
+      straightlineStep e s post → Eventually (step1 e) post s := by
+  intro n
+  induction n with
+  | zero =>
+    intro s hlen h
+    haveI := e.labels
+    apply Eventually.done
+    have hnil : e.directivesFromAddress s.2 = [] :=
+      List.eq_nil_of_length_eq_zero (Nat.le_zero.mp hlen)
+    obtain ⟨sd, pc⟩ := s
+    simp only [straightlineStep, Executable.straightline, hnil, Directives.interp,
+      Effects.bind, Effects.All] at h
+    exact h
+  | succ n ih =>
+    intro s hlen h
+    haveI := e.labels
+    by_cases hnil : e.directivesFromAddress s.2 = []
+    · apply Eventually.done
+      obtain ⟨sd, pc⟩ := s
+      simp only [straightlineStep, Executable.straightline, hnil, Directives.interp,
+        Effects.bind, Effects.All] at h
+      exact h
+    · -- Peel one block; every fall-through lands at the static address, whose
+      -- fetched suffix is strictly shorter by address coherence.
+      apply step_cps
+      unfold straightlineStep at h
+      rw [e.straightline_eq_step s (hres s.2)] at h
+      simp only [step1, Executable.step, Executable.stepWithExit] at h ⊢
+      rw [@Directives.interp_fallthrough_pc e.labels _ _ _ _ _] at h ⊢
+      rw [Effects.all_bind] at h ⊢
+      have hdec : (e.directivesFromAddress (Kraken.Directives.fallthroughPC
+          (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)) s.2)).length ≤ n := by
+        have hsplit := hres s.2
+        unfold Executable.ResolvesFallthroughAt at hsplit
+        have hblock : Kraken.Directives.takeBlock (e.directivesFromAddress s.2) ≠ [] :=
+          takeBlock_ne_nil hnil
+        have hlens := congrArg List.length hsplit
+        simp only [List.length_append] at hlens
+        have hpos : 0 < (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)).length := by
+          cases hblk : Kraken.Directives.takeBlock (e.directivesFromAddress s.2) with
+          | nil => exact absurd hblk hblock
+          | cons a l => simp
+        omega
+      refine Effects.All.imp (fun ⟨s', ex⟩ hex => ?_) h
+      cases ex with
+      | jump target => exact Eventually.done _ hex
+      | fallthrough pc' => exact ih _ hdec hex
+
+/-- Block-level proofs transfer to the single-step semantics: on an executable
+whose fetches are address-coherent, a spec proved against `straightlineStep`
+holds along `step1` execution. Completes the theorem deferred in #104 and
+resolves the question of #140 with a true statement. -/
+theorem Executable.eventually_step1_of_straightlineStep [Layout] (e : Executable)
+    (hres : ∀ pc, e.ResolvesFallthroughAt pc) (s : MachineState)
+    (post : @Post MachineState) (h : straightlineStep e s post) :
+    Eventually (step1 e) post s :=
+  eventually_step1_of_straightlineStep_aux e hres post
+    (e.directivesFromAddress s.2).length s (Nat.le_refl _) h
+
 private def twoNops : Executable :=
   (0, [
     (.instr ⟨.W64, .NOP⟩, 4),
@@ -68,7 +263,8 @@ private def twoNops : Executable :=
 example [Layout] (s : MachineData) :
     Eventually (step1 twoNops) (fun st => st.2 = 8) (s, 0) := by
   apply Executable.runSteps_all_eventually twoNops 2
-  simp [twoNops, Executable.runSteps, Executable.step,
-    Kraken.Executable.directivesAtAddress, Kraken.Executable.withAddresses,
+  simp [twoNops, Executable.runSteps, Executable.step, Executable.stepWithExit,
+    BlockExit.pc, Kraken.Directives.takeBlock,
+    Kraken.Executable.directivesFromAddress, Kraken.Executable.withAddresses,
     Directives.interp, Directive.interp, Instr.interp, Operation.interp,
     Effects.bind, Effects.All]

--- a/Kraken/AArch64/OmniSemantics.lean
+++ b/Kraken/AArch64/OmniSemantics.lean
@@ -6,19 +6,69 @@ import Kraken.AArch64.Semantics
 import Kraken.Attribute
 import Kraken.OmniSemantics
 
-@[kstep] def Effects.All (post : MachineState → Prop) : Effects → Prop
+@[kstep] def Effects.All {α : Type} (post : α → Prop) : Effects α → Prop
   | .done a => post a
   | .unimplemented _ => False
   | .unaligned_sp .. => False
   | .nonmem_load .. => False
   | .nonmem_store .. => False
-  | @Effects.undefined α _ cont => ∀ v: α, (cont v).All post
+  | @Effects.undefined _ β _ cont => ∀ v : β, (cont v).All post
   | .require_read_access _ _ cont => (cont ()).All post
   | .require_write_access _ _ cont => (cont ()).All post
   | .require_exec_access _ cont => (cont ()).All post
+
+/-- `All` is monotone in its postcondition. -/
+theorem Effects.All.imp {α : Type} {post₁ post₂ : α → Prop} {m : Effects α}
+    (h : ∀ a, post₁ a → post₂ a) : m.All post₁ → m.All post₂ := by
+  induction m <;> simp only [Effects.All] <;> intro hall
+  case done a => exact h a hall
+  case unimplemented => exact hall
+  case unaligned_sp => exact hall
+  case nonmem_load => exact hall
+  case nonmem_store => exact hall
+  case undefined ret ih => exact fun v => ih v (hall v)
+  case require_read_access _ _ _ ih => exact ih () hall
+  case require_write_access _ _ _ ih => exact ih () hall
+  case require_exec_access _ _ ih => exact ih () hall
+
+/-- Universal interpretation turns effect sequencing into nested `All`. -/
+theorem Effects.all_bind {α β : Type} {m : Effects α} {k : α → Effects β}
+    {post : β → Prop} :
+    (m.bind k).All post ↔ m.All fun a => (k a).All post := by
+  induction m <;> simp [Effects.bind, Effects.All, *]
 
 def step1 [Layout] (e: Executable) (s: MachineState) (post: @Post MachineState) : Prop :=
   (Executable.step e s .done).All post
 
 def straightlineStep [Layout] (e: Executable) (s: MachineState) (post: @Post MachineState) : Prop :=
   (Executable.straightline e s .done).All post
+
+/-- Execute `n` applications of the existing single-step semantics. -/
+def Executable.runSteps (e : Executable) : Nat → MachineState → Effects MachineState
+  | 0, s => .done s
+  | n + 1, s => (e.step s .done).bind (e.runSteps n)
+
+/-- A successful batched execution is a finite `step1` execution. -/
+theorem Executable.runSteps_all_eventually [Layout] (e : Executable) (n : Nat)
+    (s : MachineState) (post : @Post MachineState)
+    (h : (e.runSteps n s).All post) : Eventually (step1 e) post s := by
+  induction n generalizing s with
+  | zero => exact .done s h
+  | succ n ih =>
+      apply step_cps
+      exact Effects.All.imp (fun mid hmid => ih mid hmid) (Effects.all_bind.mp h)
+
+private def twoNops : Executable :=
+  (0, [
+    (.instr ⟨.W64, .NOP⟩, 4),
+    (.instr ⟨.W64, .NOP⟩, 4)
+  ])
+
+-- `runSteps` threads the state produced by each step into the next one.
+example [Layout] (s : MachineData) :
+    Eventually (step1 twoNops) (fun st => st.2 = 8) (s, 0) := by
+  apply Executable.runSteps_all_eventually twoNops 2
+  simp [twoNops, Executable.runSteps, Executable.step,
+    Kraken.Executable.directivesAtAddress, Kraken.Executable.withAddresses,
+    Directives.interp, Directive.interp, Instr.interp, Operation.interp,
+    Effects.bind, Effects.All]

--- a/Kraken/AArch64/OmniSemantics.lean
+++ b/Kraken/AArch64/OmniSemantics.lean
@@ -145,6 +145,39 @@ theorem Executable.runSteps_all_eventually [Layout] (e : Executable) (n : Nat)
       apply step_cps
       exact Effects.All.imp (fun mid hmid => ih mid hmid) (Effects.all_bind.mp h)
 
+/-- Cut a straight-line run after a listing prefix: prove the prefix's run,
+with the remaining program as a fresh straight-line obligation at each
+fall-through exit and `post` directly at each jump target. Together with
+`kstep`'s step budget this advances a bounded number of directives and stops
+at a sound resume point of the same shape. The side condition is the fetch
+coherence at this one split, the fact `ResolvesFallthroughAt` states with the
+block as the prefix. -/
+theorem Executable.straightlineStep_cut [Layout] (e : Executable)
+    (st : MachineState) (post : @Post MachineState)
+    (pre : List (Directive × Nat))
+    (hsplit : e.directivesFromAddress st.2
+      = pre ++ e.directivesFromAddress (Kraken.Directives.fallthroughPC pre st.2))
+    (h : (let _ : Labels := e.labels
+          Directives.interp pre st.1 st.2).All
+          (fun se => match se with
+            | (s', .fallthrough pc') => straightlineStep e (s', pc') post
+            | (s', .jump t) => post (s', t))) :
+    straightlineStep e st post := by
+  obtain ⟨s, pc⟩ := st
+  have key := @Directives.interp_append_from e.labels pre
+    (e.directivesFromAddress (Kraken.Directives.fallthroughPC pre pc))
+    e.directivesFromAddress s pc rfl
+  rw [← hsplit] at key
+  unfold straightlineStep Executable.straightline
+  dsimp only
+  rw [key]
+  simp only [Effects.bind_eq, Effects.bind_assoc]
+  rw [Effects.all_bind]
+  refine Effects.All.imp (fun ⟨s', ex⟩ hex => ?_) h
+  cases ex with
+  | jump t => exact hex
+  | fallthrough pc' => exact hex
+
 /-- The fetched suffix at `pc` decomposes as the block at `pc` followed by the
 fetch at the block's fall-through address. This is the address-coherence fact
 an honest layout provides; `Layout.size` alone does not guarantee it. -/

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -1043,9 +1043,8 @@ def Executable.step {α : Type} (e : Executable) (s : MachineState)
   e.stepWithExit s (fun s' ex => ret (s', ex.pc))
 
 /-- Run from the current address to the first taken jump or the end of the
-listing. Derived from the same monadic core as `step`, with the exit's
-program counter forgotten — behaviorally the semantics `Executable.eval`
-and the specs have always had. -/
+listing. Built on the same core as `step`; the continuation sees only the
+exit's program counter. -/
 def Executable.straightline {α : Type} (e : Executable) (s : MachineState)
     (ret : MachineState → Effects α) : Effects α :=
   let := e.labels

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -158,30 +158,63 @@ instance (w : RegWidth) : NondetSupportingType w.type := .bitvec w
 instance : NondetSupportingType Bool := .bool
 instance : NondetSupportingType StatusFlags := .statusFlags
 
-inductive Effects
-  | done (a : MachineData × Int64)
+inductive Effects (α : Type) : Type 1
+  | done (a : α)
   | unimplemented (msg : String)
   -- loads and stores *outside* the data memory, eg. MMIO, might still affect the data memory:
   -- for instance, MMIO reads/writes at certain device register addresses might change what
   -- data memory the process logically owns vs what memory is owned by devices
-  | nonmem_load (dmem : DataMem) (addr : BitVec 64) (w : MemWidth) (ret : w.type → DataMem → Effects)
-  | nonmem_store (dmem : DataMem) (addr : BitVec 64) {w : MemWidth} (v : w.type) (ret: DataMem → Effects)
-  | undefined {α : Type} [NondetSupportingType α] (ret : α → Effects)
-  | require_read_access (addr : BitVec 64) (w : MemWidth) (ok : Unit → Effects)
-  | require_write_access (addr : BitVec 64) (w : MemWidth) (ok : Unit → Effects)
-  | require_exec_access (p: Std.Rco Int64) (ok : Unit → Effects)
+  | nonmem_load (dmem : DataMem) (addr : BitVec 64) (w : MemWidth)
+      (ret : w.type → DataMem → Effects α)
+  | nonmem_store (dmem : DataMem) (addr : BitVec 64) {w : MemWidth} (v : w.type)
+      (ret : DataMem → Effects α)
+  | undefined {β : Type} [NondetSupportingType β] (ret : β → Effects α)
+  | require_read_access (addr : BitVec 64) (w : MemWidth) (ok : Unit → Effects α)
+  | require_write_access (addr : BitVec 64) (w : MemWidth) (ok : Unit → Effects α)
+  | require_exec_access (p : Std.Rco Int64) (ok : Unit → Effects α)
   | unaligned_sp {w : RegWidth} (sp : w.type)
 export Effects (unimplemented nonmem_load nonmem_store undefined require_read_access require_write_access require_exec_access)
 
--- the unused `Std.Rco Int64` argument and the unmodified `MachineData` return
--- value are present for uniformity with RegOrMem.interp
-def RegOrSp.interp {w} (r : RegOrSp w) (s : MachineData) (_ : Std.Rco Int64)
-  (ret : w.type → MachineData → Effects) : Effects :=
-  ret (s.regs.getRegOrSp r) s
+def Effects.bind {α β : Type} : Effects α → (α → Effects β) → Effects β
+  | .done a, k => k a
+  | .unimplemented msg, _ => .unimplemented msg
+  | .nonmem_load dmem addr w ret, k =>
+      .nonmem_load dmem addr w fun v dmem => (ret v dmem).bind k
+  | .nonmem_store dmem addr v ret, k =>
+      .nonmem_store dmem addr v fun dmem => (ret dmem).bind k
+  | @Effects.undefined _ γ inst ret, k =>
+      @Effects.undefined _ γ inst fun v => (ret v).bind k
+  | .require_read_access addr w ok, k =>
+      .require_read_access addr w fun u => (ok u).bind k
+  | .require_write_access addr w ok, k =>
+      .require_write_access addr w fun u => (ok u).bind k
+  | .require_exec_access p ok, k =>
+      .require_exec_access p fun u => (ok u).bind k
+  | .unaligned_sp sp, _ => .unaligned_sp sp
 
-def RegOrZr.interp {w} (r : RegOrZr w) (s : MachineData) (_ : Std.Rco Int64)
-  (ret : w.type → MachineData → Effects) : Effects :=
-  ret (s.regs.getRegOrZr r) s
+instance : Monad Effects where
+  pure := .done
+  bind := .bind
+
+@[simp] theorem Effects.pure_eq {α : Type} (a : α) :
+    (pure a : Effects α) = .done a := rfl
+
+@[simp] theorem Effects.bind_eq {α β : Type} (m : Effects α) (k : α → Effects β) :
+    m >>= k = m.bind k := rfl
+
+theorem Effects.bind_done {α : Type} (m : Effects α) : m.bind .done = m := by
+  induction m <;> simp [Effects.bind, *]
+
+theorem Effects.bind_assoc {α β γ : Type} (m : Effects α)
+    (k₁ : α → Effects β) (k₂ : β → Effects γ) :
+    (m.bind k₁).bind k₂ = m.bind fun a => (k₁ a).bind k₂ := by
+  induction m <;> simp [Effects.bind, *]
+
+instance : LawfulMonad Effects :=
+  LawfulMonad.mk'
+    (id_map := Effects.bind_done)
+    (pure_bind := fun _ _ => rfl)
+    (bind_assoc := Effects.bind_assoc)
 
 -- Since MMIO can cause devices to do arbitrary actions, a load might actually
 -- *modify* memory. For instance:
@@ -195,15 +228,15 @@ def RegOrZr.interp {w} (r : RegOrZr w) (s : MachineData) (_ : Std.Rco Int64)
 -- But this superfluous flexibility helps us simplify the state-threading:
 -- Instead of writing `fun v dmem => ... { s with dmem } ...` everywhere, we
 -- can just write `fun v s => ...` and the new `s` will shadow the old `s`.
-def MachineData.load
+def MachineData.load {α : Type}
   (s : MachineData) (addr : BitVec 64) (w : MemWidth)
-  (ret : w.type → MachineData → Effects): Effects :=
+  (ret : w.type → MachineData → Effects α) : Effects α :=
   require_read_access addr w (fun _unit =>
     match Mem.loadInt s.dmem addr w.bytes with
     | .some i => ret (.ofInt _ i) s
     | .none => nonmem_load s.dmem addr w (fun v dmem => ret v { s with dmem }))
 
-def MachineData.store (s : MachineData) (addr : BitVec 64) {w : MemWidth} (v : w.type) (ret: MachineData → Effects) : Effects :=
+def MachineData.store {α : Type} (s : MachineData) (addr : BitVec 64) {w : MemWidth} (v : w.type) (ret : MachineData → Effects α) : Effects α :=
   require_write_access addr w (fun _unit =>
     match Mem.loadInt s.dmem addr w.bytes with
     | .some _ =>
@@ -309,7 +342,7 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
     (addr, s')
 
 -- AArch64 mandates 16-byte alignment when accessing memory through SP.
-@[kstep] def AddrExpr.checkSPAlignment (mem : AddrExpr) (s : MachineData) (ok : Unit → Effects) : Effects :=
+@[kstep] def AddrExpr.checkSPAlignment {α : Type} (mem : AddrExpr) (s : MachineData) (ok : Unit → Effects α) : Effects α :=
   match mem.base with
   | .SP =>
     if s.regs.getRegOrSp .SP % 16#64 != 0#64 then
@@ -318,13 +351,13 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
       ok ()
   | _ => ok ()
 
-@[kstep] def AddrExpr.interpLoad [Labels] {w : MemWidth} (mem : AddrExpr) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects) :=
+@[kstep] def AddrExpr.interpLoad {α : Type} [Labels] {w : MemWidth} (mem : AddrExpr) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects α) :=
   mem.checkSPAlignment s (fun _unit =>
     let (addr, s') := mem.eval s p
     s'.load addr w ret)
 
-@[kstep] def AddrExpr.interpStore [Labels] {w : MemWidth} (mem : AddrExpr) (s : MachineData) (p : Std.Rco Int64)
-    (val : w.type) (next : MachineData → Effects) : Effects :=
+@[kstep] def AddrExpr.interpStore {α : Type} [Labels] {w : MemWidth} (mem : AddrExpr) (s : MachineData) (p : Std.Rco Int64)
+    (val : w.type) (next : MachineData → Effects α) : Effects α :=
   mem.checkSPAlignment s (fun _unit =>
     let (addr, s') := mem.eval s p
     s'.store addr (w := w) val next)
@@ -335,7 +368,7 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
   BitVec.ofInt 64 (base + off)
 
 -- AArch64 mandates 16-byte alignment when accessing memory through SP.
-@[kstep] def UnscaledAddrExpr.checkSPAlignment (mem : UnscaledAddrExpr) (s : MachineData) (ok : Unit → Effects) : Effects :=
+@[kstep] def UnscaledAddrExpr.checkSPAlignment {α : Type} (mem : UnscaledAddrExpr) (s : MachineData) (ok : Unit → Effects α) : Effects α :=
   match mem.base with
   | .SP =>
     if s.regs.getRegOrSp .SP % 16#64 != 0#64 then
@@ -344,18 +377,18 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
       ok ()
   | _ => ok ()
 
-@[kstep] def UnscaledAddrExpr.interpLoad [Labels] {w : MemWidth} (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects) :=
+@[kstep] def UnscaledAddrExpr.interpLoad {α : Type} [Labels] {w : MemWidth} (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects α) :=
   mem.checkSPAlignment s (fun _unit =>
     let addr := mem.eval s p
     s.load addr w ret)
 
-@[kstep] def UnscaledAddrExpr.interpStore [Labels] {w : MemWidth} (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64)
-    (val : w.type) (next : MachineData → Effects) : Effects :=
+@[kstep] def UnscaledAddrExpr.interpStore {α : Type} [Labels] {w : MemWidth} (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64)
+    (val : w.type) (next : MachineData → Effects α) : Effects α :=
   mem.checkSPAlignment s (fun _unit =>
     let addr := mem.eval s p
     s.store addr (w := w) val next)
 
-@[kstep] def Literal.interpLoad [Labels] {w : MemWidth} (expr : Literal) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects) : Effects :=
+@[kstep] def Literal.interpLoad {α : Type} [Labels] {w : MemWidth} (expr : Literal) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects α) : Effects α :=
   match expr with
   | .addr addr_expr => -- Load from address.
     let addr_val := Labels.label addr_expr.label
@@ -366,15 +399,15 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
     let val_bv : w.type := BitVec.ofInt w.bits (Int64.toInt val)
     ret val_bv s
 
-@[kstep] def AddrOrLit.interpLoad [Labels] {w : MemWidth} (expr : AddrOrLit) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects) :=
+@[kstep] def AddrOrLit.interpLoad {α : Type} [Labels] {w : MemWidth} (expr : AddrOrLit) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects α) :=
   match expr with
   | .addr addr_expr => addr_expr.interpLoad s p ret
   | .lit lit_expr => lit_expr.interpLoad s p ret
 
-@[kstep] def MachineData.setRegOrSp (s : MachineData) {w} (r : RegOrSp w) (v : w.type) (ret : MachineData → Effects) : Effects :=
+@[kstep] def MachineData.setRegOrSp {α : Type} (s : MachineData) {w} (r : RegOrSp w) (v : w.type) (ret : MachineData → Effects α) : Effects α :=
   ret { s with regs := s.regs.setRegOrSp r v }
 
-@[kstep] def MachineData.setRegOrZr (s : MachineData) {w} (r : RegOrZr w) (v : w.type) (ret : MachineData → Effects) : Effects :=
+@[kstep] def MachineData.setRegOrZr {α : Type} (s : MachineData) {w} (r : RegOrZr w) (v : w.type) (ret : MachineData → Effects α) : Effects α :=
   ret { s with regs := s.regs.setRegOrZr r v }
 
 @[kstep, simp] def CondCode.interp (cc : CondCode) (s : StatusFlags) : Bool := match cc with
@@ -470,10 +503,10 @@ def StatusFlags.ofNat (nzcv : Nat) : StatusFlags :=
     (dst &&& ~~~mask) ||| field
 
 set_option maxHeartbeats 1000000
-@[kstep] def Operation.interp [Labels]
+@[kstep] def Operation.interp {α : Type} [Labels]
   {w} (i : Operation w) (p : Std.Rco Int64) (s : MachineData)
-  (next : MachineData → Effects) (jmp : Int64 → MachineData → Effects) : Effects :=
-  match (generalizing := false) (motive := Operation w → Effects) i with
+  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
+  match (generalizing := false) (motive := Operation w → Effects α) i with
   | .LDR dst src => src.interpLoad s p (fun val s => s.setRegOrZr dst val next)
   | .STR src dst => dst.interpStore s p (s.regs.getRegOrZr src) next
   | .LDUR dst src => src.interpLoad s p (fun val s => s.setRegOrZr dst val next)
@@ -926,23 +959,23 @@ set_option maxHeartbeats 1000000
       next s
   | .NOP => next s
 
-@[kstep] def Instr.interp [Labels]
+@[kstep] def Instr.interp {α : Type} [Labels]
   (i : Instr) (s : MachineData) (p : Std.Rco Int64)
-  (next : MachineData → Effects) (jmp : Int64 → MachineData → Effects) : Effects :=
+  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
   require_exec_access p (fun _unit =>
     Operation.interp (w := i.operation_size) i.operation p s next jmp)
 
-@[kstep] def Directive.interp [Labels]
+@[kstep] def Directive.interp {α : Type} [Labels]
   (d : Directive) (s : MachineData) (p : Std.Rco Int64)
-  (next : MachineData → Effects) (jmp : Int64 → MachineData → Effects) : Effects :=
+  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
   match d with
   | .label _ => next s
   | .instr i => i.interp s p next jmp
   | .byteArray _ => .unimplemented s!"Unimplemented: execution reached data block at {p.1}"
 
-def Directives.interp [Labels]
+def Directives.interp {α : Type} [Labels]
   (ds : List (Directive × Nat)) (s : MachineData) (pc : Int64)
-  (ret : Int64 → MachineData → Effects) : Effects :=
+  (ret : Int64 → MachineData → Effects α) : Effects α :=
   match ds with
   | [] => ret pc s
   | (d, sz) :: ds =>
@@ -961,12 +994,14 @@ def Executable.directivesFromLabel (e : Executable) (l : Label) : List (Directiv
 
 abbrev MachineState := MachineData × Int64
 
-def Executable.step (e : Executable) (s : MachineState) (ret : MachineState → Effects) : Effects :=
-  let := Executable.labels e
+def Executable.step {α : Type} (e : Executable) (s : MachineState)
+    (ret : MachineState → Effects α) : Effects α :=
+  let := e.labels
   Directives.interp (e.directivesAtAddress s.2) s.1 s.2 (fun pc s => ret (s, pc))
 
-def Executable.straightline (e : Executable) (s : MachineState) (ret : MachineState → Effects) : Effects :=
-  let := Executable.labels e
+def Executable.straightline {α : Type} (e : Executable) (s : MachineState)
+    (ret : MachineState → Effects α) : Effects α :=
+  let := e.labels
   Directives.interp (e.directivesFromAddress s.2) s.1 s.2 (fun pc s => ret (s, pc))
 
 -- -- Concrete evaluators for expedient testing
@@ -984,7 +1019,7 @@ where
     | .nonmem_load _ addr _ _ => .error s!"Load at unmapped address {repr addr}"
     | .nonmem_store _ addr _ _ => .error s!"Store at unmapped address {repr addr}"
     | .unaligned_sp sp => .error s!"SP={sp} (is not 16-byte aligned)"
-    | @Effects.undefined _ t cont => handleEffects (cont (t.from_hash (hash s.1.regs)))
+    | @Effects.undefined _ _ t cont => handleEffects (cont (t.from_hash (hash s.1.regs)))
 
 def Directive.fakeSize (d : Directive) : Nat :=
   match d with

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -216,32 +216,36 @@ instance : LawfulMonad Effects :=
     (pure_bind := fun _ _ => rfl)
     (bind_assoc := Effects.bind_assoc)
 
--- Since MMIO can cause devices to do arbitrary actions, a load might actually
--- *modify* memory. For instance:
--- A TEST instruction might load a flag from an MMIO address and bitwise-and it with
--- an immediate, and if the result is non-zero, it might mean that some device has
--- finished processing a buffer and therefore now passes ownership of that buffer
--- to the CPU.
--- Note that `ret` takes a whole `MachineData` instead of only `DataMem`, which
--- provides a bit more flexibility than we need: MachineData.load might change
--- dmem, but will not change the registers or status flags.
--- But this superfluous flexibility helps us simplify the state-threading:
--- Instead of writing `fun v dmem => ... { s with dmem } ...` everywhere, we
--- can just write `fun v s => ...` and the new `s` will shadow the old `s`.
-def MachineData.load {α : Type}
-  (s : MachineData) (addr : BitVec 64) (w : MemWidth)
-  (ret : w.type → MachineData → Effects α) : Effects α :=
+/-- A nondeterministically chosen value for use in `do` notation. -/
+@[kstep] def Effects.undef {β : Type} [NondetSupportingType β] : Effects β :=
+  .undefined .done
+
+def Effects.exec {α : Type} (entropy : UInt64) : Effects α → Except String α
+  | .done a => .ok a
+  | .unimplemented msg => .error msg
+  | .unaligned_sp sp => .error s!"SP={sp} (is not 16-byte aligned)"
+  | .nonmem_load _ addr _ _ => .error s!"Load at unmapped address {repr addr}"
+  | .nonmem_store _ addr _ _ => .error s!"Store at unmapped address {repr addr}"
+  | @Effects.undefined _ _ inst ret => (ret (inst.from_hash entropy)).exec entropy
+  | .require_read_access _ _ ok => (ok ()).exec entropy
+  | .require_write_access _ _ ok => (ok ()).exec entropy
+  | .require_exec_access _ ok => (ok ()).exec entropy
+
+-- An MMIO load may return an updated data memory, for example when a device
+-- transfers ownership of a buffer back to the CPU.
+def MachineData.load
+  (s : MachineData) (addr : BitVec 64) (w : MemWidth) : Effects (w.type × MachineData) :=
   require_read_access addr w (fun _unit =>
     match Mem.loadInt s.dmem addr w.bytes with
-    | .some i => ret (.ofInt _ i) s
-    | .none => nonmem_load s.dmem addr w (fun v dmem => ret v { s with dmem }))
+    | .some i => .done (.ofInt _ i, s)
+    | .none => nonmem_load s.dmem addr w (fun v dmem => .done (v, { s with dmem })))
 
-def MachineData.store {α : Type} (s : MachineData) (addr : BitVec 64) {w : MemWidth} (v : w.type) (ret : MachineData → Effects α) : Effects α :=
+def MachineData.store (s : MachineData) (addr : BitVec 64) {w : MemWidth} (v : w.type) : Effects MachineData :=
   require_write_access addr w (fun _unit =>
     match Mem.loadInt s.dmem addr w.bytes with
     | .some _ =>
-        ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
-    | .none => nonmem_store s.dmem addr v (fun dmem' => ret { s with dmem := dmem' }))
+        .done { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
+    | .none => nonmem_store s.dmem addr v (fun dmem' => .done { s with dmem := dmem' }))
 
 class Labels where label : Label → Int64
 export Labels (label)
@@ -342,25 +346,25 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
     (addr, s')
 
 -- AArch64 mandates 16-byte alignment when accessing memory through SP.
-@[kstep] def AddrExpr.checkSPAlignment {α : Type} (mem : AddrExpr) (s : MachineData) (ok : Unit → Effects α) : Effects α :=
+@[kstep] def AddrExpr.checkSPAlignment (mem : AddrExpr) (s : MachineData) : Effects Unit :=
   match mem.base with
   | .SP =>
     if s.regs.getRegOrSp .SP % 16#64 != 0#64 then
       .unaligned_sp (s.regs.getRegOrSp .SP)
     else
-      ok ()
-  | _ => ok ()
+      .done ()
+  | _ => .done ()
 
-@[kstep] def AddrExpr.interpLoad {α : Type} [Labels] {w : MemWidth} (mem : AddrExpr) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects α) :=
-  mem.checkSPAlignment s (fun _unit =>
-    let (addr, s') := mem.eval s p
-    s'.load addr w ret)
+@[kstep] def AddrExpr.interpLoad [Labels] {w : MemWidth} (mem : AddrExpr) (s : MachineData) (p : Std.Rco Int64) : Effects (w.type × MachineData) := do
+  mem.checkSPAlignment s
+  let (addr, s') := mem.eval s p
+  s'.load addr w
 
-@[kstep] def AddrExpr.interpStore {α : Type} [Labels] {w : MemWidth} (mem : AddrExpr) (s : MachineData) (p : Std.Rco Int64)
-    (val : w.type) (next : MachineData → Effects α) : Effects α :=
-  mem.checkSPAlignment s (fun _unit =>
-    let (addr, s') := mem.eval s p
-    s'.store addr (w := w) val next)
+@[kstep] def AddrExpr.interpStore [Labels] {w : MemWidth} (mem : AddrExpr) (s : MachineData) (p : Std.Rco Int64)
+    (val : w.type) : Effects MachineData := do
+  mem.checkSPAlignment s
+  let (addr, s') := mem.eval s p
+  s'.store addr (w := w) val
 
 @[kstep] def UnscaledAddrExpr.eval [Labels] (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64) : BitVec 64 :=
   let base := (s.regs.getRegOrSp mem.base).signed
@@ -368,47 +372,47 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
   BitVec.ofInt 64 (base + off)
 
 -- AArch64 mandates 16-byte alignment when accessing memory through SP.
-@[kstep] def UnscaledAddrExpr.checkSPAlignment {α : Type} (mem : UnscaledAddrExpr) (s : MachineData) (ok : Unit → Effects α) : Effects α :=
+@[kstep] def UnscaledAddrExpr.checkSPAlignment (mem : UnscaledAddrExpr) (s : MachineData) : Effects Unit :=
   match mem.base with
   | .SP =>
     if s.regs.getRegOrSp .SP % 16#64 != 0#64 then
       .unaligned_sp (s.regs.getRegOrSp .SP)
     else
-      ok ()
-  | _ => ok ()
+      .done ()
+  | _ => .done ()
 
-@[kstep] def UnscaledAddrExpr.interpLoad {α : Type} [Labels] {w : MemWidth} (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects α) :=
-  mem.checkSPAlignment s (fun _unit =>
-    let addr := mem.eval s p
-    s.load addr w ret)
+@[kstep] def UnscaledAddrExpr.interpLoad [Labels] {w : MemWidth} (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64) : Effects (w.type × MachineData) := do
+  mem.checkSPAlignment s
+  let addr := mem.eval s p
+  s.load addr w
 
-@[kstep] def UnscaledAddrExpr.interpStore {α : Type} [Labels] {w : MemWidth} (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64)
-    (val : w.type) (next : MachineData → Effects α) : Effects α :=
-  mem.checkSPAlignment s (fun _unit =>
-    let addr := mem.eval s p
-    s.store addr (w := w) val next)
+@[kstep] def UnscaledAddrExpr.interpStore [Labels] {w : MemWidth} (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64)
+    (val : w.type) : Effects MachineData := do
+  mem.checkSPAlignment s
+  let addr := mem.eval s p
+  s.store addr (w := w) val
 
-@[kstep] def Literal.interpLoad {α : Type} [Labels] {w : MemWidth} (expr : Literal) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects α) : Effects α :=
+@[kstep] def Literal.interpLoad [Labels] {w : MemWidth} (expr : Literal) (s : MachineData) (p : Std.Rco Int64) : Effects (w.type × MachineData) :=
   match expr with
   | .addr addr_expr => -- Load from address.
     let addr_val := Labels.label addr_expr.label
     let addr := BitVec.ofInt 64 (Int64.toInt addr_val)
-    s.load addr w ret
+    s.load addr w
   | .pool litpool_expr => -- Bypass loading and return value directly.
     let val := litpool_expr.expr.interp p
     let val_bv : w.type := BitVec.ofInt w.bits (Int64.toInt val)
-    ret val_bv s
+    .done (val_bv, s)
 
-@[kstep] def AddrOrLit.interpLoad {α : Type} [Labels] {w : MemWidth} (expr : AddrOrLit) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects α) :=
+@[kstep] def AddrOrLit.interpLoad [Labels] {w : MemWidth} (expr : AddrOrLit) (s : MachineData) (p : Std.Rco Int64) : Effects (w.type × MachineData) :=
   match expr with
-  | .addr addr_expr => addr_expr.interpLoad s p ret
-  | .lit lit_expr => lit_expr.interpLoad s p ret
+  | .addr addr_expr => addr_expr.interpLoad s p
+  | .lit lit_expr => lit_expr.interpLoad s p
 
-@[kstep] def MachineData.setRegOrSp {α : Type} (s : MachineData) {w} (r : RegOrSp w) (v : w.type) (ret : MachineData → Effects α) : Effects α :=
-  ret { s with regs := s.regs.setRegOrSp r v }
+@[kstep] def MachineData.setRegOrSp (s : MachineData) {w} (r : RegOrSp w) (v : w.type) : MachineData :=
+  { s with regs := s.regs.setRegOrSp r v }
 
-@[kstep] def MachineData.setRegOrZr {α : Type} (s : MachineData) {w} (r : RegOrZr w) (v : w.type) (ret : MachineData → Effects α) : Effects α :=
-  ret { s with regs := s.regs.setRegOrZr r v }
+@[kstep] def MachineData.setRegOrZr (s : MachineData) {w} (r : RegOrZr w) (v : w.type) : MachineData :=
+  { s with regs := s.regs.setRegOrZr r v }
 
 @[kstep, simp] def CondCode.interp (cc : CondCode) (s : StatusFlags) : Bool := match cc with
   | .EQ => s.z
@@ -502,125 +506,143 @@ def StatusFlags.ofNat (nzcv : Nat) : StatusFlags :=
     let field : w.type := (src &&& maskOfLen (w := w) len) <<< pos
     (dst &&& ~~~mask) ||| field
 
+/-- How one instruction transfers control: fall through, or jump to `target`. -/
+inductive Ctrl : Type
+  | next
+  | jmp (target : Int64)
+  deriving Repr, BEq, DecidableEq
+
 set_option maxHeartbeats 1000000
-@[kstep] def Operation.interp {α : Type} [Labels]
-  {w} (i : Operation w) (p : Std.Rco Int64) (s : MachineData)
-  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
-  match (generalizing := false) (motive := Operation w → Effects α) i with
-  | .LDR dst src => src.interpLoad s p (fun val s => s.setRegOrZr dst val next)
-  | .STR src dst => dst.interpStore s p (s.regs.getRegOrZr src) next
-  | .LDUR dst src => src.interpLoad s p (fun val s => s.setRegOrZr dst val next)
-  | .STUR src dst => dst.interpStore s p (s.regs.getRegOrZr src) next
+@[kstep] def Operation.interp [Labels]
+  {w} (i : Operation w) (p : Std.Rco Int64) (s : MachineData) : Effects (MachineData × Ctrl) :=
+  match (generalizing := false) (motive := Operation w → Effects (MachineData × Ctrl)) i with
+  | .LDR dst src => do
+    let (val, s) ← src.interpLoad s p
+    .done (s.setRegOrZr dst val, .next)
+  | .STR src dst => do
+    let s ← dst.interpStore s p (s.regs.getRegOrZr src)
+    .done (s, .next)
+  | .LDUR dst src => do
+    let (val, s) ← src.interpLoad s p
+    .done (s.setRegOrZr dst val, .next)
+  | .STUR src dst => do
+    let s ← dst.interpStore s p (s.regs.getRegOrZr src)
+    .done (s, .next)
   -- TODO: Architecturally, the memory access ordering of LDP/STP is UNORDERED and can occur
   -- simultaneously as a 128-bit transaction or in any order on hardware. Here we model a specific
   -- sequential order (lower address first, then higher address), which does not necessarily reflect
   -- physical execution order on device memory. (Note: unpredictable cases like identical transfer
   -- registers in LDP or writeback conflicts are statically rejected during parsing).
-  | .LDP dst1 dst2 src =>
-    src.checkSPAlignment s (fun _unit =>
-      let (addr, s') := src.eval s p
-      s'.load addr w (fun val1 s'' =>
-        s''.load (addr + w.bytesv) w (fun val2 s''' =>
-          s'''.setRegOrZr dst1 val1 (fun s'''' =>
-            s''''.setRegOrZr dst2 val2 next))))
-  | .STP src1 src2 dst =>
-    dst.checkSPAlignment s (fun _unit =>
-      let val1 := s.regs.getRegOrZr src1
-      let val2 := s.regs.getRegOrZr src2
-      let (addr, s') := dst.eval s p
-      s'.store addr val1 (fun s'' =>
-        s''.store (addr + w.bytesv) val2 next))
-  | .LDRB dst src =>
-    src.interpLoad (w := .W8) s p (fun val s' =>
-      s'.setRegOrZr dst (val.zeroExtend RegWidth.W32.bits) next)
-  | .LDURB dst src =>
-    src.interpLoad (w := .W8) s p (fun val s' =>
-      s'.setRegOrZr dst (val.zeroExtend RegWidth.W32.bits) next)
-  | .STRB src dst =>
-    dst.interpStore (w := .W8) s p ((s.regs.getRegOrZr src).take MemWidth.W8.bits) next
-  | .STURB src dst =>
-    dst.interpStore (w := .W8) s p ((s.regs.getRegOrZr src).take MemWidth.W8.bits) next
-  | .LDRSB dst src =>
-    src.interpLoad (w := .W8) s p (fun val s' =>
-      s'.setRegOrZr dst (val.signExtend w.bits) next)
-  | .LDURSB dst src =>
-    src.interpLoad (w := .W8) s p (fun val s' =>
-      s'.setRegOrZr dst (val.signExtend w.bits) next)
-  | .LDRH dst src =>
-    src.interpLoad (w := .W16) s p (fun val s' =>
-      s'.setRegOrZr dst (val.zeroExtend RegWidth.W32.bits) next)
-  | .LDURH dst src =>
-    src.interpLoad (w := .W16) s p (fun val s' =>
-      s'.setRegOrZr dst (val.zeroExtend RegWidth.W32.bits) next)
-  | .STRH src dst =>
-    dst.interpStore (w := .W16) s p ((s.regs.getRegOrZr src).take MemWidth.W16.bits) next
-  | .STURH src dst =>
-    dst.interpStore (w := .W16) s p ((s.regs.getRegOrZr src).take MemWidth.W16.bits) next
-  | .LDRSH dst src =>
-    src.interpLoad (w := .W16) s p (fun val s' =>
-      s'.setRegOrZr dst (val.signExtend w.bits) next)
-  | .LDURSH dst src =>
-    src.interpLoad (w := .W16) s p (fun val s' =>
-      s'.setRegOrZr dst (val.signExtend w.bits) next)
-  | .LDRSW dst src =>
-    src.interpLoad (w := .W32) s p (fun val s' =>
-      s'.setRegOrZr dst (val.signExtend RegWidth.W64.bits) next)
-  | .LDURSW dst src =>
-    src.interpLoad (w := .W32) s p (fun val s' =>
-      s'.setRegOrZr dst (val.signExtend RegWidth.W64.bits) next)
-  | .LDPSW dst1 dst2 src =>
-    src.checkSPAlignment s (fun _unit =>
-      let (addr, s') := src.eval s p
-      s'.load addr .W32 (fun val1 s'' =>
-        s''.load (addr + MemWidth.W32.bytesv) .W32 (fun val2 s''' =>
-          s'''.setRegOrZr dst1 (val1.signExtend RegWidth.W64.bits) (fun s'''' =>
-            s''''.setRegOrZr dst2 (val2.signExtend RegWidth.W64.bits) next))))
+  | .LDP dst1 dst2 src => do
+    src.checkSPAlignment s
+    let (addr, s') := src.eval s p
+    let (val1, s'') ← s'.load addr w
+    let (val2, s''') ← s''.load (addr + w.bytesv) w
+    let s'''' := s'''.setRegOrZr dst1 val1
+    .done (s''''.setRegOrZr dst2 val2, .next)
+  | .STP src1 src2 dst => do
+    dst.checkSPAlignment s
+    let val1 := s.regs.getRegOrZr src1
+    let val2 := s.regs.getRegOrZr src2
+    let (addr, s') := dst.eval s p
+    let s'' ← s'.store addr val1
+    let s''' ← s''.store (addr + w.bytesv) val2
+    .done (s''', .next)
+  | .LDRB dst src => do
+    let (val, s') ← src.interpLoad (w := .W8) s p
+    .done (s'.setRegOrZr dst (val.zeroExtend RegWidth.W32.bits), .next)
+  | .LDURB dst src => do
+    let (val, s') ← src.interpLoad (w := .W8) s p
+    .done (s'.setRegOrZr dst (val.zeroExtend RegWidth.W32.bits), .next)
+  | .STRB src dst => do
+    let s ← dst.interpStore (w := .W8) s p ((s.regs.getRegOrZr src).take MemWidth.W8.bits)
+    .done (s, .next)
+  | .STURB src dst => do
+    let s ← dst.interpStore (w := .W8) s p ((s.regs.getRegOrZr src).take MemWidth.W8.bits)
+    .done (s, .next)
+  | .LDRSB dst src => do
+    let (val, s') ← src.interpLoad (w := .W8) s p
+    .done (s'.setRegOrZr dst (val.signExtend w.bits), .next)
+  | .LDURSB dst src => do
+    let (val, s') ← src.interpLoad (w := .W8) s p
+    .done (s'.setRegOrZr dst (val.signExtend w.bits), .next)
+  | .LDRH dst src => do
+    let (val, s') ← src.interpLoad (w := .W16) s p
+    .done (s'.setRegOrZr dst (val.zeroExtend RegWidth.W32.bits), .next)
+  | .LDURH dst src => do
+    let (val, s') ← src.interpLoad (w := .W16) s p
+    .done (s'.setRegOrZr dst (val.zeroExtend RegWidth.W32.bits), .next)
+  | .STRH src dst => do
+    let s ← dst.interpStore (w := .W16) s p ((s.regs.getRegOrZr src).take MemWidth.W16.bits)
+    .done (s, .next)
+  | .STURH src dst => do
+    let s ← dst.interpStore (w := .W16) s p ((s.regs.getRegOrZr src).take MemWidth.W16.bits)
+    .done (s, .next)
+  | .LDRSH dst src => do
+    let (val, s') ← src.interpLoad (w := .W16) s p
+    .done (s'.setRegOrZr dst (val.signExtend w.bits), .next)
+  | .LDURSH dst src => do
+    let (val, s') ← src.interpLoad (w := .W16) s p
+    .done (s'.setRegOrZr dst (val.signExtend w.bits), .next)
+  | .LDRSW dst src => do
+    let (val, s') ← src.interpLoad (w := .W32) s p
+    .done (s'.setRegOrZr dst (val.signExtend RegWidth.W64.bits), .next)
+  | .LDURSW dst src => do
+    let (val, s') ← src.interpLoad (w := .W32) s p
+    .done (s'.setRegOrZr dst (val.signExtend RegWidth.W64.bits), .next)
+  | .LDPSW dst1 dst2 src => do
+    src.checkSPAlignment s
+    let (addr, s') := src.eval s p
+    let (val1, s'') ← s'.load addr .W32
+    let (val2, s''') ← s''.load (addr + MemWidth.W32.bytesv) .W32
+    let s'''' := s'''.setRegOrZr dst1 (val1.signExtend RegWidth.W64.bits)
+    .done (s''''.setRegOrZr dst2 (val2.signExtend RegWidth.W64.bits), .next)
   | .ADD_e dst src1 src2 =>
     let val1 := s.regs.getRegOrSp src1
     let val2 := src2.interp s.regs p
     let res := val1 + val2
-    s.setRegOrSp dst res next
+    .done (s.setRegOrSp dst res, .next)
   | .ADD_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 + val2
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .ADDS_e dst src1 src2 =>
     let val1 := s.regs.getRegOrSp src1
     let val2 := src2.interp s.regs p
     let res := val1 + val2
-    { s with status := StatusFlags.adds res val1 val2 }.setRegOrZr dst res next
+    .done (({ s with status := StatusFlags.adds res val1 val2 }).setRegOrZr dst res, .next)
   | .ADDS_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 + val2
-    { s with status := StatusFlags.adds res val1 val2 }.setRegOrZr dst res next
+    .done (({ s with status := StatusFlags.adds res val1 val2 }).setRegOrZr dst res, .next)
   | .SUB_e dst src1 src2 =>
     let val1 := s.regs.getRegOrSp src1
     let val2 := src2.interp s.regs p
     let res := val1 - val2
-    s.setRegOrSp dst res next
+    .done (s.setRegOrSp dst res, .next)
   | .SUB_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 - val2
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .SUBS_e dst src1 src2 =>
     let val1 := s.regs.getRegOrSp src1
     let val2 := src2.interp s.regs p
     let res := val1 - val2
-    { s with status := StatusFlags.subs res val1 val2 }.setRegOrZr dst res next
+    .done (({ s with status := StatusFlags.subs res val1 val2 }).setRegOrZr dst res, .next)
   | .SUBS_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 - val2
-    { s with status := StatusFlags.subs res val1 val2 }.setRegOrZr dst res next
+    .done (({ s with status := StatusFlags.subs res val1 val2 }).setRegOrZr dst res, .next)
   | .ADC dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let carry : w.type := s.status.c
     let res := val1 + val2 + carry
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .ADCS dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
@@ -630,13 +652,13 @@ set_option maxHeartbeats 1000000
     let status := StatusFlags.from_result res {
       c := res.unsigned != val1.unsigned + val2.unsigned + carry_int
       v := res.signed != val1.signed + val2.signed + carry_int }
-    { s with status }.setRegOrZr dst res next
+    .done (({ s with status }).setRegOrZr dst res, .next)
   | .SBC dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let borrow : w.type := !s.status.c
     let res := val1 - val2 - borrow
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .SBCS dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
@@ -646,227 +668,227 @@ set_option maxHeartbeats 1000000
     let status := StatusFlags.from_result res {
       c := val1.unsigned >= val2.unsigned + borrow_int
       v := res.signed != val1.signed - val2.signed - borrow_int }
-    { s with status }.setRegOrZr dst res next
+    .done (({ s with status }).setRegOrZr dst res, .next)
   | .MADD dst src1 src2 src3 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let val3 := s.regs.getRegOrZr src3
     let res := val1 * val2 + val3
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .MSUB dst src1 src2 src3 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let val3 := s.regs.getRegOrZr src3
     let res := val3 - val1 * val2
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .SMULH dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let prod := val1.signed * val2.signed
     let res := (BitVec.ofInt (RegWidth.W64.bits + RegWidth.W64.bits) prod).extractLsb' RegWidth.W64.bits RegWidth.W64.bits
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .UMULH dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let prod := val1.unsigned * val2.unsigned
     let res := (BitVec.ofInt (RegWidth.W64.bits + RegWidth.W64.bits) prod).extractLsb' RegWidth.W64.bits RegWidth.W64.bits
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .SDIV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let res := if val2 == 0 then (0 : w.type) else val1.sdiv val2
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .UDIV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let res := if val2 == 0 then (0 : w.type) else val1 / val2
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .SMADDL dst src1 src2 src3 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let val3 := s.regs.getRegOrZr src3
     let res := BitVec.ofInt RegWidth.W64.bits (val1.signed * val2.signed + val3.signed)
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .UMADDL dst src1 src2 src3 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let val3 := s.regs.getRegOrZr src3
     let res := BitVec.ofInt RegWidth.W64.bits (val1.unsigned * val2.unsigned + val3.unsigned)
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .SMSUBL dst src1 src2 src3 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let val3 := s.regs.getRegOrZr src3
     let res := BitVec.ofInt RegWidth.W64.bits (val3.signed - val1.signed * val2.signed)
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .UMSUBL dst src1 src2 src3 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let val3 := s.regs.getRegOrZr src3
     let res := BitVec.ofInt RegWidth.W64.bits (val3.unsigned - val1.unsigned * val2.unsigned)
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .AND_i dst src1 imm =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
     let res := val1 &&& val2
-    s.setRegOrSp dst res next
+    .done (s.setRegOrSp dst res, .next)
   | .AND_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 &&& val2
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .ANDS_i dst src1 imm =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
     let res := val1 &&& val2
     let flags := StatusFlags.from_result res { c := false, v := false }
-    { s with status := flags }.setRegOrZr dst res next
+    .done (({ s with status := flags }).setRegOrZr dst res, .next)
   | .ANDS_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 &&& val2
     let flags := StatusFlags.from_result res { c := false, v := false }
-    { s with status := flags }.setRegOrZr dst res next
+    .done (({ s with status := flags }).setRegOrZr dst res, .next)
   | .ORR_i dst src1 imm =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
     let res := val1 ||| val2
-    s.setRegOrSp dst res next
+    .done (s.setRegOrSp dst res, .next)
   | .ORR_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 ||| val2
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .ORN_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 ||| ~~~val2
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .EOR_i dst src1 imm =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
     let res := val1 ^^^ val2
-    s.setRegOrSp dst res next
+    .done (s.setRegOrSp dst res, .next)
   | .EOR_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 ^^^ val2
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .BIC_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 &&& ~~~val2
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .EON_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 ^^^ ~~~val2
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .BICS_s dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := src2.interp s.regs p
     let res := val1 &&& ~~~val2
     let status' := StatusFlags.from_result res { c := false, v := false }
-    { s with status := status' }.setRegOrZr dst res next
+    .done (({ s with status := status' }).setRegOrZr dst res, .next)
   | .BFM dst src immr imms =>
     let val_dst := s.regs.getRegOrZr dst
     let val_src := s.regs.getRegOrZr src
     let res := evalBFM val_dst val_src immr imms
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .SBFM dst src immr imms =>
     let val_src := s.regs.getRegOrZr src
     let res := evalSBFM val_src immr imms
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .UBFM dst src immr imms =>
     let val_src := s.regs.getRegOrZr src
     let res := evalUBFM val_src immr imms
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .CLZ dst src =>
     let val := s.regs.getRegOrZr src
-    s.setRegOrZr dst val.clz next
+    .done (s.setRegOrZr dst val.clz, .next)
   | .CLS dst src =>
     let val := s.regs.getRegOrZr src
     let res := (if val.msb then (~~~val).clz else val.clz) - 1#w.bits
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .RBIT dst src =>
     let val := s.regs.getRegOrZr src
-    s.setRegOrZr dst val.reverse next
+    .done (s.setRegOrZr dst val.reverse, .next)
   | .REV dst src =>
     let val := s.regs.getRegOrZr src
     let res : w.type := match w, val with
       | .W32, v =>
-        let step1 := ((v &&& 0x00FF00FF#32) <<< 8) ||| ((v &&& 0xFF00FF00#32) >>> 8)
-        ((step1 &&& 0x0000FFFF#32) <<< 16) ||| ((step1 &&& 0xFFFF0000#32) >>> 16)
+        let swap8 := ((v &&& 0x00FF00FF#32) <<< 8) ||| ((v &&& 0xFF00FF00#32) >>> 8)
+        ((swap8 &&& 0x0000FFFF#32) <<< 16) ||| ((swap8 &&& 0xFFFF0000#32) >>> 16)
       | .W64, v =>
-        let step1 := ((v &&& 0x00FF00FF00FF00FF#64) <<< 8) ||| ((v &&& 0xFF00FF00FF00FF00#64) >>> 8)
-        let step2 := ((step1 &&& 0x0000FFFF0000FFFF#64) <<< 16) ||| ((step1 &&& 0xFFFF0000FFFF0000#64) >>> 16)
-        ((step2 &&& 0x00000000FFFFFFFF#64) <<< 32) ||| ((step2 &&& 0xFFFFFFFF00000000#64) >>> 32)
-    s.setRegOrZr dst res next
+        let swap8 := ((v &&& 0x00FF00FF00FF00FF#64) <<< 8) ||| ((v &&& 0xFF00FF00FF00FF00#64) >>> 8)
+        let swap16 := ((swap8 &&& 0x0000FFFF0000FFFF#64) <<< 16) ||| ((swap8 &&& 0xFFFF0000FFFF0000#64) >>> 16)
+        ((swap16 &&& 0x00000000FFFFFFFF#64) <<< 32) ||| ((swap16 &&& 0xFFFFFFFF00000000#64) >>> 32)
+    .done (s.setRegOrZr dst res, .next)
   | .REV16 dst src =>
     let val := s.regs.getRegOrZr src
     let res := ((val &&& 0x00FF00FF00FF00FF#w.bits) <<< 8) ||| ((val &&& 0xFF00FF00FF00FF00#w.bits) >>> 8)
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .REV32 dst src =>
     let val := s.regs.getRegOrZr src
-    let step1 := ((val &&& 0x00FF00FF00FF00FF#64) <<< 8) ||| ((val &&& 0xFF00FF00FF00FF00#64) >>> 8)
-    let res := ((step1 &&& 0x0000FFFF0000FFFF#64) <<< 16) ||| ((step1 &&& 0xFFFF0000FFFF0000#64) >>> 16)
-    s.setRegOrZr dst res next
+    let swap8 := ((val &&& 0x00FF00FF00FF00FF#64) <<< 8) ||| ((val &&& 0xFF00FF00FF00FF00#64) >>> 8)
+    let res := ((swap8 &&& 0x0000FFFF0000FFFF#64) <<< 16) ||| ((swap8 &&& 0xFFFF0000FFFF0000#64) >>> 16)
+    .done (s.setRegOrZr dst res, .next)
   | .EXTR dst src1 src2 lsb =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let lsb := lsb % w.bits
     let res := if lsb == 0 then val2 else (val1 <<< (w.bits - lsb)) ||| (val2 >>> lsb)
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .MOVZ dst imm shift =>
     let val16 := (BitVec.ofInt w.bits (Int64.toInt (imm.interp p))) &&& 0xFFFF#w.bits
     let res := val16 <<< shift.toNat
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .MOVK dst imm shift =>
     let oldVal := s.regs.getRegOrZr dst
     let mask := ~~~(0xFFFF#w.bits <<< shift.toNat)
     let val16 := (BitVec.ofInt w.bits (Int64.toInt (imm.interp p))) &&& 0xFFFF#w.bits
     let res := (oldVal &&& mask) ||| (val16 <<< shift.toNat)
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .MOVN dst imm shift =>
     let val16 := (BitVec.ofInt w.bits (Int64.toInt (imm.interp p))) &&& 0xFFFF#w.bits
     let res := ~~~(val16 <<< shift.toNat)
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .LSLV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let shift := val2.toNat % w.bits
     let res := val1 <<< shift
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .LSRV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let shift := val2.toNat % w.bits
     let res := val1.ushiftRight shift
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .ASRV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let shift := val2.toNat % w.bits
     let res := val1.sshiftRight shift
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .RORV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let shift := val2.toNat % w.bits
     let res := val1.rotateRight shift
-    s.setRegOrZr dst res next
+    .done (s.setRegOrZr dst res, .next)
   | .CSEL dst src1 src2 cond =>
     let val := if cond.interp s.status then s.regs.getRegOrZr src1 else s.regs.getRegOrZr src2
-    s.setRegOrZr dst val next
+    .done (s.setRegOrZr dst val, .next)
   | .CSINC dst src1 src2 cond =>
     let val := if cond.interp s.status then s.regs.getRegOrZr src1 else s.regs.getRegOrZr src2 + 1#w.bits
-    s.setRegOrZr dst val next
+    .done (s.setRegOrZr dst val, .next)
   | .CSINV dst src1 src2 cond =>
     let val := if cond.interp s.status then s.regs.getRegOrZr src1 else ~~~(s.regs.getRegOrZr src2)
-    s.setRegOrZr dst val next
+    .done (s.setRegOrZr dst val, .next)
   | .CSNEG dst src1 src2 cond =>
     let val := if cond.interp s.status then s.regs.getRegOrZr src1 else -(s.regs.getRegOrZr src2)
-    s.setRegOrZr dst val next
+    .done (s.setRegOrZr dst val, .next)
   | .CCMP_reg src1 src2 nzcv cond =>
     let status' := if cond.interp s.status then
         let val1 := s.regs.getRegOrZr src1
@@ -875,7 +897,7 @@ set_option maxHeartbeats 1000000
         StatusFlags.subs res val1 val2
       else
         StatusFlags.ofNat nzcv
-    next { s with status := status' }
+    .done ({ s with status := status' }, .next)
   | .CCMP_imm src1 imm nzcv cond =>
     let status' := if cond.interp s.status then
         let val1 := s.regs.getRegOrZr src1
@@ -884,7 +906,7 @@ set_option maxHeartbeats 1000000
         StatusFlags.subs res val1 val2
       else
         StatusFlags.ofNat nzcv
-    next { s with status := status' }
+    .done ({ s with status := status' }, .next)
   | .CCMN_reg src1 src2 nzcv cond =>
     let status' := if cond.interp s.status then
         let val1 := s.regs.getRegOrZr src1
@@ -893,7 +915,7 @@ set_option maxHeartbeats 1000000
         StatusFlags.adds res val1 val2
       else
         StatusFlags.ofNat nzcv
-    next { s with status := status' }
+    .done ({ s with status := status' }, .next)
   | .CCMN_imm src1 imm nzcv cond =>
     let status' := if cond.interp s.status then
         let val1 := s.regs.getRegOrZr src1
@@ -902,85 +924,96 @@ set_option maxHeartbeats 1000000
         StatusFlags.adds res val1 val2
       else
         StatusFlags.ofNat nzcv
-    next { s with status := status' }
+    .done ({ s with status := status' }, .next)
   | .ADR dst target =>
     let val := match target with
       | .int64 imm => BitVec.ofInt 64 (Int64.toInt p.lower + Int64.toInt imm)
       | _ => BitVec.ofInt 64 (Int64.toInt (target.interp p))
-    s.setRegOrZr dst val next
+    .done (s.setRegOrZr dst val, .next)
   | .ADRP dst target =>
     let val := match target with
       | .int64 imm => BitVec.ofInt 64 (Int64.toInt p.lower + Int64.toInt imm)
       | _ => BitVec.ofInt 64 (Int64.toInt (target.interp p))
-    s.setRegOrZr dst (val &&& ~~~0xFFF#64) next
+    .done (s.setRegOrZr dst (val &&& ~~~0xFFF#64), .next)
   | .B target =>
-    jmp (target.evalBranchTarget p) s
+    .done (s, .jmp (target.evalBranchTarget p))
   | .B_cond cond target =>
     if cond.interp s.status then
-      jmp (target.evalBranchTarget p) s
+      .done (s, .jmp (target.evalBranchTarget p))
     else
-      next s
+      .done (s, .next)
   | .BL target =>
     let lr_val := BitVec.ofInt 64 (Int64.toInt p.upper)
-    s.setRegOrZr RegOrZr.X30 lr_val (fun s' => jmp (target.evalBranchTarget p) s')
+    .done (s.setRegOrZr RegOrZr.X30 lr_val, .jmp (target.evalBranchTarget p))
   | .BLR target =>
     let lr_val := BitVec.ofInt 64 (Int64.toInt p.upper)
     let target_val := Int64.ofInt (s.regs.getRegOrZr target).signed
-    s.setRegOrZr RegOrZr.X30 lr_val (fun s' => jmp target_val s')
+    .done (s.setRegOrZr RegOrZr.X30 lr_val, .jmp target_val)
   | .BR target =>
     let target_val := Int64.ofInt (s.regs.getRegOrZr target).signed
-    jmp target_val s
+    .done (s, .jmp target_val)
   | .RET target =>
     let target_val := Int64.ofInt (s.regs.getRegOrZr target).signed
-    jmp target_val s
+    .done (s, .jmp target_val)
   | .CBZ reg target =>
     let val := s.regs.getRegOrZr reg
     if val == 0 then
-      jmp (target.evalBranchTarget p) s
+      .done (s, .jmp (target.evalBranchTarget p))
     else
-      next s
+      .done (s, .next)
   | .CBNZ reg target =>
     let val := s.regs.getRegOrZr reg
     if val != 0 then
-      jmp (target.evalBranchTarget p) s
+      .done (s, .jmp (target.evalBranchTarget p))
     else
-      next s
+      .done (s, .next)
   | .TBZ reg bit target =>
     let val := s.regs.getRegOrZr reg
     if val.getLsbD bit == false then
-      jmp (target.evalBranchTarget p) s
+      .done (s, .jmp (target.evalBranchTarget p))
     else
-      next s
+      .done (s, .next)
   | .TBNZ reg bit target =>
     let val := s.regs.getRegOrZr reg
     if val.getLsbD bit == true then
-      jmp (target.evalBranchTarget p) s
+      .done (s, .jmp (target.evalBranchTarget p))
     else
-      next s
-  | .NOP => next s
+      .done (s, .next)
+  | .NOP => .done (s, .next)
 
-@[kstep] def Instr.interp {α : Type} [Labels]
-  (i : Instr) (s : MachineData) (p : Std.Rco Int64)
-  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
+@[kstep] def Instr.interp [Labels]
+  (i : Instr) (s : MachineData) (p : Std.Rco Int64) : Effects (MachineData × Ctrl) :=
   require_exec_access p (fun _unit =>
-    Operation.interp (w := i.operation_size) i.operation p s next jmp)
+    Operation.interp (w := i.operation_size) i.operation p s)
 
-@[kstep] def Directive.interp {α : Type} [Labels]
-  (d : Directive) (s : MachineData) (p : Std.Rco Int64)
-  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
+@[kstep] def Directive.interp [Labels]
+  (d : Directive) (s : MachineData) (p : Std.Rco Int64) : Effects (MachineData × Ctrl) :=
   match d with
-  | .label _ => next s
-  | .instr i => i.interp s p next jmp
+  | .label _ => .done (s, .next)
+  | .instr i => i.interp s p
   | .byteArray _ => .unimplemented s!"Unimplemented: execution reached data block at {p.1}"
 
-def Directives.interp {α : Type} [Labels]
-  (ds : List (Directive × Nat)) (s : MachineData) (pc : Int64)
-  (ret : Int64 → MachineData → Effects α) : Effects α :=
+/-- How control leaves a list of directives. -/
+inductive BlockExit : Type
+  | fallthrough (next : Int64)
+  | jump (target : Int64)
+  deriving Repr, BEq, DecidableEq
+
+/-- The program counter after the exit, forgetting how control got there. -/
+@[kstep] def BlockExit.pc : BlockExit → Int64
+  | .fallthrough next => next
+  | .jump target => target
+
+/-- Run directives in order until the list ends or an instruction jumps. -/
+def Directives.interp [Labels]
+  (ds : List (Directive × Nat)) (s : MachineData) (pc : Int64) : Effects (MachineData × BlockExit) :=
   match ds with
-  | [] => ret pc s
-  | (d, sz) :: ds =>
-    d.interp s (.mk pc (pc+.ofNat sz)) (jmp:=ret) (next := (fun s =>
-    interp ds s (pc+.ofNat sz) ret))
+  | [] => .done (s, .fallthrough pc)
+  | (d, sz) :: ds => do
+    let (s, c) ← d.interp s (.mk pc (pc+.ofNat sz))
+    match c with
+    | .next => interp ds s (pc+.ofNat sz)
+    | .jmp target => pure (s, .jump target)
 
 abbrev Layout := Kraken.Layout Directive
 
@@ -994,15 +1027,30 @@ def Executable.directivesFromLabel (e : Executable) (l : Label) : List (Directiv
 
 abbrev MachineState := MachineData × Int64
 
+/-- Execute one positive-sized instruction, together with any leading
+zero-sized directives, passing the state and block exit to the continuation.
+The block is delimited by the size table (`takeBlock`); on a layout whose
+sizes wrap modulo 2^64 this can be a proper prefix of the directives whose
+assigned address equals the pc. -/
+def Executable.stepWithExit {α : Type} (e : Executable) (s : MachineState)
+    (ret : MachineData → BlockExit → Effects α) : Effects α :=
+  let := e.labels
+  (Directives.interp (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)) s.1 s.2).bind
+    fun (s', ex) => ret s' ex
+
 def Executable.step {α : Type} (e : Executable) (s : MachineState)
     (ret : MachineState → Effects α) : Effects α :=
-  let := e.labels
-  Directives.interp (e.directivesAtAddress s.2) s.1 s.2 (fun pc s => ret (s, pc))
+  e.stepWithExit s (fun s' ex => ret (s', ex.pc))
 
+/-- Run from the current address to the first taken jump or the end of the
+listing. Derived from the same monadic core as `step`, with the exit's
+program counter forgotten — behaviorally the semantics `Executable.eval`
+and the specs have always had. -/
 def Executable.straightline {α : Type} (e : Executable) (s : MachineState)
     (ret : MachineState → Effects α) : Effects α :=
   let := e.labels
-  Directives.interp (e.directivesFromAddress s.2) s.1 s.2 (fun pc s => ret (s, pc))
+  (Directives.interp (e.directivesFromAddress s.2) s.1 s.2).bind
+    fun (s', ex) => ret (s', ex.pc)
 
 -- -- Concrete evaluators for expedient testing
 

--- a/Kraken/AArch64/Sep.lean
+++ b/Kraken/AArch64/Sep.lean
@@ -7,7 +7,8 @@ open Std.ExtHashMap
 open List
 
 @[kspec]
-theorem store_sep (s : MachineData) (addr : BitVec 64) (w : MemWidth) (v : w.type) (ret : MachineData → Effects)
+theorem store_sep {α : Type} (s : MachineData) (addr : BitVec 64) (w : MemWidth)
+    (v : w.type) (ret : MachineData → Effects α)
     (bs : List UInt8) (R : DataMem → Prop)
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :
@@ -20,7 +21,8 @@ theorem store_sep (s : MachineData) (addr : BitVec 64) (w : MemWidth) (v : w.typ
   simp only [MachineData.store, h_load]
 
 @[kspec]
-theorem load_sep (s : MachineData) (addr : BitVec 64) (w : MemWidth) (ret : w.type → MachineData → Effects)
+theorem load_sep {α : Type} (s : MachineData) (addr : BitVec 64) (w : MemWidth)
+    (ret : w.type → MachineData → Effects α)
     (bs : List UInt8) (R : DataMem → Prop)
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :

--- a/Kraken/AArch64/Sep.lean
+++ b/Kraken/AArch64/Sep.lean
@@ -8,25 +8,26 @@ open List
 
 @[kspec]
 theorem store_sep {α : Type} (s : MachineData) (addr : BitVec 64) (w : MemWidth)
-    (v : w.type) (ret : MachineData → Effects α)
+    (v : w.type) (k : MachineData → Effects α)
     (bs : List UInt8) (R : DataMem → Prop)
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :
     have mem' := Mem.storeInt s.dmem addr w.bytes v.toInt
-    MachineData.store s addr v ret =
+    (MachineData.store s addr v).bind k =
       require_write_access addr w (fun _ =>
-        ret { s with dmem := mem' }) := by
+        k { s with dmem := mem' }) := by
   have h_load : Mem.loadInt s.dmem addr w.bytes = some (Int.ofBytes bs) :=
     Mem.loadInt_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)
-  simp only [MachineData.store, h_load]
+  simp only [MachineData.store, h_load, Effects.bind]
 
 @[kspec]
 theorem load_sep {α : Type} (s : MachineData) (addr : BitVec 64) (w : MemWidth)
-    (ret : w.type → MachineData → Effects α)
+    (k : w.type × MachineData → Effects α)
     (bs : List UInt8) (R : DataMem → Prop)
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :
-    MachineData.load s addr w ret =
-      require_read_access addr w (fun _ => ret (.ofInt w.bits (Int.ofBytes bs)) s) := by
+    (MachineData.load s addr w).bind k =
+      require_read_access addr w (fun _ => k (.ofInt w.bits (Int.ofBytes bs), s)) := by
   simp only [MachineData.load,
-    Mem.loadInt_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)]
+    Mem.loadInt_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide),
+    Effects.bind]

--- a/Kraken/Layout.lean
+++ b/Kraken/Layout.lean
@@ -87,13 +87,21 @@ def Directives.takeBlock {Directive : Type} : List (Directive × Nat) → List (
 were taken from. -/
 theorem Directives.takeBlock_prefix {Directive : Type} (ds : List (Directive × Nat)) :
     ∃ rest, ds = Directives.takeBlock ds ++ rest := by
-  induction ds with
-  | nil => exact ⟨[], rfl⟩
-  | cons entry rest ih =>
-    by_cases h : entry.2 = 0
-    · obtain ⟨tail, htail⟩ := ih
-      exact ⟨tail, by simp [Directives.takeBlock, h]; exact htail⟩
-    · exact ⟨rest, by simp [Directives.takeBlock, h]⟩
+  induction ds <;> simp_all [Directives.takeBlock] <;> split <;> simp_all
+
+/-- A nonempty listing yields a nonempty block. -/
+theorem Directives.takeBlock_ne_nil {Directive : Type} {ds : List (Directive × Nat)}
+    (h : ds ≠ []) : Directives.takeBlock ds ≠ [] := by
+  cases ds <;> simp_all [Directives.takeBlock] <;> split <;> simp_all
+
+/-- A listing of zero-sized directives is one block. -/
+theorem Directives.takeBlock_of_all_zero {Directive : Type} {ds : List (Directive × Nat)}
+    (h : ∀ d ∈ ds, d.2 = 0) : Directives.takeBlock ds = ds := by
+  induction ds <;> simp_all [Directives.takeBlock]
+
+theorem Directives.takeBlock_length_pos {Directive : Type} {ds : List (Directive × Nat)}
+    (h : ds ≠ []) : 0 < (Directives.takeBlock ds).length :=
+  Nat.pos_iff_ne_zero.mpr (by simpa using Directives.takeBlock_ne_nil h)
 
 /-- Advance `pc` across a sequence of laid-out directives. -/
 def Directives.fallthroughPC {Directive : Type} (ds : List (Directive × Nat)) (pc : Int64) : Int64 :=

--- a/Kraken/Layout.lean
+++ b/Kraken/Layout.lean
@@ -70,4 +70,47 @@ theorem directivesAtFromPrefix {Directive : Type} (e: Executable Directive) (a: 
   rw [← List.map_append]
   rw [List.takeWhile_append_dropWhile]
 
+/-- Take the leading zero-sized entries through the first positive-sized one.
+
+Grouping zero-sized entries with their positive-sized successor is what makes
+repeated stepping make progress: a zero-sized directive occupies no address
+space, so fetching at its address again would yield it forever. On a listing
+whose addresses are laid out consecutively this is exactly
+`directivesAtAddress` at the block's start address: the entries starting at a
+given address are the zero-sized run there plus the first positive-sized
+directive. -/
+def Directives.takeBlock {Directive : Type} : List (Directive × Nat) → List (Directive × Nat)
+  | [] => []
+  | entry :: rest => if entry.2 = 0 then entry :: takeBlock rest else [entry]
+
+/-- The directives of a block are an initial segment of the directives they
+were taken from. -/
+theorem Directives.takeBlock_prefix {Directive : Type} (ds : List (Directive × Nat)) :
+    ∃ rest, ds = Directives.takeBlock ds ++ rest := by
+  induction ds with
+  | nil => exact ⟨[], rfl⟩
+  | cons entry rest ih =>
+    by_cases h : entry.2 = 0
+    · obtain ⟨tail, htail⟩ := ih
+      exact ⟨tail, by simp [Directives.takeBlock, h]; exact htail⟩
+    · exact ⟨rest, by simp [Directives.takeBlock, h]⟩
+
+/-- Advance `pc` across a sequence of laid-out directives. -/
+def Directives.fallthroughPC {Directive : Type} (ds : List (Directive × Nat)) (pc : Int64) : Int64 :=
+  ds.foldl (fun pc d => pc + .ofNat d.2) pc
+
+theorem Directives.fallthroughPC_append {Directive : Type}
+    (ds₁ ds₂ : List (Directive × Nat)) (pc : Int64) :
+    Directives.fallthroughPC (ds₁ ++ ds₂) pc =
+      Directives.fallthroughPC ds₂ (Directives.fallthroughPC ds₁ pc) := by
+  simp [Directives.fallthroughPC, List.foldl_append]
+
+/-- The address assigned to directive `i` by an executable's size table.
+At and beyond the end of the executable this is its fall-through address. -/
+def Directives.addressAt {Directive : Type} (ds : List (Directive × Nat)) (pc : Int64) (i : Nat) : Int64 :=
+  Directives.fallthroughPC (ds.take i) pc
+
+def Executable.addressAt {Directive : Type} (e : Executable Directive) (i : Nat) : Int64 :=
+  Directives.addressAt e.2 e.1 i
+
 end Kraken

--- a/Kraken/Tactics.lean
+++ b/Kraken/Tactics.lean
@@ -166,7 +166,32 @@ inductive AdvanceResult where
 
 partial def advanceEffectsTree (maxInstrCount : Option (IO.Ref Nat)) (t : Expr) :
     DSimpM AdvanceResult := do
-  if t.isApp && t.getAppFn'.isConstOf `Directives.interp then
+  if t.isApp && t.getAppFn'.isConstOf ``Bind.bind && t.getAppArgs.size ≥ 6 then
+    -- `do`-notation elaborates to the `Bind.bind` method; when the instance is
+    -- the canonical `Effects` monad this is definitionally the structural
+    -- `Effects.bind`, and rebuilding it in that form gives the spine walk
+    -- below one head to work with. The equality is verified before stepping:
+    -- for any other instance the rebuild is not defeq, and the node is left
+    -- alone. Argument layout of `@Bind.bind`: [monad, inst, α, β, x, f].
+    let bargs := t.getAppArgs
+    let t' := mkApp4 (mkConst `Effects.bind)
+      bargs[bargs.size - 4]! bargs[bargs.size - 3]! bargs[bargs.size - 2]! bargs[bargs.size - 1]!
+    if ← (try withNewMCtxDepth (Meta.withTransparency .default (Meta.isDefEq t' t)) catch _ => pure false) then
+      return .stepped t'
+    else
+      return .stuck
+  else if t.isApp && t.getAppFn'.isConstOf ``Pure.pure && t.getAppArgs.size ≥ 4 then
+    -- Likewise `pure` is the `Pure.pure` method over `Effects.done`, with the
+    -- same canonical-instance check. Argument layout of `@Pure.pure`:
+    -- [monad, inst, α, a].
+    let bargs := t.getAppArgs
+    let t' := mkApp2 (mkConst `Effects.done)
+      bargs[bargs.size - 2]! bargs[bargs.size - 1]!
+    if ← (try withNewMCtxDepth (Meta.withTransparency .default (Meta.isDefEq t' t)) catch _ => pure false) then
+      return .stepped t'
+    else
+      return .stuck
+  else if t.isApp && t.getAppFn'.isConstOf `Directives.interp then
     -- We optionally track how many times we've hit Directives.interp -- this tracks how
     -- many instructions we've stepped through.
     if (← maxInstrCount.mapM (·.get)) = .some 0 then
@@ -180,8 +205,18 @@ partial def advanceEffectsTree (maxInstrCount : Option (IO.Ref Nat)) (t : Expr) 
     if bargs.size < 2 then
       return .stuck
     else
-      let m := bargs[bargs.size - 2]!
-      if ← isEffectsCtorHead m then
+      let m := bargs[bargs.size - 2]!.consumeMData
+      if m.isLet then
+        -- Float the let through the bind (a defeq step):
+        -- `bind (let x := v; T) k ≡ let x := v; bind T k`. Everything here is
+        -- locally closed except the let body's own binder, so no lifting is
+        -- needed to move `k` under it. The arg-peeling machinery at the
+        -- enclosing `Effects.All` node then hoists it into the context, as the
+        -- CPS reduction path always did.
+        let .letE n ty val body nondep := m | return .stuck
+        return .stepped (.letE n ty val
+          (mkAppN t.getAppFn' ((bargs.set! (bargs.size - 2) body))) nondep)
+      else if ← isEffectsCtorHead m then
         -- `m` is a constructor application: delta `bind` here so the matcher
         -- can consume it on the next pass.
         let some t' ← Meta.unfoldDefinition? t true | return .stuck
@@ -402,7 +437,18 @@ partial def evalSymKStep : Grind.GrindTactic :=
   let specLemmas := (kspecExtension.getState env).toList
   let specTree: DiscrTree Name ← specLemmas.foldlM (fun specTree name => do
     -- NOTE: hardcoding left-to-right order, for now
-    let (pat, _) ← mkEqPatternFromDecl name
+    -- Key each lemma on the effectful operation itself: for a bind-context
+    -- equation `(op …).bind k = …` that is the bind's first operand. Keying on
+    -- the whole bind node would drag `Effects.bind`'s type argument into the
+    -- key — for a load that is the dependent `w.type × MachineData`, which
+    -- never matches the goal's already-reduced form.
+    let (pat, _) ← Sym.mkPatternFromDeclWithKey name (selectKey := fun type => do
+      let_expr Eq _ lhs _ := type | throwError "kspec lemma {name} is not an equation"
+      let lhs := lhs.consumeMData
+      if lhs.isApp && lhs.getAppFn.isConstOf `Effects.bind && lhs.getAppArgs.size ≥ 2 then
+        pure (lhs.getAppArgs[lhs.getAppArgs.size - 2]!, ())
+      else
+        pure (lhs, ()))
     pure (insertPattern specTree pat name)
   ) {}
 

--- a/Kraken/Tactics.lean
+++ b/Kraken/Tactics.lean
@@ -90,6 +90,15 @@ elab_rules : tactic
          rw [Executable.directivesFromStart]
          simp [List.mapIdx, List.mapIdx.go])))
 
+/-- Cut the current straight-line goal after the given listing prefix: the
+`hsplit` goal is the fetch-coherence side condition at the split, and the
+`run` goal executes the prefix, leaving a same-shaped straight-line goal at
+each fall-through exit. With `kstep`'s budget this advances a bounded number
+of directives and stops at a sound resume point. -/
+macro "kcut" pre:term : tactic => do
+  let cut := Lean.mkIdent `Executable.straightlineStep_cut
+  `(tactic| refine $cut _ _ _ $pre ?hsplit ?run)
+
 --------------------------------------------------------------------------------
 
 open Sym Sym.DSimp
@@ -195,10 +204,15 @@ partial def advanceEffectsTree (maxInstrCount : Option (IO.Ref Nat)) (t : Expr) 
     -- many instructions we've stepped through.
     if (← maxInstrCount.mapM (·.get)) = .some 0 then
       return .budgetExhausted
-    let some t' ← Meta.unfoldDefinition? t true | throwError "can't unfold Directives.interp"
-    maxInstrCount.forM (fun r => r.modify (· - 1))
-    trace[Kraken.kstep] "consumed a directive at {t}"
-    return .stepped t'
+    match ← Meta.unfoldDefinition? t true with
+    | some t' =>
+      maxInstrCount.forM (fun r => r.modify (· - 1))
+      trace[Kraken.kstep] "consumed a directive at {t}"
+      return .stepped t'
+    | none =>
+      -- The directive list is not yet in constructor form (for example a
+      -- `take` that STEP 2 still needs to evaluate); stall rather than fail.
+      return .stuck
   else if t.isApp && t.getAppFn'.isConstOf `Effects.bind then
     let bargs := t.getAppArgs
     if bargs.size < 2 then

--- a/Kraken/Tactics.lean
+++ b/Kraken/Tactics.lean
@@ -132,6 +132,67 @@ partial def peelArgsLets (args : Array Expr) (i : Nat) (peeled : Array Expr) (fv
   else
     k peeled fvars
 
+/-- Is `e` an application headed by a constructor of the (ISA-local, root-level)
+`Effects` inductive? -/
+def isEffectsCtorHead (e : Expr) : MetaM Bool := do
+  let some n := e.getAppFn'.constName? | return false
+  match (← getEnv).find? n with
+  | some (.ctorInfo ci) => return ci.induct == `Effects
+  | _ => return false
+
+/-- Advance the effects tree sitting under `Effects.All` by one defeq step.
+
+While `Effects` is a monomorphic CPS type, the tree's head is
+`Directives.interp` directly. Under a result-polymorphic monadic `Effects`,
+the tree is a left-nested `Effects.bind` spine and the reduction site is its
+leftmost operand: a `Directives.interp` there gets force-unfolded in place
+(this is the event the step budget counts — one directive consumed from the
+list), and a constructor-headed operand lets the `bind` matcher itself reduce
+(plain definitional unfolding; the ctor commutes with `bind` one node at a
+time). Neither `Directives.interp` nor `Effects.bind` may be `@[kstep]`-tagged:
+the dsimp traversal is pre-order, so unfolding them head-first would produce
+matchers stuck on unreduced scrutinees.
+
+`stuck` means nothing here can advance (a `@[kspec]` hand-off such as
+`MachineData.load`/`store`, or a symbolic branch); `budgetExhausted` means the
+next advance would consume a directive the step budget no longer allows — the
+caller must block further reduction of this node rather than fall through to
+generic unfolding, which would step through directives behind the counter's
+back. -/
+inductive AdvanceResult where
+  | stepped (tree : Expr)
+  | budgetExhausted
+  | stuck
+
+partial def advanceEffectsTree (maxInstrCount : Option (IO.Ref Nat)) (t : Expr) :
+    DSimpM AdvanceResult := do
+  if t.isApp && t.getAppFn'.isConstOf `Directives.interp then
+    -- We optionally track how many times we've hit Directives.interp -- this tracks how
+    -- many instructions we've stepped through.
+    if (← maxInstrCount.mapM (·.get)) = .some 0 then
+      return .budgetExhausted
+    let some t' ← Meta.unfoldDefinition? t true | throwError "can't unfold Directives.interp"
+    maxInstrCount.forM (fun r => r.modify (· - 1))
+    trace[Kraken.kstep] "consumed a directive at {t}"
+    return .stepped t'
+  else if t.isApp && t.getAppFn'.isConstOf `Effects.bind then
+    let bargs := t.getAppArgs
+    if bargs.size < 2 then
+      return .stuck
+    else
+      let m := bargs[bargs.size - 2]!
+      if ← isEffectsCtorHead m then
+        -- `m` is a constructor application: delta `bind` here so the matcher
+        -- can consume it on the next pass.
+        let some t' ← Meta.unfoldDefinition? t true | return .stuck
+        return .stepped t'
+      else
+        match ← advanceEffectsTree maxInstrCount m with
+        | .stepped m' => return .stepped (mkAppN t.getAppFn' (bargs.set! (bargs.size - 2) m'))
+        | r => return r
+  else
+    return .stuck
+
 def kdeltaBetaOnly (targets: List Name) (maxInstrCount : Option (IO.Ref Nat)) : DSimproc := fun e => do
   -- This focuses on application nodes.
   unless e.isApp && targets.any e.getAppFn'.isConstOf do return .rfl
@@ -146,34 +207,13 @@ def kdeltaBetaOnly (targets: List Name) (maxInstrCount : Option (IO.Ref Nat)) : 
   -- semantics. Concretely: `f (let x = ... in arg)` => `let x = ... in f arg`.
   peelArgsLets args 0 #[] #[] fun (args : Array Expr) (fvars : Array Expr) => do
 
-    if f.isConstOf `Effects.All && args[1]!.isApp && args[1]!.getAppFn'.isConstOf `Directives.interp then
-      -- We optionally track how many times we've hit Directives.interp -- this tracks how
-      -- many instructions we've stepped through.
-      if (← maxInstrCount.mapM (·.get)) = .some 0 then
-        return .rfl
-      maxInstrCount.forM (fun r => r.modify (· - 1))
-
-      -- Finding a node of the form `Effects.All ... (Directives.interp ...)`
-      -- means that we are ready to step through. We manually force reduction of
-      -- Directives.interp (since it is *not* is our list of targets), then let
-      -- everything simplify until we're called again.
-      let some arg1 ← Meta.unfoldDefinition? args[1]! true | throwError "can't unfold Directives.interp"
-      let e := mkAppN f (args.set! 1 arg1)
-      let e' ← shareCommon e
-      let e'' ← mkLetFVars fvars e'
-      return .step e''
-      -- TODO: we could here have a post := in the simproc that forces the
-      -- result to be .step ... (done := true) to prevent the next unrolling of
-      -- Directives.interp from being applied. This would essentially allow
-      -- implementing a kstep1 tactic (and leave it to done := false to keep
-      -- stepping until something blocks).
-
-      -- Essentially this behavior allows us to keep reducing and stepping,
-      -- until we have no steps left to apply and YET the goal has landed us
-      -- back on something that is neither Effects.All ... (Directives.interp
-      -- ...), nor Effects.All ... (require_exec_access ...), handled in the
-      -- case below.
-    else
+    -- The generic path: force one step of delta-beta on a `@[kstep]`-tagged
+    -- application. (Also the fallback when the effects tree cannot advance:
+    -- this keeps reducing and stepping until we have no steps left to apply
+    -- and YET the goal has landed us back on something that is neither
+    -- `Effects.All ... (Directives.interp ...)` nor
+    -- `Effects.All ... (require_exec_access ...)`.)
+    let generic : DSimpM Result := do
       -- Application, *sans* the let-bindings in the arguments.
       let e_rebuilt := mkAppN f args
       -- Remember that `Meta.unfoldDefinition` is "smart" and wants to see the whole
@@ -194,6 +234,31 @@ def kdeltaBetaOnly (targets: List Name) (maxInstrCount : Option (IO.Ref Nat)) : 
       else
         -- Really nothing to do here.
         return .rfl
+
+    -- The effects tree is `Effects.All`'s last argument: the predicate is
+    -- 2-ary while `Effects` is monomorphic and 3-ary once it is
+    -- result-polymorphic.
+    let treeIdx := args.size - 1
+    if f.isConstOf `Effects.All && args.size ≥ 2 && args[treeIdx]!.isApp then
+      match ← advanceEffectsTree maxInstrCount args[treeIdx]! with
+      | .stepped tree' =>
+        let e := mkAppN f (args.set! treeIdx tree')
+        let e' ← shareCommon e
+        let e'' ← mkLetFVars fvars e'
+        return .step e''
+        -- TODO: we could here have a post := in the simproc that forces the
+        -- result to be .step ... (done := true) to prevent the next unrolling of
+        -- Directives.interp from being applied. This would essentially allow
+        -- implementing a kstep1 tactic (and leave it to done := false to keep
+        -- stepping until something blocks).
+      | .budgetExhausted =>
+        -- Out of steps: freeze this node. Falling through to the generic
+        -- branch would let smart unfolding of `Effects.All` keep executing
+        -- directives without counting them.
+        return .rfl
+      | .stuck => generic
+    else
+      generic
 
 def gimmickId (p: Prop): Prop := p
 
@@ -261,19 +326,6 @@ def kdsimpProj : DSimproc := fun e => do
       | none   => return .rfl
   -- TODO: special support for instances?
   reduceProjCont? (← unfoldDefinition? e)
-
-def kLiftLets : DSimproc := fun e => do
-  -- We only lift lets to the top-level (which is always an application of
-  -- Effects.all)
-  unless e.isApp && e.getAppFn'.isConstOf `Effects.All do return .rfl
-
-  let (es, st) ← ExtractLets.extract #[e] |>.run {} |>.run' {} |>.run { givenNames := [] }
-  unless st.decls.size > 0 do return .rfl
-
-  let e' := Meta.ExtractLets.mkLetDecls st.decls es[0]!
-  let e' ← Sym.share e'
-  /- logInfo m!"liftLets produces {e'}" -/
-  return .step e'
 
 -- FIXME: a copy-paste of the Lean implementation since it's marked as private
 def rwTarget (goal: Grind.Goal) (symm : Bool) (term : Expr) : Grind.GrindTacticM (Grind.Goal × List Grind.Goal) := do
@@ -404,17 +456,39 @@ partial def evalSymKStep : Grind.GrindTactic :=
         | .letE _ _ _ body _ => getEffectsState body
         | .mdata _ e => getEffectsState e
         | _ =>
-          if e.isApp && e.getAppFn.isConstOf `Effects.All && e.getAppArgs.size == 2 then
-            some e.getAppArgs[1]!
+          -- The effects tree is `Effects.All`'s last argument (2-ary while
+          -- `Effects` is monomorphic, 3-ary once it is result-polymorphic).
+          if e.isApp && e.getAppFn.isConstOf `Effects.All && e.getAppArgs.size ≥ 2 then
+            some e.getAppArgs.back!
           else
             none
       -- No more Effects.All in the goal -- return to the user (we might be done,
       -- or realistically, we might need to debug).
       let some state := getEffectsState goalT' | return (goal, [])
+      -- Guard against shape drift: what we hand to the spec engine must be an
+      -- `Effects` tree. (A partially applied `Effects.All` would satisfy the
+      -- arity test above and silently hand a predicate to the DiscrTree.)
+      let stateTy ← inferType state
+      unless stateTy.getAppFn.isConstOf `Effects do
+        throwError m!"kstep: found Effects.All but its last argument is not an effects tree:{indentExpr state}"
       pure state
 
+    -- A spec lemma's LHS may sit at the top of the tree (the CPS shapes, e.g.
+    -- `MachineData.load s addr w ret`) or at the leftmost operand of an
+    -- `Effects.bind` spine (the monadic shapes). Offer the tree and each spine
+    -- operand to the DiscrTree, outermost first, and take the first hit.
+    let rec specCandidates (t : Expr) (acc : Array Expr) : Array Expr :=
+      let acc := acc.push t
+      if t.isApp && t.getAppFn.isConstOf `Effects.bind && t.getAppArgs.size ≥ 2 then
+        specCandidates t.getAppArgs[t.getAppArgs.size - 2]! acc
+      else
+        acc
+    let specMatches := ((specCandidates goalState #[]).findSome? (fun c =>
+      let ms := getMatch specTree c
+      if ms.isEmpty then none else some ms)).getD #[]
+
     let (keepGoingSpec, goal) ←
-      match getMatch specTree goalState with
+      match specMatches with
       | #[ thmName ] =>
         logInfo m!"Found a spec lemma: {thmName}"
         let (goal, subGoals) ← rwTarget goal false (mkConst thmName)

--- a/Kraken/Tactics.lean
+++ b/Kraken/Tactics.lean
@@ -142,23 +142,22 @@ def isEffectsCtorHead (e : Expr) : MetaM Bool := do
 
 /-- Advance the effects tree sitting under `Effects.All` by one defeq step.
 
-While `Effects` is a monomorphic CPS type, the tree's head is
-`Directives.interp` directly. Under a result-polymorphic monadic `Effects`,
-the tree is a left-nested `Effects.bind` spine and the reduction site is its
-leftmost operand: a `Directives.interp` there gets force-unfolded in place
-(this is the event the step budget counts — one directive consumed from the
-list), and a constructor-headed operand lets the `bind` matcher itself reduce
-(plain definitional unfolding; the ctor commutes with `bind` one node at a
-time). Neither `Directives.interp` nor `Effects.bind` may be `@[kstep]`-tagged:
+The tree is a left-nested `Effects.bind` spine (or a bare `Directives.interp`
+application), and the reduction site is its leftmost operand: a
+`Directives.interp` there gets force-unfolded in place, which is the event
+the step budget counts, one directive consumed from the list. A
+constructor-headed operand lets the `bind` matcher itself reduce by plain
+definitional unfolding; the constructor commutes with `bind` one node at a
+time. Neither `Directives.interp` nor `Effects.bind` may be `@[kstep]`-tagged:
 the dsimp traversal is pre-order, so unfolding them head-first would produce
 matchers stuck on unreduced scrutinees.
 
 `stuck` means nothing here can advance (a `@[kspec]` hand-off such as
-`MachineData.load`/`store`, or a symbolic branch); `budgetExhausted` means the
-next advance would consume a directive the step budget no longer allows — the
-caller must block further reduction of this node rather than fall through to
-generic unfolding, which would step through directives behind the counter's
-back. -/
+`MachineData.load`/`store`, or a symbolic branch). `budgetExhausted` means
+the next advance would consume a directive the step budget does not allow;
+the caller must block further reduction of this node rather than fall
+through to generic unfolding, which would step through directives behind the
+counter's back. -/
 inductive AdvanceResult where
   | stepped (tree : Expr)
   | budgetExhausted
@@ -211,8 +210,8 @@ partial def advanceEffectsTree (maxInstrCount : Option (IO.Ref Nat)) (t : Expr) 
         -- `bind (let x := v; T) k ≡ let x := v; bind T k`. Everything here is
         -- locally closed except the let body's own binder, so no lifting is
         -- needed to move `k` under it. The arg-peeling machinery at the
-        -- enclosing `Effects.All` node then hoists it into the context, as the
-        -- CPS reduction path always did.
+        -- enclosing `Effects.All` node then hoists it into the context, where
+        -- reduction can continue around it.
         let .letE n ty val body nondep := m | return .stuck
         return .stepped (.letE n ty val
           (mkAppN t.getAppFn' ((bargs.set! (bargs.size - 2) body))) nondep)
@@ -270,9 +269,9 @@ def kdeltaBetaOnly (targets: List Name) (maxInstrCount : Option (IO.Ref Nat)) : 
         -- Really nothing to do here.
         return .rfl
 
-    -- The effects tree is `Effects.All`'s last argument: the predicate is
-    -- 2-ary while `Effects` is monomorphic and 3-ary once it is
-    -- result-polymorphic.
+    -- The effects tree is `Effects.All`'s last argument; indexing from the
+    -- end keeps this independent of the number of leading implicit
+    -- arguments.
     let treeIdx := args.size - 1
     if f.isConstOf `Effects.All && args.size ≥ 2 && args[treeIdx]!.isApp then
       match ← advanceEffectsTree maxInstrCount args[treeIdx]! with
@@ -438,9 +437,9 @@ partial def evalSymKStep : Grind.GrindTactic :=
   let specTree: DiscrTree Name ← specLemmas.foldlM (fun specTree name => do
     -- NOTE: hardcoding left-to-right order, for now
     -- Key each lemma on the effectful operation itself: for a bind-context
-    -- equation `(op …).bind k = …` that is the bind's first operand. Keying on
-    -- the whole bind node would drag `Effects.bind`'s type argument into the
-    -- key — for a load that is the dependent `w.type × MachineData`, which
+    -- equation `(op …).bind k = …` that is the bind's first operand. Keying
+    -- on the whole bind node would drag `Effects.bind`'s type argument into
+    -- the key; for a load that is the dependent `w.type × MachineData`, which
     -- never matches the goal's already-reduced form.
     let (pat, _) ← Sym.mkPatternFromDeclWithKey name (selectKey := fun type => do
       let_expr Eq _ lhs _ := type | throwError "kspec lemma {name} is not an equation"
@@ -502,8 +501,8 @@ partial def evalSymKStep : Grind.GrindTactic :=
         | .letE _ _ _ body _ => getEffectsState body
         | .mdata _ e => getEffectsState e
         | _ =>
-          -- The effects tree is `Effects.All`'s last argument (2-ary while
-          -- `Effects` is monomorphic, 3-ary once it is result-polymorphic).
+          -- The effects tree is `Effects.All`'s last argument; indexing
+          -- from the end keeps this independent of the leading implicits.
           if e.isApp && e.getAppFn.isConstOf `Effects.All && e.getAppArgs.size ≥ 2 then
             some e.getAppArgs.back!
           else
@@ -519,10 +518,10 @@ partial def evalSymKStep : Grind.GrindTactic :=
         throwError m!"kstep: found Effects.All but its last argument is not an effects tree:{indentExpr state}"
       pure state
 
-    -- A spec lemma's LHS may sit at the top of the tree (the CPS shapes, e.g.
-    -- `MachineData.load s addr w ret`) or at the leftmost operand of an
-    -- `Effects.bind` spine (the monadic shapes). Offer the tree and each spine
-    -- operand to the DiscrTree, outermost first, and take the first hit.
+    -- A spec lemma's subject may sit at the top of the tree or at the
+    -- leftmost operand of an `Effects.bind` spine. Offer the tree and each
+    -- spine operand to the DiscrTree, outermost first, and take the first
+    -- hit.
     let rec specCandidates (t : Expr) (acc : Array Expr) : Array Expr :=
       let acc := acc.push t
       if t.isApp && t.getAppFn.isConstOf `Effects.bind && t.getAppArgs.size ≥ 2 then

--- a/Kraken/X64/Examples/Examples.lean
+++ b/Kraken/X64/Examples/Examples.lean
@@ -253,32 +253,22 @@ theorem p3_len : ((layout p3).2).length = 10 := by
 theorem p3_fst : (layout p3).1 = layout.start := rfl
 
 theorem p3_raddr2 : raddr layout.start ((layout p3).2) 2 = paddr 2 := by
-  simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil]
-  simp [raddr, paddr]
+  simp [Kraken.Layout.apply, p3, raddr, paddr, List.mapIdx_cons, List.mapIdx_nil]
 
 theorem p3_raddr8 : raddr layout.start ((layout p3).2) 8 = paddr 8 := by
-  simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil]
-  simp [raddr, paddr]
+  simp [Kraken.Layout.apply, p3, raddr, paddr, List.mapIdx_cons, List.mapIdx_nil]
 
 theorem p3_raddr_lt2 (i : Nat) (hi : i < 2) :
     raddr layout.start ((layout p3).2) i = paddr i := by
   simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil]
   match i, hi with
-  | 0, _ => simp [raddr, paddr]
-  | 1, _ => simp [raddr, paddr]
+  | 0, _ | 1, _ => simp [raddr, paddr]
 
 theorem p3_raddr_lt8 (i : Nat) (hi : i < 8) :
     raddr layout.start ((layout p3).2) i = paddr i := by
   simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil]
   match i, hi with
-  | 0, _ => simp [raddr, paddr]
-  | 1, _ => simp [raddr, paddr]
-  | 2, _ => simp [raddr, paddr]
-  | 3, _ => simp [raddr, paddr]
-  | 4, _ => simp [raddr, paddr]
-  | 5, _ => simp [raddr, paddr]
-  | 6, _ => simp [raddr, paddr]
-  | 7, _ => simp [raddr, paddr]
+  | 0, _ | 1, _ | 2, _ | 3, _ | 4, _ | 5, _ | 6, _ | 7, _ => simp [raddr, paddr]
 
 /-- The layout places p3's directives so that the two jump targets are unambiguous. -/
 structure SaneP3Layout : Prop where
@@ -339,11 +329,7 @@ theorem jmp_back_plain (X : Int64) : X + ((paddr 2 : Int64) - X) = paddr 2 := by
 
 theorem jmp_back (X : Int64) :
     Int64.ofBitVec ((X + ((paddr 2 : Int64) - X)).toBitVec) = (paddr 2 : Int64) := by
-  have h : X + ((paddr 2 : Int64) - X) = paddr 2 := by
-    apply Int64.toBitVec_inj.mp
-    simp [Int64.toBitVec_add, Int64.toBitVec_sub]
-    rw [BitVec.add_comm, BitVec.sub_add_cancel]
-  rw [h]; rfl
+  simp [jmp_back_plain]
 
 
 -- Gauge: the head block with rbx = 0 falls through to _end, registers intact.
@@ -406,8 +392,8 @@ theorem step_head_nz (h : SaneP3Layout (layout := layout)) (s : MachineData)
     sym =>
     kstep
     tactic =>
-    simp [Effects.bind_eq, Effects.pure_eq, Effects.bind, Effects.All,
-      RelRegOrMem.interp, ConstExpr.interp, p3_label_start', jmp_back, jmp_back_plain]
+    simp [Effects.pure_eq, Effects.bind, Effects.All,
+      RelRegOrMem.interp, ConstExpr.interp, p3_label_start', jmp_back_plain]
     refine hQ _ _ _ _ ?_ ?_ ?_
     · show BitVec.ofInt 64 _ = _
       congr 1
@@ -485,8 +471,8 @@ theorem step_init_nz (s : MachineData) (hnz : s.regs.rbx ≠ 0) (Q : @Post Machi
     sym =>
     kstep
     tactic =>
-    simp [Effects.bind_eq, Effects.pure_eq, Effects.bind, Effects.All,
-      RelRegOrMem.interp, ConstExpr.interp, p3_label_start', jmp_back, jmp_back_plain]
+    simp [Effects.pure_eq, Effects.bind, Effects.All,
+      RelRegOrMem.interp, ConstExpr.interp, p3_label_start', jmp_back_plain]
     refine hQ _ _ _ _ ?_ ?_ ?_
     · show BitVec.ofInt 64 _ = _
       decide
@@ -500,17 +486,12 @@ theorem step_init_nz (s : MachineData) (hnz : s.regs.rbx ≠ 0) (Q : @Post Machi
 
 -- Arithmetic helpers for the mulx bound.
 theorem ofInt_toNat_of_lt (m : Nat) (hm : m < 2^64) :
-    (BitVec.ofInt 64 (m : Int)).toNat = m := by
-  simp [BitVec.toNat_ofInt]
-  omega
+    (BitVec.ofInt 64 (m : Int)).toNat = m := by simp; omega
 
 theorem ofInt_shift_of_lt (m : Nat) (hm : m < 2^64) :
     (BitVec.ofInt 64 ((m : Int) >>> 64)) = 0#64 := by
-  have : ((m : Int) >>> 64) = 0 := by
-    rw [Int.shiftRight_eq_div_pow]
-    omega
-  rw [this]
-  rfl
+  have : ((m : Int) >>> 64) = 0 := by rw [Int.shiftRight_eq_div_pow]; omega
+  simp [this]
 
 
 
@@ -544,8 +525,7 @@ theorem inv_zero_post (h : SaneP3Layout (layout := layout)) (n : Nat)
 theorem uint64_sub_one_toNat (x : UInt64) (hx : x.toNat ≠ 0) :
     (x - 1).toNat = x.toNat - 1 := by
   have h1 : x.toNat < 2^64 := x.toNat_lt_size
-  have h2 : UInt64.toNat 1 = 1 := rfl
-  simp only [UInt64.toNat_sub, h2]
+  simp only [UInt64.toNat_sub, show UInt64.toNat 1 = 1 from rfl]
   omega
 
 set_option maxHeartbeats 4000000 in
@@ -648,18 +628,10 @@ theorem L1_sane : SaneP3Layout (layout := L1) := by
   constructor
   · intro i hi
     match i, hi with
-    | 0, _ => decide
-    | 1, _ => decide
+    | 0, _ | 1, _ => decide
   · intro i hi
     match i, hi with
-    | 0, _ => decide
-    | 1, _ => decide
-    | 2, _ => decide
-    | 3, _ => decide
-    | 4, _ => decide
-    | 5, _ => decide
-    | 6, _ => decide
-    | 7, _ => decide
+    | 0, _ | 1, _ | 2, _ | 3, _ | 4, _ | 5, _ | 6, _ | 7, _ => decide
 
 /-- ...and it really applies to a nontrivial state: `rbx = 3`, so the program
 must compute `rdx = 2^(2^3) = 256`. -/

--- a/Kraken/X64/Examples/Examples.lean
+++ b/Kraken/X64/Examples/Examples.lean
@@ -106,6 +106,44 @@ theorem swap_correct_step1 (d : MachineData) :
     (swapUnitLayout swap) swapExe_resolves _ _ (swap_correct d)
 end SwapStep1
 
+def fourMovs : Program := parse("
+  mov $1, %rax
+  mov $2, %rbx
+  mov $3, %rcx
+  mov $4, %rdx")
+
+-- Bounded stepping with a sound resume point: run the first two directives,
+-- stop, and continue from a goal of the same shape.
+section BoundedStepping
+
+local instance fourMovsLayout : Layout := { start := 0, size := fun _ => 1 }
+
+example (s : MachineData) :
+    straightlineStep (fourMovsLayout fourMovs) (s, (0 : Int64))
+      (fun s' => s'.1.regs.rdx = 4) := by
+  kcut ((fourMovsLayout fourMovs).2.take 2)
+  case hsplit =>
+    simp [fourMovs, Kraken.Layout.apply, List.mapIdx_cons, List.mapIdx_nil,
+      Kraken.Layout.start, Kraken.Layout.size,
+      Kraken.Executable.directivesFromAddress, Kraken.Executable.withAddresses,
+      List.dropWhile, Kraken.Directives.fallthroughPC]
+  case run =>
+  simp only [fourMovs, Kraken.Layout.apply, List.mapIdx_cons, List.mapIdx_nil,
+    Kraken.Layout.size, List.take_succ_cons, List.take_zero]
+  sym =>
+  kstep
+  tactic =>
+  -- the resume point: the same goal shape, at the middle of the program
+  dsimp only [straightlineStep, Executable.straightline]
+  simp only [Kraken.Layout.start, Kraken.Executable.directivesFromAddress,
+    Kraken.Executable.withAddresses, List.dropWhile]
+  sym =>
+  kstep
+  tactic =>
+  rfl
+
+end BoundedStepping
+
 -- Stepping demo. Ideally, this demo should be without the first .mov
 def p2 : Program := parse("
 start:

--- a/Kraken/X64/Examples/Examples.lean
+++ b/Kraken/X64/Examples/Examples.lean
@@ -20,6 +20,31 @@ import Kraken.X64.Sep
 
 open Kraken.X64.Parser
 
+attribute [ksimp]
+  BitVec.add_zero
+  BitVec.ofInt_add
+  BitVec.ofInt_ofNat
+  BitVec.ofInt_toInt
+  BitVec.ofNat_uInt64ToNat
+  BitVec.reduceOfInt
+  BitVec.setWidth_eq
+  Int.add_zero
+  Int.reduceBmod
+  Int.reduceNeg
+  Int64.reduceToInt
+  Int64.toInt_neg
+  Nat.reducePow
+  Nat.shiftRight_zero
+  Nat.sub_zero
+  UInt64.ofBitVec_add
+  UInt64.ofBitVec_ofNat
+  UInt64.ofBitVec_sub
+  UInt64.ofBitVec_toBitVec
+  UInt64.sub_add_cancel
+  UInt64.toBitVec_ofNat
+  UInt64.toBitVec_sub
+  UInt64.toNat_toBitVec
+
 --------------------------------------------------------------------------------
 
 def p1 := parse("start: mov $1, %rax")
@@ -228,31 +253,6 @@ set_option maxHeartbeats 1000000
 set_option pp.rawOnError true
 /- set_option pp.coercions false -/
 /- set_option pp.all true -/
-
-attribute [ksimp]
-  BitVec.add_zero
-  BitVec.ofInt_add
-  BitVec.ofInt_ofNat
-  BitVec.ofInt_toInt
-  BitVec.ofNat_uInt64ToNat
-  BitVec.reduceOfInt
-  BitVec.setWidth_eq
-  Int.add_zero
-  Int.reduceBmod
-  Int.reduceNeg
-  Int64.reduceToInt
-  Int64.toInt_neg
-  Nat.reducePow
-  Nat.shiftRight_zero
-  Nat.sub_zero
-  UInt64.ofBitVec_add
-  UInt64.ofBitVec_ofNat
-  UInt64.ofBitVec_sub
-  UInt64.ofBitVec_toBitVec
-  UInt64.sub_add_cancel
-  UInt64.toBitVec_ofNat
-  UInt64.toBitVec_sub
-  UInt64.toNat_toBitVec
 
 theorem p6_correct [layout : Layout] (s₀ : MachineData)
     (stack : List UInt8) (h_len : stack.length = 8) (R : DataMem → Prop)

--- a/Kraken/X64/Examples/Examples.lean
+++ b/Kraken/X64/Examples/Examples.lean
@@ -76,6 +76,36 @@ theorem swap_correct [layout : Layout] (d : MachineData) :
   apply Eventually.done
   grind
 
+-- The block-level proof above transfers to single-step execution at any
+-- coherently-laid-out executable; a unit layout is checked here concretely.
+section SwapStep1
+
+local instance swapUnitLayout : Layout := { start := 0, size := fun _ => 1 }
+
+theorem swapExe_resolves : Executable.Resolves (swapUnitLayout swap) := by
+  apply Executable.resolves_of_members
+  intro p hp
+  simp only [swap, Kraken.Layout.apply, List.mapIdx_cons, List.mapIdx_nil,
+    Kraken.Layout.start, Kraken.Layout.size,
+    Kraken.Executable.withAddresses, List.map, List.mem_cons,
+    List.not_mem_nil, or_false] at hp
+  unfold Executable.ResolvesFallthroughAt
+  rcases hp with rfl | rfl | rfl <;>
+    simp [swap, Kraken.Layout.apply, List.mapIdx_cons, List.mapIdx_nil,
+      Kraken.Layout.start, Kraken.Layout.size,
+      Kraken.Executable.directivesFromAddress, Kraken.Executable.withAddresses,
+      List.dropWhile, Kraken.Directives.takeBlock, Kraken.Directives.fallthroughPC]
+
+theorem swap_correct_step1 (d : MachineData) :
+    Eventually (step1 (swapUnitLayout swap))
+      (fun s' =>
+          s'.1.regs.get Reg.rax = d.regs.get Reg.rbx ∧
+          s'.1.regs.get Reg.rbx = d.regs.get Reg.rax)
+      (d, (0 : Int64)) :=
+  Executable.eventually_step1_of_eventually_straightlineStep
+    (swapUnitLayout swap) swapExe_resolves _ _ (swap_correct d)
+end SwapStep1
+
 -- Stepping demo. Ideally, this demo should be without the first .mov
 def p2 : Program := parse("
 start:
@@ -103,8 +133,6 @@ example [layout : Layout] (s : MachineData): Eventually (straightlineStep (layou
 
 -- Example 3, more sophisticated
 
--- TODO: restore p3
-
 def p3: Program := parse("
 init:
   mov $2, %rdx             # rdx: current result = 2
@@ -120,102 +148,492 @@ _end:
 
 def p3_spec (s: MachineData): Nat := 2^(2^s.regs.rbx.toNat)
 
+-- Address resolution for p3's two jump targets.
+
+theorem wa_cons (a : Int64) (d : Directive) (n : Nat) (ds : List (Directive × Nat)) :
+    Kraken.Executable.withAddresses (a, (d,n) :: ds)
+      = (a, d, n) :: Kraken.Executable.withAddresses (a + .ofNat n, ds) := by
+  simp [Kraken.Executable.withAddresses]
+
+theorem wa_nil (a : Int64) : Kraken.Executable.withAddresses (a, ([] : List (Directive × Nat))) = [] := by
+  simp [Kraken.Executable.withAddresses]
+
+def raddr (a : Int64) : List (Directive × Nat) → Nat → Int64
+  | _, 0 => a
+  | [], _+1 => a
+  | (_,n) :: ds, i+1 => raddr (a + .ofNat n) ds i
+
+theorem wa_dropWhile (tgt : Int64) :
+    ∀ (k : Nat) (ds : List (Directive × Nat)) (a : Int64),
+      k ≤ ds.length →
+      (∀ i, i < k → raddr a ds i ≠ tgt) →
+      raddr a ds k = tgt →
+      (Kraken.Executable.withAddresses (a, ds)).dropWhile (·.1 ≠ tgt)
+        = Kraken.Executable.withAddresses (raddr a ds k, ds.drop k)
+  | 0, ds, a, _, _, hk => by
+      cases ds with
+      | nil => simp [wa_nil]
+      | cons dn ds =>
+        obtain ⟨d, n⟩ := dn
+        simp only [raddr] at hk
+        rw [wa_cons]
+        simp only [List.dropWhile, hk, ne_eq, not_true_eq_false, decide_false, List.drop_zero]
+        simp only [raddr, wa_cons]
+  | k+1, [], a, hlen, _, _ => by simp at hlen
+  | k+1, (d,n) :: ds, a, hlen, hne, hk => by
+      have h0 : a ≠ tgt := by
+        have := hne 0 (Nat.succ_pos k)
+        simpa [raddr] using this
+      rw [wa_cons]
+      simp only [List.dropWhile, ne_eq, h0, not_false_eq_true, decide_true]
+      simp only [raddr] at hk ⊢
+      rw [wa_dropWhile tgt k ds (a + .ofNat n) (by simpa using Nat.le_of_succ_le_succ hlen)
+        (fun i hi => by have := hne (i+1) (Nat.succ_lt_succ hi); simpa [raddr] using this) hk]
+      simp [List.drop_succ_cons]
+
+/-- `directivesFromAddress` at the address of index `k`. -/
+theorem dfa_eq_drop (e : Executable) (tgt : Int64) (k : Nat)
+    (hlen : k ≤ e.2.length)
+    (hne : ∀ i, i < k → raddr e.1 e.2 i ≠ tgt)
+    (hk : raddr e.1 e.2 k = tgt) :
+    e.directivesFromAddress tgt = e.2.drop k := by
+  show (List.map (·.2) ((Kraken.Executable.withAddresses (e.1, e.2)).dropWhile (·.1 ≠ tgt))) = _
+  rw [wa_dropWhile tgt k e.2 e.1 hlen hne hk, hk]
+  -- withAddresses then map snd is the identity
+  exact Kraken.Executable.withAddresses_map_snd _ _
+
+section
+variable [layout : Layout]
+
+def paddr : Nat → Int64
+  | 0 => layout.start
+  | n+1 => paddr n + .ofNat (layout.size n)
+
+theorem p3_len : ((layout p3).2).length = 10 := by
+  simp [Kraken.Layout.apply, p3]
+
+theorem p3_fst : (layout p3).1 = layout.start := rfl
+
+theorem p3_raddr2 : raddr layout.start ((layout p3).2) 2 = paddr 2 := by
+  simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil]
+  simp [raddr, paddr]
+
+theorem p3_raddr8 : raddr layout.start ((layout p3).2) 8 = paddr 8 := by
+  simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil]
+  simp [raddr, paddr]
+
+theorem p3_raddr_lt2 (i : Nat) (hi : i < 2) :
+    raddr layout.start ((layout p3).2) i = paddr i := by
+  simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil]
+  match i, hi with
+  | 0, _ => simp [raddr, paddr]
+  | 1, _ => simp [raddr, paddr]
+
+theorem p3_raddr_lt8 (i : Nat) (hi : i < 8) :
+    raddr layout.start ((layout p3).2) i = paddr i := by
+  simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil]
+  match i, hi with
+  | 0, _ => simp [raddr, paddr]
+  | 1, _ => simp [raddr, paddr]
+  | 2, _ => simp [raddr, paddr]
+  | 3, _ => simp [raddr, paddr]
+  | 4, _ => simp [raddr, paddr]
+  | 5, _ => simp [raddr, paddr]
+  | 6, _ => simp [raddr, paddr]
+  | 7, _ => simp [raddr, paddr]
+
+/-- The layout places p3's directives so that the two jump targets are unambiguous. -/
+structure SaneP3Layout : Prop where
+  ne2 : ∀ i, i < 2 → (paddr i : Int64) ≠ paddr 2
+  ne8 : ∀ i, i < 8 → (paddr i : Int64) ≠ paddr 8
+
+theorem p3_from_2 (h : SaneP3Layout (layout := layout)) :
+    (layout p3).directivesFromAddress (paddr 2) = ((layout p3).2).drop 2 := by
+  refine dfa_eq_drop _ _ 2 (by rw [p3_len]; omega) ?_ ?_
+  · intro i hi
+    rw [p3_fst, p3_raddr_lt2 i hi]
+    exact h.ne2 i hi
+  · rw [p3_fst]; exact p3_raddr2
+
+theorem p3_from_8 (h : SaneP3Layout (layout := layout)) :
+    (layout p3).directivesFromAddress (paddr 8) = ((layout p3).2).drop 8 := by
+  refine dfa_eq_drop _ _ 8 (by rw [p3_len]; omega) ?_ ?_
+  · intro i hi
+    rw [p3_fst, p3_raddr_lt8 i hi]
+    exact h.ne8 i hi
+  · rw [p3_fst]; exact p3_raddr8
+
+/-- `label "start"` resolves to the address of directive #2. -/
+theorem p3_label_start : Labels.label (self := (Executable.labels (layout p3))) "start" = paddr 2 := by
+  show (List.findSome? _ (Kraken.Executable.withAddresses (layout p3))).getD (-1) = _
+  show (List.findSome? _ (Kraken.Executable.withAddresses (layout.start, (layout p3).2))).getD (-1) = _
+  simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil]
+  simp only [wa_cons, wa_nil, List.findSome?]
+  simp only [paddr]
+  rfl
+
+/-- `label "_end"` resolves to the address of directive #8. -/
+theorem p3_label_end : Labels.label (self := (Executable.labels (layout p3))) "_end" = paddr 8 := by
+  show (List.findSome? _ (Kraken.Executable.withAddresses (layout p3))).getD (-1) = _
+  show (List.findSome? _ (Kraken.Executable.withAddresses (layout.start, (layout p3).2))).getD (-1) = _
+  simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil]
+  simp only [wa_cons, wa_nil, List.findSome?]
+  simp only [paddr]
+  rfl
+end
+
+
+section
+variable [layout : Layout]
+
+theorem p3_label_start' :
+    (List.findSome? (fun x => if x.2.1 = Directive.label "start" then some x.1 else none)
+      (Kraken.Layout.apply layout p3).withAddresses).getD (-1) = paddr 2 := p3_label_start
+
+theorem p3_label_end' :
+    (List.findSome? (fun x => if x.2.1 = Directive.label "_end" then some x.1 else none)
+      (Kraken.Layout.apply layout p3).withAddresses).getD (-1) = paddr 8 := p3_label_end
+
+theorem jmp_back_plain (X : Int64) : X + ((paddr 2 : Int64) - X) = paddr 2 := by
+  apply Int64.toBitVec_inj.mp
+  simp [Int64.toBitVec_add, Int64.toBitVec_sub]
+  rw [BitVec.add_comm, BitVec.sub_add_cancel]
+
+theorem jmp_back (X : Int64) :
+    Int64.ofBitVec ((X + ((paddr 2 : Int64) - X)).toBitVec) = (paddr 2 : Int64) := by
+  have h : X + ((paddr 2 : Int64) - X) = paddr 2 := by
+    apply Int64.toBitVec_inj.mp
+    simp [Int64.toBitVec_add, Int64.toBitVec_sub]
+    rw [BitVec.add_comm, BitVec.sub_add_cancel]
+  rw [h]; rfl
+
+
+-- Gauge: the head block with rbx = 0 falls through to _end, registers intact.
 set_option maxHeartbeats 4000000 in
-theorem p3_correct [layout: Layout] (s: MachineData):
-    p3_spec s < 2^64 →
-    Eventually (straightlineStep (layout p3)) (fun s => s.1.regs.rdx.toNat = p3_spec s.1 ∧ s.1.regs.rax = 0) (s, layout.start) :=
-  by
-    intros h_bounds
-    apply step_cps
-    kprologue p3 with s
+theorem step_head_zero (h : SaneP3Layout (layout := layout)) (s : MachineData)
+    (hz : s.regs.rbx = 0) (Q : @Post MachineState)
+    (hQ : ∀ st, Q ({ s with status := st }, paddr 8)) :
+    straightlineStep (layout p3) (s, paddr 2) Q := by
+  let ss := s
+  change (straightlineStep _ (ss, _) _)
+  obtain ⟨⟨rax,rbx,rcx,rdx,rsi,rdi,rsp,rbp,r8,r9,r10,r11,r12,r13,r14,r15⟩, zmms, flags, mem⟩ := s
+  dsimp only [straightlineStep, Executable.straightline]
+  rw [p3_from_2 h]
+  simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil, List.drop_succ_cons,
+    List.drop_zero]
+  simp at hz
+  subst hz
+  simp only at hQ
+  sym =>
+  kstep
+  tactic =>
+  rename_i v status
+  have hv : v = BitVec.zero 64 := by simp [v]
+  simp [hv]
+  rw [p3_label_end']
+  exact hQ _
 
+-- Unfolded form of the `_end` label lookup, as it appears after `kstep`.
+set_option maxHeartbeats 4000000 in
+theorem step_head_nz (h : SaneP3Layout (layout := layout)) (s : MachineData)
+    (hnz : s.regs.rbx ≠ 0) (Q : @Post MachineState)
+    (hQ : ∀ (st : StatusFlags) (nrax nrdx nrbx : UInt64),
+            nrdx.toBitVec = BitVec.ofInt 64 ((s.regs.rdx.toNat : Int) * (s.regs.rdx.toNat : Int)) →
+            nrax.toBitVec = BitVec.ofInt 64 (((s.regs.rdx.toNat : Int) * (s.regs.rdx.toNat : Int)) >>> 64) →
+            nrbx = s.regs.rbx - 1 →
+            Q ({ regs := { s.regs with rax := nrax, rdx := nrdx, rbx := nrbx },
+                 zmms := s.zmms, status := st, dmem := s.dmem }, paddr 2)) :
+    straightlineStep (layout p3) (s, paddr 2) Q := by
+  let ss := s
+  change (straightlineStep _ (ss, _) _)
+  obtain ⟨⟨rax,rbx,rcx,rdx,rsi,rdi,rsp,rbp,r8,r9,r10,r11,r12,r13,r14,r15⟩, zmms, flags, mem⟩ := s
+  dsimp only [straightlineStep, Executable.straightline]
+  rw [p3_from_2 h]
+  simp only [Kraken.Layout.apply, p3, List.mapIdx_cons, List.mapIdx_nil, List.drop_succ_cons,
+    List.drop_zero]
+  simp at hnz
+  simp only at hQ
+  sym =>
+  kstep
+  tactic =>
+  rename_i v status
+  apply all_ite
+  · intro hc
+    exfalso
+    apply hnz
+    have : v = BitVec.zero 64 := by simpa using hc
+    simp [v] at this
+    exact UInt64.eq_of_toBitVec_eq (by simpa using this)
+  · intro hc
     sym =>
-    -- kstep 3
-    -- tactic =>
-    -- apply reg_dec_loop
-    -- intros
+    kstep
+    tactic =>
+    simp [Effects.bind_eq, Effects.pure_eq, Effects.bind, Effects.All,
+      RelRegOrMem.interp, ConstExpr.interp, p3_label_start', jmp_back, jmp_back_plain]
+    refine hQ _ _ _ _ ?_ ?_ ?_
+    · show BitVec.ofInt 64 _ = _
+      congr 1
+      simp +zetaDelta
+      rfl
+    · show BitVec.ofInt 64 _ = _
+      congr 1
+      simp +zetaDelta
+      rfl
+    · show (⟨_⟩ : UInt64) = _
+      congr 1
+      simp +zetaDelta
 
-    sorry
 
-/-     intros h_bounds h_rip
-    simp [p3]
-    -- First step sets rdx = 2
-    apply step_cps
-    step_one
-    rw [h_rip]
-    clear h_rip
+
+-- Initial block with `rbx = 0`: sets `rdx := 2`, then falls through to `_end`.
+set_option maxHeartbeats 4000000 in
+theorem step_init_zero (s : MachineData) (hz : s.regs.rbx = 0) (Q : @Post MachineState)
+    (hQ : ∀ (st : StatusFlags) (nrdx : UInt64), nrdx.toBitVec = 2#64 →
+            Q ({ regs := { s.regs with rdx := nrdx }, zmms := s.zmms, status := st,
+                 dmem := s.dmem }, paddr 8)) :
+    straightlineStep (layout p3) (s, layout.start) Q := by
+  let ss := s
+  change (straightlineStep _ (ss, _) _)
+  obtain ⟨⟨rax,rbx,rcx,rdx,rsi,rdi,rsp,rbp,r8,r9,r10,r11,r12,r13,r14,r15⟩, zmms, flags, mem⟩ := s
+  dsimp only [straightlineStep, Executable.straightline]
+  rw [Kraken.Executable.directivesFromStart]
+  simp only [p3, List.mapIdx_cons, List.mapIdx_nil]
+  simp at hz
+  subst hz
+  simp only at hQ
+  sym =>
+  kstep
+  tactic =>
+  rename_i v status
+  apply all_ite
+  · intro hc
+    rw [p3_label_end]
+    exact hQ _ _ rfl
+  · intro hc
+    exfalso
+    apply hc
+    simp [v]
+
+
+
+-- Initial block with `rbx ≠ 0`: rdx := 2, then one loop body iteration (2 -> 4).
+set_option maxHeartbeats 4000000 in
+theorem step_init_nz (s : MachineData) (hnz : s.regs.rbx ≠ 0) (Q : @Post MachineState)
+    (hQ : ∀ (st : StatusFlags) (nrax nrdx nrbx : UInt64),
+            nrdx.toBitVec = 4#64 → nrax.toBitVec = 0#64 → nrbx = s.regs.rbx - 1 →
+            Q ({ regs := { s.regs with rax := nrax, rdx := nrdx, rbx := nrbx },
+                 zmms := s.zmms, status := st, dmem := s.dmem }, paddr 2)) :
+    straightlineStep (layout p3) (s, layout.start) Q := by
+  let ss := s
+  change (straightlineStep _ (ss, _) _)
+  obtain ⟨⟨rax,rbx,rcx,rdx,rsi,rdi,rsp,rbp,r8,r9,r10,r11,r12,r13,r14,r15⟩, zmms, flags, mem⟩ := s
+  dsimp only [straightlineStep, Executable.straightline]
+  rw [Kraken.Executable.directivesFromStart]
+  simp only [p3, List.mapIdx_cons, List.mapIdx_nil]
+  simp at hnz
+  simp only at hQ
+  sym =>
+  kstep
+  tactic =>
+  rename_i v status
+  apply all_ite
+  · intro hc
+    exfalso
+    apply hnz
+    have : v = BitVec.zero 64 := by simpa using hc
+    simp [v] at this
+    exact UInt64.eq_of_toBitVec_eq (by simpa using this)
+  · intro hc
+    sym =>
+    kstep
+    tactic =>
+    simp [Effects.bind_eq, Effects.pure_eq, Effects.bind, Effects.All,
+      RelRegOrMem.interp, ConstExpr.interp, p3_label_start', jmp_back, jmp_back_plain]
+    refine hQ _ _ _ _ ?_ ?_ ?_
+    · show BitVec.ofInt 64 _ = _
+      decide
+    · show BitVec.ofInt 64 _ = _
+      decide
+    · show (⟨_⟩ : UInt64) = _
+      congr 1
+      simp +zetaDelta
+
+
+
+-- Arithmetic helpers for the mulx bound.
+theorem ofInt_toNat_of_lt (m : Nat) (hm : m < 2^64) :
+    (BitVec.ofInt 64 (m : Int)).toNat = m := by
+  simp [BitVec.toNat_ofInt]
+  omega
+
+theorem ofInt_shift_of_lt (m : Nat) (hm : m < 2^64) :
+    (BitVec.ofInt 64 ((m : Int) >>> 64)) = 0#64 := by
+  have : ((m : Int) >>> 64) = 0 := by
+    rw [Int.shiftRight_eq_div_pow]
+    omega
+  rw [this]
+  rfl
+
+
+
+-- Loop invariant: at the loop head with `k` iterations left.
+def p3_inv (n : Nat) (k : Nat) : @Post MachineState := fun m =>
+  m.2 = paddr 2 ∧ m.1.regs.rbx.toNat = k ∧ k ≤ n ∧
+  m.1.regs.rdx.toNat = 2^(2^(n-k)) ∧ m.1.regs.rax = 0
+
+-- Invariant at k=0 implies the postcondition.
+set_option maxHeartbeats 4000000 in
+theorem inv_zero_post (h : SaneP3Layout (layout := layout)) (n : Nat)
+    (target : Nat) (htgt : target = 2^(2^n)) (m : MachineState) (hinv : p3_inv n 0 m) :
+    Eventually (straightlineStep (layout p3))
+      (fun s' => s'.1.regs.rdx.toNat = target ∧ s'.1.regs.rax = 0) m := by
+  obtain ⟨hpc, hrbx, hkn, hrdx, hrax⟩ := hinv
+  apply step_cps
+  obtain ⟨md, pc⟩ := m
+  simp only at hpc hrbx hrdx hrax
+  subst hpc
+  apply step_head_zero h md (UInt64.toNat_inj.mp (by simpa using hrbx))
+  intro st
+  apply Eventually.done
+  refine ⟨?_, ?_⟩
+  · simp only
+    rw [hrdx, htgt]
     simp
-    -- Loop invariant introduction
-    apply reg_dec_loop p3 _ _ (fun i s => s.rip = 1 ∧ s.regs.rbx.toNat = i ∧ i ≤ initial.regs.rbx.toNat ∧ s.regs.rdx.toNat = 2^(2^(initial.regs.rbx.toNat - i))) initial.regs.rbx.toNat
-    constructor
-    . simp
-    . constructor
-      -- Invariant at index 0 ==> post
-      . intros state inv
-        rcases inv with ⟨ h_rip, h_rbx_zero, h_rbx_le, h_inv ⟩
-        -- Step through a few program steps
-        simp [p3]
-        apply step_cps
-        step_one
-        rw [h_rip]
-        simp
-        apply step_cps
-        step_one
-        have : state.regs.rbx.toNat = 0 := by grind
-        simp [this]
-        apply step_cps
-        step_one
-        apply eventually.done
-        simp
-        -- Now functional correctness for initial invariant
-        simp [p3_spec]
-        grind
-      -- Invariant preserved
-      . intro state k h_k_nonzero inv
-        rcases inv with ⟨ h_rip, h_rbx_is_k, h_rbx_le, h_inv ⟩
-        simp [p3]
-        apply step_cps
-        step_one
-        rw [h_rip]
-        simp
-        apply step_cps
-        step_one
-        have h_k_ne : k ≠ 0 := by grind
-        -- state.regs.rbx.toNat = k and toNat < 2^64 for UInt64
-        have h_k_lt : k < 2^64 := h_rbx_is_k ▸ (state.regs.rbx.toNat_lt)
-        -- Simplify all the Int64.toUInt64 terms
-        simp_all only [ne_eq, not_false_eq_true]
-        -- Prove the if-condition is false: UInt64.ofInt ↑k ≠ 0 when k ≠ 0
-        have h_cond : UInt64.ofInt (k : Int) ≠ 0 := UInt64_ofInt_natCast_ne_zero k h_k_lt h_k_ne
-        rw [if_neg h_cond]
-        apply step_cps
-        step_one
-        apply step_cps
-        step_one
-        apply step_cps
-        step_one
-        apply eventually.done
-        -- Goals for invariant preservation
-        constructor
-        . simp -- back to correct address
-        . match h_state:state.regs.rbx, h_init:initial.regs.rbx with
-          | ⟨v_s⟩, ⟨v_i⟩ =>
-            have h_k_lt : k < 2^64 := h_rbx_is_k ▸ (by rw [h_state]; exact v_s.isLt)
-            have h_init_lt : v_i.toNat < 2^64 := v_i.isLt
-            simp [h_state, h_init, p3_spec, Reg.width, UInt64.ofInt, UInt64.ofNat, UInt64.toNat_ofNat] at *
-            constructor
-            . omega
-            . constructor
-              . omega
-              . rw [h_inv]
-                have h_vi_k : v_i.toNat - (k - 1) = (v_i.toNat - k) + 1 := by omega
-                rw [h_vi_k, Nat.mod_eq_of_lt]
-                . rw [← Nat.pow_two, ← Nat.pow_mul, ← Nat.pow_succ]
-                . apply Nat.lt_of_le_of_lt _ h_bounds
-                  rw [← Nat.pow_two, ← Nat.pow_mul, ← Nat.pow_succ]
-                  apply Nat.pow_le_pow_right (by decide)
-                  apply Nat.pow_le_pow_right (by decide)
-                  omega -/
+  · simpa using hrax
+
+
+
+theorem uint64_sub_one_toNat (x : UInt64) (hx : x.toNat ≠ 0) :
+    (x - 1).toNat = x.toNat - 1 := by
+  have h1 : x.toNat < 2^64 := x.toNat_lt_size
+  have h2 : UInt64.toNat 1 = 1 := rfl
+  simp only [UInt64.toNat_sub, h2]
+  omega
+
+set_option maxHeartbeats 4000000 in
+theorem inv_step (h : SaneP3Layout (layout := layout)) (n : Nat)
+    (hbound : 2^(2^n) < 2^64) (m : MachineState) (k : Nat) (hk : k ≠ 0)
+    (hinv : p3_inv n k m) :
+    Eventually (straightlineStep (layout p3)) (p3_inv n (k-1)) m := by
+  obtain ⟨hpc, hrbx, hkn, hrdx, hrax⟩ := hinv
+  apply step_cps
+  obtain ⟨md, pc⟩ := m
+  simp only at hpc hrbx hrdx hrax
+  subst hpc
+  have hexp : n - (k-1) = (n-k) + 1 := by omega
+  have hsq : md.regs.rdx.toNat * md.regs.rdx.toNat = 2^(2^(n-(k-1))) := by
+    rw [hrdx, hexp, ← Nat.pow_add, ← Nat.two_mul, ← Nat.pow_succ']
+  have hlt : md.regs.rdx.toNat * md.regs.rdx.toNat < 2^64 := by
+    rw [hsq]
+    refine Nat.lt_of_le_of_lt ?_ hbound
+    apply Nat.pow_le_pow_right (by decide)
+    apply Nat.pow_le_pow_right (by decide)
+    omega
+  have hcast : ((md.regs.rdx.toNat : Int) * (md.regs.rdx.toNat : Int))
+      = ((md.regs.rdx.toNat * md.regs.rdx.toNat : Nat) : Int) :=
+    Int.ofNat_mul_ofNat _ _
+  have hrbxne : md.regs.rbx ≠ 0 := by
+    intro hc
+    rw [hc] at hrbx
+    simp at hrbx
+    omega
+  apply step_head_nz h md hrbxne
+  intro st nrax nrdx nrbx hnrdx hnrax hnrbx
+  apply Eventually.done
+  refine ⟨rfl, ?_, by omega, ?_, ?_⟩
+  · show nrbx.toNat = k - 1
+    rw [hnrbx, uint64_sub_one_toNat _ (by omega), hrbx]
+  · show nrdx.toNat = _
+    rw [show nrdx.toNat = (nrdx.toBitVec).toNat from rfl, hnrdx, hcast,
+      ofInt_toNat_of_lt _ hlt, hsq]
+  · show nrax = 0
+    apply UInt64.eq_of_toBitVec_eq
+    rw [hnrax, hcast]
+    exact ofInt_shift_of_lt _ hlt
+
+
+
+set_option maxHeartbeats 4000000 in
+/-- Runs of `p3` compute `p3_spec` of the initial state: the loop squares
+`rdx` while counting `rbx` down to zero. `hrax` is required because a
+zero-iteration run never writes `rax`; `SaneP3Layout` because an aliasing
+layout re-executes the init block on the back edge. -/
+theorem p3_correct (h : SaneP3Layout (layout := layout)) (s : MachineData)
+    (hrax : s.regs.rax = 0) (hb : p3_spec s < 2^64) :
+    Eventually (straightlineStep (layout p3))
+      (fun s' => s'.1.regs.rdx.toNat = p3_spec s ∧ s'.1.regs.rax = 0)
+      (s, layout.start) := by
+  have hbound : 2^(2^s.regs.rbx.toNat) < 2^64 := hb
+  by_cases hz : s.regs.rbx = 0
+  · apply step_cps
+    apply step_init_zero s hz
+    intro st nrdx hnrdx
+    apply Eventually.done
+    refine ⟨?_, ?_⟩
+    · simp only [p3_spec]
+      rw [show nrdx.toNat = (nrdx.toBitVec).toNat from rfl, hnrdx]
+      simp [hz]
+    · simpa using hrax
+  · have hn0 : s.regs.rbx.toNat ≠ 0 := by
+      intro hc
+      exact hz (UInt64.toNat_inj.mp (by simpa using hc))
+    apply step_cps
+    apply step_init_nz s hz
+    intro st nrax nrdx nrbx hnrdx hnrax hnrbx
+    apply reg_dec_loop _ _ _ (p3_inv s.regs.rbx.toNat) (s.regs.rbx.toNat - 1)
+    refine ⟨?_, ?_, ?_⟩
+    · refine ⟨rfl, ?_, by omega, ?_, ?_⟩
+      · show nrbx.toNat = _
+        rw [hnrbx, uint64_sub_one_toNat _ (by omega)]
+      · show nrdx.toNat = _
+        rw [show nrdx.toNat = (nrdx.toBitVec).toNat from rfl, hnrdx]
+        have hgap : s.regs.rbx.toNat - (s.regs.rbx.toNat - 1) = 1 := by omega
+        rw [hgap]
+        rfl
+      · show nrax = 0
+        apply UInt64.eq_of_toBitVec_eq
+        rw [hnrax]
+        rfl
+    · exact fun state hinv => inv_zero_post h _ (p3_spec s) rfl state hinv
+    · exact fun state k hk hinv => inv_step h _ hbound state k hk hinv
+
+end
+
+
+-- `SaneP3Layout` is satisfiable, so `p3_correct` is not vacuous: an ordinary
+-- layout (start at 0, one byte per directive) satisfies it. The `local instance`
+-- is confined to this section so it cannot affect other examples.
+section P3NonVacuous
+local instance L1 : Layout := { start := 0, size := fun _ => 1 }
+
+theorem L1_sane : SaneP3Layout (layout := L1) := by
+  constructor
+  · intro i hi
+    match i, hi with
+    | 0, _ => decide
+    | 1, _ => decide
+  · intro i hi
+    match i, hi with
+    | 0, _ => decide
+    | 1, _ => decide
+    | 2, _ => decide
+    | 3, _ => decide
+    | 4, _ => decide
+    | 5, _ => decide
+    | 6, _ => decide
+    | 7, _ => decide
+
+/-- ...and it really applies to a nontrivial state: `rbx = 3`, so the program
+must compute `rdx = 2^(2^3) = 256`. -/
+example : Eventually (straightlineStep (L1 p3))
+    (fun s' => s'.1.regs.rdx.toNat = p3_spec ({ regs := { rbx := 3 } } : MachineData)
+               ∧ s'.1.regs.rax = 0)
+    (({ regs := { rbx := 3 } } : MachineData), L1.start) := by
+  apply p3_correct L1_sane
+  · rfl
+  · decide
+
+end P3NonVacuous
 
 def p4 := eval% parse("start: mov $2, %rax
 dec %rax")

--- a/Kraken/X64/Examples/IncrementDMA.lean
+++ b/Kraken/X64/Examples/IncrementDMA.lean
@@ -64,5 +64,6 @@ structure SystemState where
   machineState : MachineState
   deviceState : IncrementerState
 
-def Effects.All (s : Effects) (ds : IncrementerState) (post : SystemState → Prop) : Prop
+def Effects.All (s : Effects MachineState) (ds : IncrementerState)
+    (post : SystemState → Prop) : Prop
   := by sorry

--- a/Kraken/X64/Examples/IncrementMMIO.lean
+++ b/Kraken/X64/Examples/IncrementMMIO.lean
@@ -85,7 +85,7 @@ structure SystemState where
   machineState : MachineState
   deviceState : IncrementerState
 
-def handleEffects (ds : IncrementerState) (es : Effects)
+def handleEffects (ds : IncrementerState) (es : Effects MachineState)
     (ok : SystemState → Except String SystemState) :
     Except String SystemState :=
   match es with
@@ -104,7 +104,7 @@ def handleEffects (ds : IncrementerState) (es : Effects)
       let some (reply, ds') := ds.read_step r
         | throw s!"Incrementer.read_step failed"
       handleEffects ds' (cont (h ▸ UInt32.toBitVec reply) dmem) ok
-  | @Effects.nonmem_store dmem addr w v cont =>
+  | @Effects.nonmem_store _ dmem addr w v cont =>
     match w with
       | .W32 => match Incrementer.Register.of_addr (UInt64.ofBitVec addr) with
         | .some r => match ds.write_step r (UInt32.ofBitVec v) with
@@ -113,7 +113,7 @@ def handleEffects (ds : IncrementerState) (es : Effects)
           | .none => .error s!"Incrementer.write_step failed"
         | .none => .error s!"nonmem_store at unmapped address {repr addr}"
       | _ => .error s!"nonmem_store of width other than 4 bytes"
-  | @Effects.undefined _ t cont => handleEffects ds (cont (t.from_hash (hash ds))) ok
+  | @Effects.undefined _ _ t cont => handleEffects ds (cont (t.from_hash (hash ds))) ok
 
 def eval_schedule (schedule : List Bool) (e : Executable) (s : SystemState)
     : Except String SystemState :=

--- a/Kraken/X64/OmniSemantics.lean
+++ b/Kraken/X64/OmniSemantics.lean
@@ -191,8 +191,18 @@ private theorem takeBlock_ne_nil {Directive : Type} {ds : List (Directive × Nat
     by_cases hz : entry.2 = 0 <;>
       simp [Kraken.Directives.takeBlock, hz]
 
+/-- A listing of zero-sized directives is one block. -/
+private theorem takeBlock_of_all_zero {Directive : Type} :
+    ∀ {ds : List (Directive × Nat)}, (∀ d ∈ ds, d.2 = 0) →
+      Kraken.Directives.takeBlock ds = ds
+  | [], _ => rfl
+  | entry :: rest, h => by
+    simp [Kraken.Directives.takeBlock, h entry (List.mem_cons_self ..),
+      takeBlock_of_all_zero (fun d hd => h d (List.mem_cons_of_mem _ hd))]
+
 private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executable)
-    (hres : ∀ pc, e.ResolvesFallthroughAt pc) (post : @Post MachineState) :
+    (hres : ∀ pc, e.ResolvesFallthroughAt pc ∨
+      ∀ d ∈ e.directivesFromAddress pc, d.2 = 0) (post : @Post MachineState) :
     ∀ (n : Nat) (s : MachineState), (e.directivesFromAddress s.2).length ≤ n →
       straightlineStep e s post → Eventually (step1 e) post s := by
   intro n
@@ -216,17 +226,27 @@ private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executabl
       simp only [straightlineStep, Executable.straightline, hnil, Directives.interp,
         Effects.bind, Effects.All] at h
       exact h
-    · -- Peel one block; every fall-through lands at the static address, whose
+    · rcases hres s.2 with hA | hz
+      case inr =>
+        -- Every remaining directive is zero-sized: one step runs the whole
+        -- suffix, which is exactly the straight-line run.
+        apply step_cps
+        unfold straightlineStep at h
+        simp only [Executable.straightline] at h
+        simp only [step1, Executable.step, Executable.stepWithExit]
+        rw [takeBlock_of_all_zero hz]
+        exact Effects.All.imp (fun mid hm => Eventually.done mid hm) h
+      -- Peel one block; every fall-through lands at the static address, whose
       -- fetched suffix is strictly shorter by address coherence.
       apply step_cps
       unfold straightlineStep at h
-      rw [e.straightline_eq_step s (hres s.2)] at h
+      rw [e.straightline_eq_step s hA] at h
       simp only [step1, Executable.step, Executable.stepWithExit] at h ⊢
       rw [@Directives.interp_fallthrough_pc e.labels _ _ _ _ _] at h ⊢
       rw [Effects.all_bind] at h ⊢
       have hdec : (e.directivesFromAddress (Kraken.Directives.fallthroughPC
           (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)) s.2)).length ≤ n := by
-        have hsplit := hres s.2
+        have hsplit := hA
         unfold Executable.ResolvesFallthroughAt at hsplit
         have hblock : Kraken.Directives.takeBlock (e.directivesFromAddress s.2) ≠ [] :=
           takeBlock_ne_nil hnil
@@ -247,11 +267,110 @@ whose fetches are address-coherent, a spec proved against `straightlineStep`
 holds along `step1` execution. Completes the theorem deferred in #104 and
 resolves the question of #140 with a true statement. -/
 theorem Executable.eventually_step1_of_straightlineStep [Layout] (e : Executable)
-    (hres : ∀ pc, e.ResolvesFallthroughAt pc) (s : MachineState)
+    (hres : ∀ pc, e.ResolvesFallthroughAt pc ∨
+      ∀ d ∈ e.directivesFromAddress pc, d.2 = 0) (s : MachineState)
     (post : @Post MachineState) (h : straightlineStep e s post) :
     Eventually (step1 e) post s :=
   eventually_step1_of_straightlineStep_aux e hres post
     (e.directivesFromAddress s.2).length s (Nat.le_refl _) h
+
+
+
+
+/-- Binds push through branches: the canonical form keeps the branch at the
+tree top, where `all_ite` can split it. -/
+theorem Effects.ite_bind {α β : Type} {c : Prop} [Decidable c]
+    (a b : Effects α) (k : α → Effects β) :
+    (if c then a else b).bind k = if c then a.bind k else b.bind k := by
+  by_cases hc : c <;> simp [hc]
+
+attribute [ksimp] Effects.ite_bind
+
+theorem all_ite {α : Type} {c : Prop} [Decidable c] (Q : α → Prop) (a b : Effects α) :
+    (c → Effects.All Q a) → (¬ c → Effects.All Q b) → Effects.All Q (if c then a else b) := by
+  intro ha hb
+  by_cases hc : c
+  · simp [hc]; exact ha hc
+  · simp [hc]; exact hb hc
+
+/-- Every address either fetches coherently (the block there is followed by
+the fetch at its fall-through address) or reaches only zero-sized directives,
+a terminal stutter that a single step runs in full. Concrete sane layouts
+satisfy this, including programs that end in labels; an adversarial
+`Layout.size` (aliasing, wraparound) need not. -/
+def Executable.Resolves (e : Executable) : Prop :=
+  ∀ pc, e.ResolvesFallthroughAt pc ∨
+    ∀ d ∈ e.directivesFromAddress pc, d.2 = 0
+
+instance (e : Executable) (pc : Int64) :
+    Decidable (Executable.ResolvesFallthroughAt e pc) :=
+  inferInstanceAs (Decidable (e.directivesFromAddress pc =
+    Kraken.Directives.takeBlock (e.directivesFromAddress pc) ++
+      e.directivesFromAddress (Kraken.Directives.fallthroughPC
+        (Kraken.Directives.takeBlock (e.directivesFromAddress pc)) pc)))
+
+private theorem dropWhile_ne_eq_nil {α : Type} (p : α → Bool) :
+    ∀ (l : List α), (∀ x ∈ l, p x = true) → l.dropWhile p = []
+  | [], _ => rfl
+  | x :: xs, h => by
+    simp only [List.dropWhile, h x (List.mem_cons_self ..)]
+    exact dropWhile_ne_eq_nil p xs (fun y hy => h y (List.mem_cons_of_mem _ hy))
+
+/-- At an address where nothing starts, the fetch is empty and coherence is
+trivial — so `Resolves` reduces to a check over the finitely many start
+addresses of the executable. -/
+theorem Executable.resolves_of_members (e : Executable)
+    (h : ∀ p ∈ e.withAddresses.map (·.1), e.ResolvesFallthroughAt p ∨
+      ∀ d ∈ e.directivesFromAddress p, d.2 = 0) :
+    Executable.Resolves e := by
+  intro pc
+  by_cases hmem : pc ∈ e.withAddresses.map (·.1)
+  · exact h pc hmem
+  · refine Or.inl ?_
+    have hnil : e.directivesFromAddress pc = [] := by
+      unfold Kraken.Executable.directivesFromAddress
+      have : e.withAddresses.dropWhile (·.1 ≠ pc) = [] := by
+        apply dropWhile_ne_eq_nil
+        intro x hx
+        simp only [ne_eq, decide_eq_true_eq]
+        intro heq
+        exact hmem (List.mem_map.mpr ⟨x, hx, heq⟩)
+      rw [this]
+      rfl
+    unfold Executable.ResolvesFallthroughAt
+    rw [hnil]
+    show ([] : List (Directive × Nat)) = [] ++ e.directivesFromAddress
+        (Kraken.Directives.fallthroughPC [] pc)
+    have : Kraken.Directives.fallthroughPC ([] : List (Directive × Nat)) pc = pc := rfl
+    rw [this, List.nil_append, hnil]
+
+/-- The Eventually-level transfer: a block-granular execution proof yields a
+single-step one on a coherently-laid-out executable. -/
+theorem Executable.eventually_step1_of_eventually_straightlineStep [Layout]
+    (e : Executable) (hres : Executable.Resolves e) (post : @Post MachineState) :
+    ∀ s, Eventually (straightlineStep e) post s → Eventually (step1 e) post s := by
+  intro s h
+  induction h with
+  | done s hp => exact .done s hp
+  | step s mid_p ht _ ih =>
+    exact eventually_trans _ _ _ _
+      (e.eventually_step1_of_straightlineStep hres s mid_p ht)
+      (fun s' hs' => ih s' hs')
+
+-- A trailing zero-sized label is a terminal stutter: coherence holds through
+-- the second disjunct of `Resolves`.
+private def nopThenLabel : Executable :=
+  (0, [(.instr (.regular .W64 .W64 (.nop 1)), 1), (.label "end", 0)])
+
+example : Executable.Resolves nopThenLabel := by
+  apply Executable.resolves_of_members
+  intro p hp
+  simp only [nopThenLabel, Kraken.Executable.withAddresses, List.map,
+    List.mem_cons, List.not_mem_nil, or_false] at hp
+  rcases hp with rfl | rfl <;>
+    simp [Executable.ResolvesFallthroughAt, nopThenLabel,
+      Kraken.Executable.directivesFromAddress, Kraken.Executable.withAddresses,
+      List.dropWhile, Kraken.Directives.takeBlock, Kraken.Directives.fallthroughPC]
 
 private def twoNops : Executable :=
   (0, [

--- a/Kraken/X64/OmniSemantics.lean
+++ b/Kraken/X64/OmniSemantics.lean
@@ -20,16 +20,7 @@ import Kraken.X64.Semantics
 /-- `All` is monotone in its postcondition. -/
 theorem Effects.All.imp {α : Type} {post₁ post₂ : α → Prop} {m : Effects α}
     (h : ∀ a, post₁ a → post₂ a) : m.All post₁ → m.All post₂ := by
-  induction m <;> simp only [Effects.All] <;> intro hall
-  case done a => exact h a hall
-  case unimplemented => exact hall
-  case gp_unaligned => exact hall
-  case nonmem_load => exact hall
-  case nonmem_store => exact hall
-  case undefined ret ih => exact fun v => ih v (hall v)
-  case require_read_access _ _ _ ih => exact ih () hall
-  case require_write_access _ _ _ ih => exact ih () hall
-  case require_exec_access _ _ ih => exact ih () hall
+  induction m <;> simp_all [Effects.All]
 
 /-- Universal interpretation turns effect sequencing into nested `All`. -/
 theorem Effects.all_bind {α β : Type} {m : Effects α} {k : α → Effects β}
@@ -40,16 +31,7 @@ theorem Effects.all_bind {α β : Type} {m : Effects α} {k : α → Effects β}
 /-- `Effects.exec` chooses one of the outcomes described by `Effects.All`. -/
 theorem Effects.exec_ok {α : Type} {post : α → Prop} {m : Effects α} {entropy : UInt64} {a : α}
     (hall : m.All post) (hexec : m.exec entropy = .ok a) : post a := by
-  induction m with
-  | done b => cases hexec; exact hall
-  | unimplemented _ => exact absurd hexec (by simp [Effects.exec])
-  | gp_unaligned _ _ => exact absurd hexec (by simp [Effects.exec])
-  | nonmem_load _ _ _ _ _ => exact absurd hexec (by simp [Effects.exec])
-  | nonmem_store _ _ _ _ _ => exact absurd hexec (by simp [Effects.exec])
-  | undefined ret ih => exact ih _ (hall _) hexec
-  | require_read_access _ _ _ ih => exact ih () hall hexec
-  | require_write_access _ _ _ ih => exact ih () hall hexec
-  | require_exec_access _ _ ih => exact ih () hall hexec
+  induction m <;> simp_all [Effects.All, Effects.exec] <;> grind
 
 /-- Appending directives extends only the fall-through path; a jump from the
 prefix bypasses the suffix. -/
@@ -171,12 +153,10 @@ theorem Executable.straightlineStep_cut [Layout] (e : Executable)
   unfold straightlineStep Executable.straightline
   dsimp only
   rw [key]
-  simp only [Effects.bind_eq, Effects.bind_assoc]
+  simp only [Effects.bind_assoc]
   rw [Effects.all_bind]
   refine Effects.All.imp (fun ⟨s', ex⟩ hex => ?_) h
-  cases ex with
-  | jump t => exact hex
-  | fallthrough pc' => exact hex
+  cases ex <;> exact hex
 
 /-- The fetched suffix at `pc` decomposes as the block at `pc` followed by the
 fetch at the block's fall-through address. This is the address-coherence fact
@@ -209,28 +189,10 @@ theorem Executable.straightline_eq_step {α : Type}
   rw [← h] at key
   simp only [Executable.straightline, Executable.stepWithExit]
   rw [key]
-  simp only [Effects.bind_eq, Effects.bind_assoc]
+  simp only [Effects.bind_assoc]
   congr 1
   funext ⟨s', ex⟩
   cases ex <;> rfl
-
-/-- A nonempty listing yields a nonempty block. -/
-private theorem takeBlock_ne_nil {Directive : Type} {ds : List (Directive × Nat)}
-    (h : ds ≠ []) : Kraken.Directives.takeBlock ds ≠ [] := by
-  cases ds with
-  | nil => exact absurd rfl h
-  | cons entry rest =>
-    by_cases hz : entry.2 = 0 <;>
-      simp [Kraken.Directives.takeBlock, hz]
-
-/-- A listing of zero-sized directives is one block. -/
-private theorem takeBlock_of_all_zero {Directive : Type} :
-    ∀ {ds : List (Directive × Nat)}, (∀ d ∈ ds, d.2 = 0) →
-      Kraken.Directives.takeBlock ds = ds
-  | [], _ => rfl
-  | entry :: rest, h => by
-    simp [Kraken.Directives.takeBlock, h entry (List.mem_cons_self ..),
-      takeBlock_of_all_zero (fun d hd => h d (List.mem_cons_of_mem _ hd))]
 
 private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executable)
     (hres : ∀ pc, e.ResolvesFallthroughAt pc ∨
@@ -266,7 +228,7 @@ private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executabl
         unfold straightlineStep at h
         simp only [Executable.straightline] at h
         simp only [step1, Executable.step, Executable.stepWithExit]
-        rw [takeBlock_of_all_zero hz]
+        rw [Kraken.Directives.takeBlock_of_all_zero hz]
         exact Effects.All.imp (fun mid hm => Eventually.done mid hm) h
       -- Peel one block; every fall-through lands at the static address, whose
       -- fetched suffix is strictly shorter by address coherence.
@@ -280,14 +242,9 @@ private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executabl
           (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)) s.2)).length ≤ n := by
         have hsplit := hA
         unfold Executable.ResolvesFallthroughAt at hsplit
-        have hblock : Kraken.Directives.takeBlock (e.directivesFromAddress s.2) ≠ [] :=
-          takeBlock_ne_nil hnil
         have hlens := congrArg List.length hsplit
         simp only [List.length_append] at hlens
-        have hpos : 0 < (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)).length := by
-          cases hblk : Kraken.Directives.takeBlock (e.directivesFromAddress s.2) with
-          | nil => exact absurd hblk hblock
-          | cons a l => simp
+        have hpos := Kraken.Directives.takeBlock_length_pos hnil
         omega
       refine Effects.All.imp (fun ⟨s', ex⟩ hex => ?_) h
       cases ex with
@@ -319,10 +276,7 @@ attribute [ksimp] Effects.ite_bind
 
 theorem all_ite {α : Type} {c : Prop} [Decidable c] (Q : α → Prop) (a b : Effects α) :
     (c → Effects.All Q a) → (¬ c → Effects.All Q b) → Effects.All Q (if c then a else b) := by
-  intro ha hb
-  by_cases hc : c
-  · simp [hc]; exact ha hc
-  · simp [hc]; exact hb hc
+  by_cases hc : c <;> simp_all
 
 /-- Every address either fetches coherently (the block there is followed by
 the fetch at its fall-through address) or reaches only zero-sized directives,
@@ -341,11 +295,9 @@ instance (e : Executable) (pc : Int64) :
         (Kraken.Directives.takeBlock (e.directivesFromAddress pc)) pc)))
 
 private theorem dropWhile_ne_eq_nil {α : Type} (p : α → Bool) :
-    ∀ (l : List α), (∀ x ∈ l, p x = true) → l.dropWhile p = []
-  | [], _ => rfl
-  | x :: xs, h => by
-    simp only [List.dropWhile, h x (List.mem_cons_self ..)]
-    exact dropWhile_ne_eq_nil p xs (fun y hy => h y (List.mem_cons_of_mem _ hy))
+    ∀ (l : List α), (∀ x ∈ l, p x = true) → l.dropWhile p = [] := by
+  intro l h
+  induction l <;> simp_all [List.dropWhile]
 
 /-- At an address where nothing starts, the fetch is empty and coherence is
 trivial, so `Resolves` reduces to a check over the finitely many start
@@ -360,20 +312,13 @@ theorem Executable.resolves_of_members (e : Executable)
   · refine Or.inl ?_
     have hnil : e.directivesFromAddress pc = [] := by
       unfold Kraken.Executable.directivesFromAddress
-      have : e.withAddresses.dropWhile (·.1 ≠ pc) = [] := by
-        apply dropWhile_ne_eq_nil
-        intro x hx
-        simp only [ne_eq, decide_eq_true_eq]
-        intro heq
-        exact hmem (List.mem_map.mpr ⟨x, hx, heq⟩)
-      rw [this]
-      rfl
-    unfold Executable.ResolvesFallthroughAt
-    rw [hnil]
-    show ([] : List (Directive × Nat)) = [] ++ e.directivesFromAddress
-        (Kraken.Directives.fallthroughPC [] pc)
-    have : Kraken.Directives.fallthroughPC ([] : List (Directive × Nat)) pc = pc := rfl
-    rw [this, List.nil_append, hnil]
+      rw [dropWhile_ne_eq_nil]
+      · rfl
+      · intro x hx
+        simpa only [ne_eq, decide_eq_true_eq] using
+          fun heq => hmem (List.mem_map.mpr ⟨x, hx, heq⟩)
+    simp [Executable.ResolvesFallthroughAt, hnil, Kraken.Directives.takeBlock,
+      Kraken.Directives.fallthroughPC]
 
 /-- The Eventually-level transfer: a block-granular execution proof yields a
 single-step one on a coherently-laid-out executable. -/

--- a/Kraken/X64/OmniSemantics.lean
+++ b/Kraken/X64/OmniSemantics.lean
@@ -6,19 +6,69 @@ import Kraken.Attribute
 import Kraken.OmniSemantics
 import Kraken.X64.Semantics
 
-@[kstep] def Effects.All (post : MachineState → Prop) : Effects → Prop
+@[kstep] def Effects.All {α : Type} (post : α → Prop) : Effects α → Prop
   | .done a => post a
   | .unimplemented _ => False
   | .gp_unaligned .. => False
   | .nonmem_load .. => False
   | .nonmem_store .. => False
-  | @Effects.undefined α _ cont => ∀ v: α, (cont v).All post
+  | @Effects.undefined _ β _ cont => ∀ v : β, (cont v).All post
   | .require_read_access _ _ cont => (cont ()).All post
   | .require_write_access _ _ cont => (cont ()).All post
   | .require_exec_access _ cont => (cont ()).All post
+
+/-- `All` is monotone in its postcondition. -/
+theorem Effects.All.imp {α : Type} {post₁ post₂ : α → Prop} {m : Effects α}
+    (h : ∀ a, post₁ a → post₂ a) : m.All post₁ → m.All post₂ := by
+  induction m <;> simp only [Effects.All] <;> intro hall
+  case done a => exact h a hall
+  case unimplemented => exact hall
+  case gp_unaligned => exact hall
+  case nonmem_load => exact hall
+  case nonmem_store => exact hall
+  case undefined ret ih => exact fun v => ih v (hall v)
+  case require_read_access _ _ _ ih => exact ih () hall
+  case require_write_access _ _ _ ih => exact ih () hall
+  case require_exec_access _ _ ih => exact ih () hall
+
+/-- Universal interpretation turns effect sequencing into nested `All`. -/
+theorem Effects.all_bind {α β : Type} {m : Effects α} {k : α → Effects β}
+    {post : β → Prop} :
+    (m.bind k).All post ↔ m.All fun a => (k a).All post := by
+  induction m <;> simp [Effects.bind, Effects.All, *]
 
 def step1 [Layout] (e: Executable) (s: MachineState) (post: @Post MachineState) : Prop :=
   (Executable.step e s .done).All post
 
 def straightlineStep [Layout] (e: Executable) (s: MachineState) (post: @Post MachineState) : Prop :=
   (Executable.straightline e s .done).All post
+
+/-- Execute `n` applications of the existing single-step semantics. -/
+def Executable.runSteps (e : Executable) : Nat → MachineState → Effects MachineState
+  | 0, s => .done s
+  | n + 1, s => (e.step s .done).bind (e.runSteps n)
+
+/-- A successful batched execution is a finite `step1` execution. -/
+theorem Executable.runSteps_all_eventually [Layout] (e : Executable) (n : Nat)
+    (s : MachineState) (post : @Post MachineState)
+    (h : (e.runSteps n s).All post) : Eventually (step1 e) post s := by
+  induction n generalizing s with
+  | zero => exact .done s h
+  | succ n ih =>
+      apply step_cps
+      exact Effects.All.imp (fun mid hmid => ih mid hmid) (Effects.all_bind.mp h)
+
+private def twoNops : Executable :=
+  (0, [
+    (.instr (.regular .W64 .W64 (.nop 1)), 1),
+    (.instr (.regular .W64 .W64 (.nop 1)), 1)
+  ])
+
+-- `runSteps` threads the state produced by each step into the next one.
+example [Layout] (s : MachineData) :
+    Eventually (step1 twoNops) (fun st => st.2 = 2) (s, 0) := by
+  apply Executable.runSteps_all_eventually twoNops 2
+  simp [twoNops, Executable.runSteps, Executable.step,
+    Kraken.Executable.directivesAtAddress, Kraken.Executable.withAddresses,
+    Directives.interp, Directive.interp, Instr.interp, Operation.interp,
+    Effects.bind, Effects.All]

--- a/Kraken/X64/OmniSemantics.lean
+++ b/Kraken/X64/OmniSemantics.lean
@@ -155,8 +155,7 @@ def Executable.ResolvesFallthroughAt (e : Executable) (pc : Int64) : Prop :=
         (Kraken.Directives.takeBlock (e.directivesFromAddress pc)) pc)
 
 /-- A straight-line run executes the block at the current address, then
-continues only on fall-through. A jump ends the run at its target. This is the
-sound form of the step/straightline relation PR #140 was after. -/
+continues only on fall-through. A jump ends the run at its target. -/
 theorem Executable.straightline_eq_step {α : Type}
     (e : Executable) (st : MachineState)
     (h : e.ResolvesFallthroughAt st.2)
@@ -264,8 +263,7 @@ private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executabl
 
 /-- Block-level proofs transfer to the single-step semantics: on an executable
 whose fetches are address-coherent, a spec proved against `straightlineStep`
-holds along `step1` execution. Completes the theorem deferred in #104 and
-resolves the question of #140 with a true statement. -/
+holds along `step1` execution. -/
 theorem Executable.eventually_step1_of_straightlineStep [Layout] (e : Executable)
     (hres : ∀ pc, e.ResolvesFallthroughAt pc ∨
       ∀ d ∈ e.directivesFromAddress pc, d.2 = 0) (s : MachineState)
@@ -317,7 +315,7 @@ private theorem dropWhile_ne_eq_nil {α : Type} (p : α → Bool) :
     exact dropWhile_ne_eq_nil p xs (fun y hy => h y (List.mem_cons_of_mem _ hy))
 
 /-- At an address where nothing starts, the fetch is empty and coherence is
-trivial — so `Resolves` reduces to a check over the finitely many start
+trivial, so `Resolves` reduces to a check over the finitely many start
 addresses of the executable. -/
 theorem Executable.resolves_of_members (e : Executable)
     (h : ∀ p ∈ e.withAddresses.map (·.1), e.ResolvesFallthroughAt p ∨

--- a/Kraken/X64/OmniSemantics.lean
+++ b/Kraken/X64/OmniSemantics.lean
@@ -37,6 +37,93 @@ theorem Effects.all_bind {α β : Type} {m : Effects α} {k : α → Effects β}
     (m.bind k).All post ↔ m.All fun a => (k a).All post := by
   induction m <;> simp [Effects.bind, Effects.All, *]
 
+/-- `Effects.exec` chooses one of the outcomes described by `Effects.All`. -/
+theorem Effects.exec_ok {α : Type} {post : α → Prop} {m : Effects α} {entropy : UInt64} {a : α}
+    (hall : m.All post) (hexec : m.exec entropy = .ok a) : post a := by
+  induction m with
+  | done b => cases hexec; exact hall
+  | unimplemented _ => exact absurd hexec (by simp [Effects.exec])
+  | gp_unaligned _ _ => exact absurd hexec (by simp [Effects.exec])
+  | nonmem_load _ _ _ _ _ => exact absurd hexec (by simp [Effects.exec])
+  | nonmem_store _ _ _ _ _ => exact absurd hexec (by simp [Effects.exec])
+  | undefined ret ih => exact ih _ (hall _) hexec
+  | require_read_access _ _ _ ih => exact ih () hall hexec
+  | require_write_access _ _ _ ih => exact ih () hall hexec
+  | require_exec_access _ _ ih => exact ih () hall hexec
+
+/-- Appending directives extends only the fall-through path; a jump from the
+prefix bypasses the suffix. -/
+theorem Directives.interp_append [Labels] (ds₁ ds₂ : List (Directive × Nat))
+    (s : MachineData) (pc : Int64) :
+    Directives.interp (ds₁ ++ ds₂) s pc =
+      (Directives.interp ds₁ s pc).bind fun se =>
+        match se with
+        | (s', .fallthrough pc') => Directives.interp ds₂ s' pc'
+        | (s', .jump t) => .done (s', .jump t) := by
+  induction ds₁ generalizing s pc with
+  | nil => rfl
+  | cons hd rest ih =>
+    obtain ⟨d, sz⟩ := hd
+    simp only [List.cons_append, Directives.interp, Effects.bind_eq, Effects.bind_assoc]
+    congr 1
+    funext ⟨s', c⟩
+    cases c with
+    | next => exact ih ..
+    | jmp t => rfl
+
+/-- The append law when the suffix is obtained by fetching at the prefix's
+fall-through address. -/
+theorem Directives.interp_append_from [Labels]
+    (ds rest : List (Directive × Nat))
+    (fetch : Int64 → List (Directive × Nat))
+    (s : MachineData) (pc : Int64)
+    (hrest : fetch (Kraken.Directives.fallthroughPC ds pc) = rest) :
+    Directives.interp (ds ++ rest) s pc =
+      (Directives.interp ds s pc).bind fun se =>
+        match se with
+        | (s', .fallthrough pc') => Directives.interp (fetch pc') s' pc'
+        | (s', .jump t) => .done (s', .jump t) := by
+  induction ds generalizing s pc with
+  | nil =>
+    change fetch pc = rest at hrest
+    simp [Directives.interp, Effects.bind, hrest]
+  | cons hd ds ih =>
+    obtain ⟨d, sz⟩ := hd
+    simp only [List.cons_append, Directives.interp, Effects.bind_eq, Effects.bind_assoc]
+    congr 1
+    funext ⟨s', c⟩
+    cases c with
+    | next =>
+      have hrest' :
+          fetch (Kraken.Directives.fallthroughPC ds (pc + Int64.ofNat sz)) = rest := by
+        simpa [Kraken.Directives.fallthroughPC] using hrest
+      exact ih (s := s') (pc := pc + Int64.ofNat sz) hrest'
+    | jmp t => rfl
+
+/-- Inside a block, every fall-through exit lands at the statically computed
+fall-through address, so a continuation may assume that pc. -/
+theorem Directives.interp_fallthrough_pc [Labels] {α : Type}
+    (ds : List (Directive × Nat)) (s : MachineData) (pc : Int64)
+    (k : MachineData × BlockExit → Effects α) :
+    (Directives.interp ds s pc).bind k =
+      (Directives.interp ds s pc).bind (fun (s', ex) =>
+        match ex with
+        | .fallthrough _ => k (s', .fallthrough (Kraken.Directives.fallthroughPC ds pc))
+        | .jump target => k (s', .jump target)) := by
+  induction ds generalizing s pc with
+  | nil => rfl
+  | cons hd rest ih =>
+    obtain ⟨d, size⟩ := hd
+    simp only [Directives.interp, Effects.bind_eq, Effects.bind_assoc]
+    congr 1
+    funext se
+    obtain ⟨s', ctrl⟩ := se
+    cases ctrl with
+    | next =>
+      simpa [Kraken.Directives.fallthroughPC, List.foldl] using
+        ih s' (pc + Int64.ofNat size)
+    | jmp target => rfl
+
 def step1 [Layout] (e: Executable) (s: MachineState) (post: @Post MachineState) : Prop :=
   (Executable.step e s .done).All post
 
@@ -58,6 +145,114 @@ theorem Executable.runSteps_all_eventually [Layout] (e : Executable) (n : Nat)
       apply step_cps
       exact Effects.All.imp (fun mid hmid => ih mid hmid) (Effects.all_bind.mp h)
 
+/-- The fetched suffix at `pc` decomposes as the block at `pc` followed by the
+fetch at the block's fall-through address. This is the address-coherence fact
+an honest layout provides; `Layout.size` alone does not guarantee it. -/
+def Executable.ResolvesFallthroughAt (e : Executable) (pc : Int64) : Prop :=
+  e.directivesFromAddress pc =
+    Kraken.Directives.takeBlock (e.directivesFromAddress pc) ++
+      e.directivesFromAddress (Kraken.Directives.fallthroughPC
+        (Kraken.Directives.takeBlock (e.directivesFromAddress pc)) pc)
+
+/-- A straight-line run executes the block at the current address, then
+continues only on fall-through. A jump ends the run at its target. This is the
+sound form of the step/straightline relation PR #140 was after. -/
+theorem Executable.straightline_eq_step {α : Type}
+    (e : Executable) (st : MachineState)
+    (h : e.ResolvesFallthroughAt st.2)
+    (ret : MachineState → Effects α) :
+    e.straightline st ret =
+      e.stepWithExit st fun s exit =>
+        match exit with
+        | .fallthrough pc => e.straightline (s, pc) ret
+        | .jump target => ret (s, target) := by
+  obtain ⟨s, pc⟩ := st
+  unfold Executable.ResolvesFallthroughAt at h
+  dsimp only at h
+  have key := @Directives.interp_append_from e.labels
+    (Kraken.Directives.takeBlock (e.directivesFromAddress pc))
+    (e.directivesFromAddress (Kraken.Directives.fallthroughPC
+      (Kraken.Directives.takeBlock (e.directivesFromAddress pc)) pc))
+    e.directivesFromAddress s pc rfl
+  rw [← h] at key
+  simp only [Executable.straightline, Executable.stepWithExit]
+  rw [key]
+  simp only [Effects.bind_eq, Effects.bind_assoc]
+  congr 1
+  funext ⟨s', ex⟩
+  cases ex <;> rfl
+
+/-- A nonempty listing yields a nonempty block. -/
+private theorem takeBlock_ne_nil {Directive : Type} {ds : List (Directive × Nat)}
+    (h : ds ≠ []) : Kraken.Directives.takeBlock ds ≠ [] := by
+  cases ds with
+  | nil => exact absurd rfl h
+  | cons entry rest =>
+    by_cases hz : entry.2 = 0 <;>
+      simp [Kraken.Directives.takeBlock, hz]
+
+private theorem eventually_step1_of_straightlineStep_aux [Layout] (e : Executable)
+    (hres : ∀ pc, e.ResolvesFallthroughAt pc) (post : @Post MachineState) :
+    ∀ (n : Nat) (s : MachineState), (e.directivesFromAddress s.2).length ≤ n →
+      straightlineStep e s post → Eventually (step1 e) post s := by
+  intro n
+  induction n with
+  | zero =>
+    intro s hlen h
+    haveI := e.labels
+    apply Eventually.done
+    have hnil : e.directivesFromAddress s.2 = [] :=
+      List.eq_nil_of_length_eq_zero (Nat.le_zero.mp hlen)
+    obtain ⟨sd, pc⟩ := s
+    simp only [straightlineStep, Executable.straightline, hnil, Directives.interp,
+      Effects.bind, Effects.All] at h
+    exact h
+  | succ n ih =>
+    intro s hlen h
+    haveI := e.labels
+    by_cases hnil : e.directivesFromAddress s.2 = []
+    · apply Eventually.done
+      obtain ⟨sd, pc⟩ := s
+      simp only [straightlineStep, Executable.straightline, hnil, Directives.interp,
+        Effects.bind, Effects.All] at h
+      exact h
+    · -- Peel one block; every fall-through lands at the static address, whose
+      -- fetched suffix is strictly shorter by address coherence.
+      apply step_cps
+      unfold straightlineStep at h
+      rw [e.straightline_eq_step s (hres s.2)] at h
+      simp only [step1, Executable.step, Executable.stepWithExit] at h ⊢
+      rw [@Directives.interp_fallthrough_pc e.labels _ _ _ _ _] at h ⊢
+      rw [Effects.all_bind] at h ⊢
+      have hdec : (e.directivesFromAddress (Kraken.Directives.fallthroughPC
+          (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)) s.2)).length ≤ n := by
+        have hsplit := hres s.2
+        unfold Executable.ResolvesFallthroughAt at hsplit
+        have hblock : Kraken.Directives.takeBlock (e.directivesFromAddress s.2) ≠ [] :=
+          takeBlock_ne_nil hnil
+        have hlens := congrArg List.length hsplit
+        simp only [List.length_append] at hlens
+        have hpos : 0 < (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)).length := by
+          cases hblk : Kraken.Directives.takeBlock (e.directivesFromAddress s.2) with
+          | nil => exact absurd hblk hblock
+          | cons a l => simp
+        omega
+      refine Effects.All.imp (fun ⟨s', ex⟩ hex => ?_) h
+      cases ex with
+      | jump target => exact Eventually.done _ hex
+      | fallthrough pc' => exact ih _ hdec hex
+
+/-- Block-level proofs transfer to the single-step semantics: on an executable
+whose fetches are address-coherent, a spec proved against `straightlineStep`
+holds along `step1` execution. Completes the theorem deferred in #104 and
+resolves the question of #140 with a true statement. -/
+theorem Executable.eventually_step1_of_straightlineStep [Layout] (e : Executable)
+    (hres : ∀ pc, e.ResolvesFallthroughAt pc) (s : MachineState)
+    (post : @Post MachineState) (h : straightlineStep e s post) :
+    Eventually (step1 e) post s :=
+  eventually_step1_of_straightlineStep_aux e hres post
+    (e.directivesFromAddress s.2).length s (Nat.le_refl _) h
+
 private def twoNops : Executable :=
   (0, [
     (.instr (.regular .W64 .W64 (.nop 1)), 1),
@@ -68,7 +263,8 @@ private def twoNops : Executable :=
 example [Layout] (s : MachineData) :
     Eventually (step1 twoNops) (fun st => st.2 = 2) (s, 0) := by
   apply Executable.runSteps_all_eventually twoNops 2
-  simp [twoNops, Executable.runSteps, Executable.step,
-    Kraken.Executable.directivesAtAddress, Kraken.Executable.withAddresses,
+  simp [twoNops, Executable.runSteps, Executable.step, Executable.stepWithExit,
+    BlockExit.pc, Kraken.Directives.takeBlock,
+    Kraken.Executable.directivesFromAddress, Kraken.Executable.withAddresses,
     Directives.interp, Directive.interp, Instr.interp, Operation.interp,
     Effects.bind, Effects.All]

--- a/Kraken/X64/OmniSemantics.lean
+++ b/Kraken/X64/OmniSemantics.lean
@@ -145,6 +145,39 @@ theorem Executable.runSteps_all_eventually [Layout] (e : Executable) (n : Nat)
       apply step_cps
       exact Effects.All.imp (fun mid hmid => ih mid hmid) (Effects.all_bind.mp h)
 
+/-- Cut a straight-line run after a listing prefix: prove the prefix's run,
+with the remaining program as a fresh straight-line obligation at each
+fall-through exit and `post` directly at each jump target. Together with
+`kstep`'s step budget this advances a bounded number of directives and stops
+at a sound resume point of the same shape. The side condition is the fetch
+coherence at this one split, the fact `ResolvesFallthroughAt` states with the
+block as the prefix. -/
+theorem Executable.straightlineStep_cut [Layout] (e : Executable)
+    (st : MachineState) (post : @Post MachineState)
+    (pre : List (Directive × Nat))
+    (hsplit : e.directivesFromAddress st.2
+      = pre ++ e.directivesFromAddress (Kraken.Directives.fallthroughPC pre st.2))
+    (h : (let _ : Labels := e.labels
+          Directives.interp pre st.1 st.2).All
+          (fun se => match se with
+            | (s', .fallthrough pc') => straightlineStep e (s', pc') post
+            | (s', .jump t) => post (s', t))) :
+    straightlineStep e st post := by
+  obtain ⟨s, pc⟩ := st
+  have key := @Directives.interp_append_from e.labels pre
+    (e.directivesFromAddress (Kraken.Directives.fallthroughPC pre pc))
+    e.directivesFromAddress s pc rfl
+  rw [← hsplit] at key
+  unfold straightlineStep Executable.straightline
+  dsimp only
+  rw [key]
+  simp only [Effects.bind_eq, Effects.bind_assoc]
+  rw [Effects.all_bind]
+  refine Effects.All.imp (fun ⟨s', ex⟩ hex => ?_) h
+  cases ex with
+  | jump t => exact hex
+  | fallthrough pc' => exact hex
+
 /-- The fetched suffix at `pc` decomposes as the block at `pc` followed by the
 fetch at the block's fall-through address. This is the address-coherence fact
 an honest layout provides; `Layout.size` alone does not guarantee it. -/

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -284,6 +284,10 @@ instance : Monad Effects where
   pure := .done
   bind := .bind
 
+/-- A nondeterministically chosen value for use in `do` notation. -/
+@[kstep] def Effects.undef {β : Type} [NondetSupportingType β] : Effects β :=
+  .undefined .done
+
 @[simp] theorem Effects.pure_eq {α : Type} (a : α) :
     (pure a : Effects α) = .done a := rfl
 
@@ -304,31 +308,38 @@ instance : LawfulMonad Effects :=
     (pure_bind := fun _ _ => rfl)
     (bind_assoc := Effects.bind_assoc)
 
+def Effects.exec {α : Type} (entropy : UInt64) : Effects α → Except String α
+  | .done a => .ok a
+  | .unimplemented msg => .error msg
+  | .gp_unaligned addr w =>
+      .error s!"#GP: Memory op at {repr addr} did not have mandatory alignment of {w}"
+  | .nonmem_load _ addr _ _ => .error s!"Load at unmapped address {repr addr}"
+  | .nonmem_store _ addr _ _ => .error s!"Store at unmapped address {repr addr}"
+  | @Effects.undefined _ _ inst ret => (ret (inst.from_hash entropy)).exec entropy
+  | .require_read_access _ _ ok => (ok ()).exec entropy
+  | .require_write_access _ _ ok => (ok ()).exec entropy
+  | .require_exec_access _ ok => (ok ()).exec entropy
+
+/-- How one instruction transfers control: fall through, or jump to `target`. -/
+inductive Ctrl : Type
+  | next
+  | jmp (target : Int64)
+  deriving Repr, BEq, DecidableEq
+
 -- the unused `Std.Rco Int64` argument and the unmodified `MachineData` return
 -- value are present for uniformity with RegOrMem.interp
-@[kstep] def Reg.interp {α : Type} {w} (r : Reg w) (s : MachineData) (_ : Std.Rco Int64)
-  (ret : w.type → MachineData → Effects α) : Effects α :=
-  ret (s.regs.get r) s
+@[kstep] def Reg.interp {w} (r : Reg w) (s : MachineData) (_ : Std.Rco Int64) :
+    Effects (w.type × MachineData) :=
+  .done (s.regs.get r, s)
 
--- Since MMIO can cause devices to do arbitrary actions, a load might actually
--- *modify* memory. For instance:
--- A TEST instruction might load a flag from an MMIO address and bitwise-and it with
--- an immediate, and if the result is non-zero, it might mean that some device has
--- finished processing a buffer and therefore now passes ownership of that buffer
--- to the CPU.
--- Note that `ret` takes a whole `MachineData` instead of only `DataMem`, which
--- provides a bit more flexibility than we need: MachineData.load might change
--- dmem, but will not change the registers or status flags.
--- But this superfluous flexibility helps us simplify the state-threading:
--- Instead of writing `fun v dmem => ... { s with dmem } ...` everywhere, we
--- can just write `fun v s => ...` and the new `s` will shadow the old `s`.
+-- An MMIO load may return an updated data memory, for example when a device
+-- transfers ownership of a buffer back to the CPU.
 def MachineData.load
-  {α : Type} (s : MachineData) (addr : BitVec 64) (w : Width)
-  (ret : w.type → MachineData → Effects α) : Effects α :=
+  (s : MachineData) (addr : BitVec 64) (w : Width) : Effects (w.type × MachineData) :=
   require_read_access addr w (fun _unit =>
     match Mem.loadInt s.dmem addr w.bytes with
-    | .some i => ret (.ofInt _ i) s
-    | .none => nonmem_load s.dmem addr w (fun v dmem => ret v { s with dmem }))
+    | .some i => .done (.ofInt _ i, s)
+    | .none => nonmem_load s.dmem addr w (fun v dmem => .done (v, { s with dmem })))
 
 -- Alternatively, we could define this in terms of BitVecs without %:
 -- (addr &&& BitVec.ofNat 64 (bytes - 1)) == 0#64
@@ -340,34 +351,31 @@ def isAligned (bytes : Nat) (addr : BitVec 64) : Bool :=
 -- addresses (https://discourse.llvm.org/t/memory-alignment-model-on-avx-avx2-and-avx-512-targets/34705).
 -- For this reason we default checkAlign to false.
 def MachineData.loadAvx
-  {α : Type} (s : MachineData) (addr : BitVec 64) (w : AvxWidth)
-  (ret : w.type → MachineData → Effects α) (checkAlign : Bool := false) : Effects α :=
+  (s : MachineData) (addr : BitVec 64) (w : AvxWidth)
+  (checkAlign : Bool := false) : Effects (w.type × MachineData) :=
   if checkAlign && !(isAligned w.bytes addr) then
     .gp_unaligned addr w.bytes
   else
     require_read_access addr .W64 (fun _unit =>
   match Mem.loadInt s.dmem addr w.bytes with
-      | .some i => ret (.ofInt _ i) s
+      | .some i => .done (.ofInt _ i, s)
       | .none => unimplemented "AVX nonmem load not supported")
 
-def MachineData.store {α : Type} (s : MachineData) (addr : BitVec 64)
-    {w : Width} (v : w.type) (ret : MachineData → Effects α) : Effects α :=
+def MachineData.store (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.type) : Effects MachineData :=
   require_write_access addr w (fun _unit =>
     match Mem.loadInt s.dmem addr w.bytes with
     | .some _ =>
-        ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
-    | .none => nonmem_store s.dmem addr v (fun dmem' => ret { s with dmem := dmem' }))
+        .done { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
+    | .none => nonmem_store s.dmem addr v (fun dmem' => .done { s with dmem := dmem' }))
 
-def MachineData.storeAvx {α : Type} (s : MachineData) (addr : BitVec 64)
-    {w : AvxWidth} (v : w.type) (ret : MachineData → Effects α)
-    (checkAlign : Bool := false) : Effects α :=
+def MachineData.storeAvx (s : MachineData) (addr : BitVec 64) {w : AvxWidth} (v : w.type) (checkAlign : Bool := false) : Effects MachineData :=
   if checkAlign && !(isAligned w.bytes addr) then
     .gp_unaligned addr w.bytes
   else
     require_write_access addr .W64 (fun _unit =>
   match Mem.loadInt s.dmem addr w.bytes with
       | .some _ =>
-          ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
+          .done { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
       | .none => unimplemented "AVX nonmem store not supported")
 
 class Labels where label : Label → Int64
@@ -391,22 +399,20 @@ export Labels (label)
              | .none => 0
   BitVec.ofInt address_size.address_size.bits (base + idx + (a.disp.interp p).toInt)
 
-@[kstep] def RegOrMem.interp {α : Type} {w} [Labels] [AddressSize]
-  (o : RegOrMem w) (s : MachineData) (p : Std.Rco Int64)
-  (ret : w.type → MachineData → Effects α) : Effects α :=
+@[kstep] def RegOrMem.interp {w} [Labels] [AddressSize]
+  (o : RegOrMem w) (s : MachineData) (p : Std.Rco Int64) : Effects (w.type × MachineData) :=
 match o with
-  | .reg r => ret (s.regs.get r) s
-  | .mem a => s.load ((a.interp s.regs p).zeroExtend _) w ret
+  | .reg r => .done (s.regs.get r, s)
+  | .mem a => s.load ((a.interp s.regs p).zeroExtend _) w
 
-def AvxRegOrMem.interp {α : Type} {w} [Labels] [AddressSize]
+def AvxRegOrMem.interp {w} [Labels] [AddressSize]
   (o : AvxRegOrMem w) (s : MachineData) (p : Std.Rco Int64)
-  (ret : w.type → MachineData → Effects α) (checkAlign : Bool := false) : Effects α :=
+  (checkAlign : Bool := false) : Effects (w.type × MachineData) :=
 match o with
-  | .avx r => ret (s.zmms.get r) s
-  | .mem a => s.loadAvx ((a.interp s.regs p).zeroExtend _) w ret checkAlign
+  | .avx r => .done (s.zmms.get r, s)
+  | .mem a => s.loadAvx ((a.interp s.regs p).zeroExtend _) w checkAlign
 
-@[kstep]
-def MachineData.setReg (s : MachineData) {w} (r : Reg w) (v : w.type) : MachineData :=
+@[kstep] def MachineData.setReg (s : MachineData) {w} (r : Reg w) (v : w.type) : MachineData :=
   { s with regs := s.regs.set r v }
 
 def MachineData.setAvxReg (s : MachineData) {w : AvxWidth} (r : AvxReg w) (v : w.type) : MachineData :=
@@ -415,44 +421,35 @@ def MachineData.setAvxReg (s : MachineData) {w : AvxWidth} (r : AvxReg w) (v : w
 def MachineData.setAvxLegacyReg (s : MachineData) {w : AvxWidth} (r : AvxReg w) (v : w.type) : MachineData :=
   { s with zmms := s.zmms.setLegacy r v }
 
-@[kstep]
-def MachineData.set {α : Type} {w} [Labels] [AddressSize] (s : MachineData)
-    (d : Dst w) (v : w.type) (p : Std.Rco Int64)
-    (ret : MachineData → Effects α) : Effects α :=
+@[kstep] def MachineData.set {w} [Labels] [AddressSize] (s : MachineData) (d : Dst w) (v : w.type) (p : Std.Rco Int64) : Effects MachineData :=
   match d with
-  | .reg r => ret (s.setReg r v)
-  | .mem a => s.store ((a.interp s.regs p).zeroExtend _) v ret
+  | .reg r => .done (s.setReg r v)
+  | .mem a => s.store ((a.interp s.regs p).zeroExtend _) v
 
-def MachineData.setAvx {α : Type} {aw} [Labels] [AddressSize] (s : MachineData)
-    (d : AvxDst aw) (v : aw.type) (p : Std.Rco Int64)
-    (ret : MachineData → Effects α) (checkAlign : Bool := false) : Effects α :=
+def MachineData.setAvx {aw} [Labels] [AddressSize] (s : MachineData) (d : AvxDst aw) (v : aw.type) (p : Std.Rco Int64) (checkAlign : Bool := false) : Effects MachineData :=
 match d with
-  | .avx r => ret (s.setAvxReg r v)
-  | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v ret checkAlign
+  | .avx r => .done (s.setAvxReg r v)
+  | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v checkAlign
 
-def MachineData.setAvxLegacy {α : Type} {w} [Labels] [AddressSize] (s : MachineData)
-    (d : AvxDst w) (v : w.type) (p : Std.Rco Int64)
-    (ret : MachineData → Effects α) (checkAlign : Bool := false) : Effects α :=
+def MachineData.setAvxLegacy {w} [Labels] [AddressSize] (s : MachineData) (d : AvxDst w) (v : w.type) (p : Std.Rco Int64) (checkAlign : Bool := false) : Effects MachineData :=
 match d with
-  | .avx r => ret (s.setAvxLegacyReg r v)
-  | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v ret checkAlign
+  | .avx r => .done (s.setAvxLegacyReg r v)
+  | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v checkAlign
 
-@[kstep] def Operand.interp {α : Type} {w} [Labels] [AddressSize]
-  (o : Operand w) (s : MachineData) (p : Std.Rco Int64)
-  (ret : w.type → MachineData → Effects α) : Effects α :=
+@[kstep] def Operand.interp {w} [Labels] [AddressSize]
+  (o : Operand w) (s : MachineData) (p : Std.Rco Int64) : Effects (w.type × MachineData) :=
   match o with
-  | regOrMem rm => rm.interp s p ret
-  | .imm v => ret ((v.interp p).toBitVec.truncate _) s
+  | regOrMem rm => rm.interp s p
+  | .imm v => .done ((v.interp p).toBitVec.truncate _, s)
   -- we rely on assemblers erroring out on too-large immediates in uniform ops
 
-def AvxOperand.interp {α : Type} {aw} [Labels] [AddressSize]
+def AvxOperand.interp {aw} [Labels] [AddressSize]
   (o : AvxOperand aw) (s : MachineData) (p : Std.Rco Int64)
-  (ret : aw.type → MachineData → Effects α) (checkAlign : Bool := false) : Effects α :=
+  (checkAlign : Bool := false) : Effects (aw.type × MachineData) :=
 match o with
-  | regOrMem rm => rm.interp s p ret checkAlign
+  | regOrMem rm => rm.interp s p checkAlign
 
-@[kstep]
-def CondCode.interp (cc : CondCode) (s : StatusFlags) : Bool := match cc with
+@[kstep] def CondCode.interp (cc : CondCode) (s : StatusFlags) : Bool := match cc with
   | .z  => s.zf | .nz => !s.zf | .c  => s.cf | .nc => !s.cf
   | .a  => !s.cf && !s.zf | .be => s.cf || s.zf
   | .l => s.sf != s.of | .le => (s.sf != s.of) || s.zf
@@ -463,13 +460,12 @@ def CondCode.interp (cc : CondCode) (s : StatusFlags) : Bool := match cc with
 @[kstep] def ShiftCountExpr.interpMasked [Labels] (c : ShiftCountExpr) (s : MachineData) (p : Std.Rco Int64) (w : Width) : Nat :=
   (c.interp s p).toNat &&& match w with | .W64 => 0x3f | _ => 0x1f -- "masked to 5 bits (or 6 bits with a 64-bit operand)"
 
-def RelRegOrMem.interp {α : Type} [Labels] [AddressSize]
-  (o : RelRegOrMem) (s : MachineData) (p : Std.Rco Int64)
-  (ret : BitVec 64 → MachineData → Effects α) : Effects α :=
+def RelRegOrMem.interp [Labels] [AddressSize]
+  (o : RelRegOrMem) (s : MachineData) (p : Std.Rco Int64) : Effects (BitVec 64 × MachineData) :=
   match o with
-  | .rel c => ret (p.upper + c.interp p).toBitVec s
-  | .reg r => ret (s.regs.get r) s
-  | .mem a => s.load ((a.interp s.regs p).zeroExtend _) .W64 ret
+  | .rel c => .done ((p.upper + c.interp p).toBitVec, s)
+  | .reg r => .done (s.regs.get r, s)
+  | .mem a => s.load ((a.interp s.regs p).zeroExtend _) .W64
 
 structure StatusFlags.from_result.Remaining where
   cf : Bool
@@ -496,135 +492,156 @@ end BitVec
 
 
 set_option maxHeartbeats 1000000
-@[kstep] def Operation.interp {α : Type} [Labels] [address_size : AddressSize]
-  {w} (i : Operation w) (p : Std.Rco Int64) (s : MachineData)
-  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
-  match (generalizing := false) (motive := Operation w → Effects α) i with
-  | .mov dst src => src.interp s p (fun val s => s.set dst val p next)
-  | .movsx dst src => src.interp s p (fun val s => s.set dst (val.signExtend _) p next)
-  | .movzx dst src => src.interp s p (fun val s => s.set dst (val.zeroExtend _) p next)
-  | .push src =>
-    src.interp s p (fun v s =>
+@[kstep] def Operation.interp [Labels] [address_size : AddressSize]
+  {w} (i : Operation w) (p : Std.Rco Int64) (s : MachineData) : Effects (MachineData × Ctrl) :=
+  match (generalizing := false) (motive := Operation w → Effects (MachineData × Ctrl)) i with
+  | .mov dst src => do
+    let (val, s) ← src.interp s p
+    let s ← s.set dst val p
+    pure (s, .next)
+  | .movsx dst src => do
+    let (val, s) ← src.interp s p
+    let s ← s.set dst (val.signExtend _) p
+    pure (s, .next)
+  | .movzx dst src => do
+    let (val, s) ← src.interp s p
+    let s ← s.set dst (val.zeroExtend _) p
+    pure (s, .next)
+  | .push src => do
+    let (v, s) ← src.interp s p
     let rsp := s.regs.get64 .rsp - w.bytesv
-    { s with regs := s.regs.set64 .rsp rsp }.store rsp v next)
-  | .pop dst =>
+    let s ← { s with regs := s.regs.set64 .rsp rsp }.store rsp v
+    pure (s, .next)
+  | .pop dst => do
     let rsp := s.regs.get64 .rsp
-    s.load rsp w (fun val s =>
+    let (val, s) ← s.load rsp w
     let s := { s with regs := s.regs.set64 .rsp (rsp + w.bytesv) }
-    s.set dst val p next)
-  | .setcc cc dst =>
-    s.set dst (cc.interp s.status) p next
-  | .cmovcc cc dst src =>
-    src.interp s p (fun src s =>
+    let s ← s.set dst val p
+    pure (s, .next)
+  | .setcc cc dst => do
+    let s ← s.set dst (cc.interp s.status) p
+    pure (s, .next)
+  | .cmovcc cc dst src => do
+    let (src, s) ← src.interp s p
     let v := if cc.interp s.status then src else s.regs.get dst
-    next (s.setReg dst v))
+    pure (s.setReg dst v, .next)
 -- Arithmetic
-  | .lea dst src => next (s.setReg dst ((src.interp s.regs p).zeroExtend _))
-  | .add dst src =>
-    src.interp s p (fun a s =>
-    dst.interp s p (fun b s =>
+  | .lea dst src => .done (s.setReg dst ((src.interp s.regs p).zeroExtend _), .next)
+  | .add dst src => do
+    let (a, s) ← src.interp s p
+    let (b, s) ← dst.interp s p
     let v := a + b
-    let status := .from_result v {
+    let status := StatusFlags.from_result v {
       cf := v.unsigned != a.unsigned + b.unsigned
       af := (v.take 4).unsigned != (a.take 4).unsigned + (b.take 4).unsigned,
       of := v.signed != a.signed + b.signed }
-    { s with status }.set dst v p next))
-  | .adc dst src =>
-    src.interp s p (fun a s =>
-    dst.interp s p (fun b s =>
+    let s ← { s with status }.set dst v p
+    pure (s, .next)
+  | .adc dst src => do
+    let (a, s) ← src.interp s p
+    let (b, s) ← dst.interp s p
     let c := s.status.cf
     let v := a + b + c
-    let status := .from_result v {
+    let status := StatusFlags.from_result v {
       cf := v.unsigned != a.unsigned + b.unsigned + c
       af := (v.take 4).unsigned != (a.take 4).unsigned + (b.take 4).unsigned + c,
       of := v.signed != a.signed + b.signed + c }
-    { s with status }.set dst v p next))
-  | .adcx dst src =>
-    src.interp s p (fun a s =>
-    dst.interp s p (fun b s =>
+    let s ← { s with status }.set dst v p
+    pure (s, .next)
+  | .adcx dst src => do
+    let (a, s) ← src.interp s p
+    let (b, s) ← dst.interp s p
     let v := a + b + s.status.cf
     let cf := v.unsigned != a.unsigned + b.unsigned + s.status.cf
-    next { s with regs := s.regs.set dst v, status := { s.status with cf := cf }}))
-  | .adox dst src =>
-    src.interp s p (fun a s =>
-    dst.interp s p (fun b s =>
+    pure ({ s with regs := s.regs.set dst v, status := { s.status with cf := cf }}, .next)
+  | .adox dst src => do
+    let (a, s) ← src.interp s p
+    let (b, s) ← dst.interp s p
     let v := a + b + s.status.of
     let of := v.unsigned != a.unsigned + b.unsigned + s.status.of
-    next { s with regs := s.regs.set dst v, status := { s.status with of := of }}))
-  | .inc dst =>
-    dst.interp s p (fun a s =>
+    pure ({ s with regs := s.regs.set dst v, status := { s.status with of := of }}, .next)
+  | .inc dst => do
+    let (a, s) ← dst.interp s p
     let v := a + 1
-    let status := .from_result v {
+    let status := StatusFlags.from_result v {
       cf := s.status.cf
       af := (v.take 4).unsigned != (a.take 4).unsigned + 1,
       of := v.signed != a.signed + 1 }
-    { s with status }.set dst v p next)
-  | .dec dst =>
-    dst.interp s p (fun a s =>
+    let s ← { s with status }.set dst v p
+    pure (s, .next)
+  | .dec dst => do
+    let (a, s) ← dst.interp s p
     let v := a - 1
-    let status := .from_result v {
+    let status := StatusFlags.from_result v {
       cf := s.status.cf
       af := (v.take 4).unsigned != (a.take 4).unsigned - 1,
       of := v.signed != a.signed - 1 }
-    { s with status }.set dst v p next)
-  | .neg dst =>
-    dst.interp s p (fun b s =>
+    let s ← { s with status }.set dst v p
+    pure (s, .next)
+  | .neg dst => do
+    let (b, s) ← dst.interp s p
     let v := -b
-    let status := .from_result v {
+    let status := StatusFlags.from_result v {
       cf := b != 0
       af := (b.take 4) != 0,
       of := v.signed != - b.signed }
-    { s with status }.set dst v p next)
-  | .sub dst src =>
-    src.interp s p (fun a s =>
-    dst.interp s p (fun b s =>
+    let s ← { s with status }.set dst v p
+    pure (s, .next)
+  | .sub dst src => do
+    let (a, s) ← src.interp s p
+    let (b, s) ← dst.interp s p
     let v := b - a
-    let status := .from_result v {
+    let status := StatusFlags.from_result v {
       cf := v.unsigned != b.unsigned - a.unsigned
       af := (v.take 4).unsigned != (b.take 4).unsigned - (a.take 4).unsigned,
       of := v.signed != b.signed - a.signed }
-    { s with status }.set dst v p next))
-  | .sbb dst src =>
-    src.interp s p (fun a s =>
-    dst.interp s p (fun b s =>
+    let s ← { s with status }.set dst v p
+    pure (s, .next)
+  | .sbb dst src => do
+    let (a, s) ← src.interp s p
+    let (b, s) ← dst.interp s p
     let c := s.status.cf
     let v := b - a - c
-    let status := .from_result v {
+    let status := StatusFlags.from_result v {
       cf := v.unsigned != b.unsigned - a.unsigned - c
       af := (v.take 4).unsigned != (b.take 4).unsigned - (a.take 4).unsigned - c,
       of := v.signed != b.signed - a.signed - c }
-    { s with status }.set dst v p next))
-  | .cmp a b =>
-    a.interp s p (fun a s =>
-    b.interp s p (fun b s =>
+    let s ← { s with status }.set dst v p
+    pure (s, .next)
+  | .cmp a b => do
+    let (a, s) ← a.interp s p
+    let (b, s) ← b.interp s p
     let v := a - b
-    let status := .from_result v {
+    let status := StatusFlags.from_result v {
       cf := v.unsigned != a.unsigned - b.unsigned
       af := (v.take 4).unsigned != (a.take 4).unsigned - (b.take 4).unsigned,
       of := v.signed != a.signed - b.signed }
-    next { s with status }))
-  | .mul src =>
+    pure ({ s with status }, .next)
+  | .mul src => do
     let a := s.regs.get (Reg.low .rax w)
-    src.interp s p (fun b s =>
+    let (b, s) ← src.interp s p
     let v := a * b
     let vn := a.unsigned * b.unsigned
     let s := if w == .W8
       then s.setReg (.low .rax .W16) (.ofInt _ vn)
       else (s.setReg (.low .rax w) v).setReg (.low .rdx w) (.ofInt _ (vn >>> w.bits))
-    undefined (λ sf => undefined (λ zf => undefined (λ af => undefined (λ pf =>
-    next { s with status := { cf := v.unsigned != vn, pf, af, zf, sf, of := v.unsigned != vn }})))))
-  | .mulx r_hi r_lo src1 =>
-    src1.interp s p (fun a s =>
+    let sf : Bool ← Effects.undef
+    let zf : Bool ← Effects.undef
+    let af : Bool ← Effects.undef
+    let pf : Bool ← Effects.undef
+    pure ({ s with status := { cf := v.unsigned != vn, pf, af, zf, sf, of := v.unsigned != vn }}, .next)
+  | .mulx r_hi r_lo src1 => do
+    let (a, s) ← src1.interp s p
     let b := s.regs.get (.low .rdx w)
     let v := a.unsigned * b.unsigned
     let s := s.setReg r_lo (.ofInt _ v) -- if r_hi = r_li, hi is written:
     let s := s.setReg r_hi (.ofInt _ (v >>> w.bits))
-    next s)
+    pure (s, .next)
   -- imul1 and imul collectively describe variants of the same
   -- syntax level `imul` instruction, where imul1 is the 1-operand case
-  | .imul1 src =>
+  | .imul1 src => do
     let a := s.regs.get (Reg.low .rax w)
-    src.interp s p (fun b s =>
+    let (b, s) ← src.interp s p
     let v := a.toInt * b.toInt
     let s := if w == .W8 then
       s.setReg (.low .rax .W16) (BitVec.ofInt 16 v)
@@ -633,207 +650,247 @@ set_option maxHeartbeats 1000000
       let low := result.take w.bits
       let high := (result.drop w.bits).setWidth _
       (s.setReg (.low .rax w) low).setReg (.low .rdx w) high
-    undefined (λ sf => undefined (λ zf => undefined (λ af => undefined (λ pf =>
+    let sf : Bool ← Effects.undef
+    let zf : Bool ← Effects.undef
+    let af : Bool ← Effects.undef
+    let pf : Bool ← Effects.undef
     let low := BitVec.ofInt w.bits v
     let cf := v != low.toInt
-    next { s with status := { cf := cf, pf, af, zf, sf, of := cf }})))))
-  | .imul dst src1 src2 =>
-    src1.interp s p (fun a s =>
-    src2.interp s p (fun b s =>
+    pure ({ s with status := { cf := cf, pf, af, zf, sf, of := cf }}, .next)
+  | .imul dst src1 src2 => do
+    let (a, s) ← src1.interp s p
+    let (b, s) ← src2.interp s p
     let v := a * b
-    s.set (match (generalizing := false) (motive := Option (RegOrMem w) → RegOrMem w)
-             dst with | .some dst => dst | _ => src1) v p (fun s =>
+    let s ← s.set (match (generalizing := false) (motive := Option (RegOrMem w) → RegOrMem w)
+             dst with | .some dst => dst | _ => src1) v p
     let cf := v.signed != a.signed * b.signed
-    undefined (λ sf => undefined (λ zf => undefined (λ af => undefined (λ pf =>
-    next { s with status := { cf := cf, pf, af, zf, sf, of := cf }})))))))
+    let sf : Bool ← Effects.undef
+    let zf : Bool ← Effects.undef
+    let af : Bool ← Effects.undef
+    let pf : Bool ← Effects.undef
+    pure ({ s with status := { cf := cf, pf, af, zf, sf, of := cf }}, .next)
 -- Bitwise
-  | .test a b =>
-    a.interp s p (fun a s =>
-    b.interp s p (fun b s =>
+  | .test a b => do
+    let (a, s) ← a.interp s p
+    let (b, s) ← b.interp s p
     let v := a &&& b
-    undefined (fun af =>
-    let status := .from_result v { cf := false, af, of := false}
-    next { s with status})))
-  | .and dst src | .or dst src | .xor dst src =>
-    dst.interp s p (fun a s =>
-    src.interp s p (fun b s =>
+    let af : Bool ← Effects.undef
+    let status := StatusFlags.from_result v { cf := false, af, of := false}
+    pure ({ s with status}, .next)
+  | .and dst src | .or dst src | .xor dst src => do
+    let (a, s) ← dst.interp s p
+    let (b, s) ← src.interp s p
     let v := match i with | .and _ _ => a &&& b | .or _ _ => a ||| b | _ => a ^^^ b
-    undefined (fun af =>
-    let status := .from_result v { cf := false, of := false, af }
-    { s with status }.set dst v p next)))
-  | .not dst =>
-    dst.interp s p (fun a s =>
+    let af : Bool ← Effects.undef
+    let status := StatusFlags.from_result v { cf := false, of := false, af }
+    let s ← { s with status }.set dst v p
+    pure (s, .next)
+  | .not dst => do
+    let (a, s) ← dst.interp s p
     let v := ~~~a
-    s.set dst v p next)
-  | .shl dst count =>
-    dst.interp s p (fun a s =>
+    let s ← s.set dst v p
+    pure (s, .next)
+  | .shl dst count => do
+    let (a, s) ← dst.interp s p
     let count := count.interpMasked s p w
-    if count == 0 then next s else
+    if count == 0 then pure (s, .next) else do
     let v := a <<< count
-    undefined (λ af =>
-    (λ setcf => if count < w.bits then setcf (a <<< (count-1)).msb else undefined setcf) (λ cf =>
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
-    { s with status := .from_result v { s.status with cf, af, of } }.set dst v p next))))
-  | .shr dst count =>
-    dst.interp s p (fun a s =>
+    let af : Bool ← Effects.undef
+    let cf : Bool ← if count < w.bits then pure (a <<< (count-1)).msb else Effects.undef
+    let of : Bool ← if count == 1 then pure (v.msb != a.msb) else Effects.undef
+    let s ← { s with status := .from_result v { s.status with cf, af, of } }.set dst v p
+    pure (s, .next)
+  | .shr dst count => do
+    let (a, s) ← dst.interp s p
     let count := count.interpMasked s p w
-    if count == 0 then next s else
+    if count == 0 then pure (s, .next) else do
     let v := a.ushiftRight count
-    undefined (λ af =>
-    (λ setcf => if count < w.bits then setcf (a.getLsbD (count-1)) else undefined setcf) (λ cf =>
-    (λ setof => if count == 1 then setof a.msb else undefined setof) (λ of =>
-    { s with status := .from_result v { s.status with cf, af, of } }.set dst v p next))))
-  | .sar dst count =>
-    dst.interp s p (fun a s =>
+    let af : Bool ← Effects.undef
+    let cf : Bool ← if count < w.bits then pure (a.getLsbD (count-1)) else Effects.undef
+    let of : Bool ← if count == 1 then pure a.msb else Effects.undef
+    let s ← { s with status := .from_result v { s.status with cf, af, of } }.set dst v p
+    pure (s, .next)
+  | .sar dst count => do
+    let (a, s) ← dst.interp s p
     let count := count.interpMasked s p w
-    if count == 0 then next s else
+    if count == 0 then pure (s, .next) else do
     let v := a.sshiftRight count
-    undefined (λ af =>
-    (λ setcf => if count < w.bits then setcf (a.getLsbD (count-1)) else undefined setcf) (λ cf =>
-    (λ setof => if count == 1 then setof false else undefined setof) (λ of =>
-    { s with status := .from_result v { s.status with cf, af, of } }.set dst v p next))))
-  | .shrd dst src count =>
-    dst.interp s p (fun a s =>
-    src.interp s p (fun b s =>
+    let af : Bool ← Effects.undef
+    let cf : Bool ← if count < w.bits then pure (a.getLsbD (count-1)) else Effects.undef
+    let of : Bool ← if count == 1 then pure false else Effects.undef
+    let s ← { s with status := .from_result v { s.status with cf, af, of } }.set dst v p
+    pure (s, .next)
+  | .shrd dst src count => do
+    let (a, s) ← dst.interp s p
+    let (b, s) ← src.interp s p
     let count := count.interpMasked s p w
-    if count == 0 then next s else
+    if count == 0 then pure (s, .next) else do
     let v := (((b.append a) >>> count).take w.bits).setWidth _
-    (λ setstatus => if count >= w.bits then undefined setstatus else
-      let cf := a.getLsbD (count-1)
-      undefined (λ af =>
-      (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
-      setstatus (.from_result v { cf, af, of})))) (λ status =>
-    { s with status }.set dst v p next)))
-  | .shld dst src count =>
-    dst.interp s p (fun a s =>
-    src.interp s p (fun b s =>
+    let status : StatusFlags ←
+      if count >= w.bits then Effects.undef else do
+        let cf := a.getLsbD (count-1)
+        let af : Bool ← Effects.undef
+        let of : Bool ← if count == 1 then pure (v.msb != a.msb) else Effects.undef
+        pure (.from_result v { cf, af, of})
+    let s ← { s with status }.set dst v p
+    pure (s, .next)
+  | .shld dst src count => do
+    let (a, s) ← dst.interp s p
+    let (b, s) ← src.interp s p
     let count := count.interpMasked s p w
-    if count == 0 then next s else
+    if count == 0 then pure (s, .next) else do
     let v := (((a.append b) <<< count).drop w.bits).setWidth _
-    (λ setstatus => if count >= w.bits then undefined setstatus else
-      let cf := (a <<< (count-1)).msb
-      undefined (λ af =>
-      (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
-      setstatus (.from_result v { cf, af, of})))) (λ status =>
-    { s with status }.set dst v p next)))
-  | .rol dst count =>
-    dst.interp s p (fun a s =>
+    let status : StatusFlags ←
+      if count >= w.bits then Effects.undef else do
+        let cf := (a <<< (count-1)).msb
+        let af : Bool ← Effects.undef
+        let of : Bool ← if count == 1 then pure (v.msb != a.msb) else Effects.undef
+        pure (.from_result v { cf, af, of})
+    let s ← { s with status }.set dst v p
+    pure (s, .next)
+  | .rol dst count => do
+    let (a, s) ← dst.interp s p
     let count := count.interpMasked s p w
-    if count == 0 then next s else
+    if count == 0 then pure (s, .next) else do
     let v := a.rotateLeft count
     let cf := v.getLsbD 0
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
-    { s with status := { s.status with cf, of } }.set dst v p next))
-  | .ror dst count =>
-    dst.interp s p (fun a s =>
+    let of : Bool ← if count == 1 then pure (v.msb != a.msb) else Effects.undef
+    let s ← { s with status := { s.status with cf, of } }.set dst v p
+    pure (s, .next)
+  | .ror dst count => do
+    let (a, s) ← dst.interp s p
     let count := count.interpMasked s p w
-    if count == 0 then next s else
+    if count == 0 then pure (s, .next) else do
     let v := a.rotateRight count
     let cf := v.msb
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
-    { s with status := { s.status with cf, of } }.set dst v p next))
-  | .rcr dst count =>
-    dst.interp s p (fun a s =>
+    let of : Bool ← if count == 1 then pure (v.msb != a.msb) else Effects.undef
+    let s ← { s with status := { s.status with cf, of } }.set dst v p
+    pure (s, .next)
+  | .rcr dst count => do
+    let (a, s) ← dst.interp s p
     let count := count.interpMasked s p w
-    if count == 0 then next s else
+    if count == 0 then pure (s, .next) else do
     let t := (BitVec.ofBool s.status.cf ++ a).rotateRight count
     let (cf, v) := (t.msb, t.take w.bits)
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
-    { s with status := { s.status with cf, of } }.set dst v p next))
-  | .rcl dst count =>
-    dst.interp s p (fun a s =>
+    let of : Bool ← if count == 1 then pure (v.msb != a.msb) else Effects.undef
+    let s ← { s with status := { s.status with cf, of } }.set dst v p
+    pure (s, .next)
+  | .rcl dst count => do
+    let (a, s) ← dst.interp s p
     let count := count.interpMasked s p w
-    if count == 0 then next s else
+    if count == 0 then pure (s, .next) else do
     let t := (BitVec.ofBool s.status.cf ++ a).rotateLeft count
     let (cf, v) := (t.msb, t.take w.bits)
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
-    { s with status := { s.status with cf, of } }.set dst v p next))
+    let of : Bool ← if count == 1 then pure (v.msb != a.msb) else Effects.undef
+    let s ← { s with status := { s.status with cf, of } }.set dst v p
+    pure (s, .next)
   | .bswap dst =>
     let a := s.regs.get dst
-    match (generalizing := false) (motive := Width → Effects α) w with
+    match (generalizing := false) (motive := Width → Effects (MachineData × Ctrl)) w with
     | .W32 =>
       let v := a.take 8 ++ a.extractLsb' 8 8 ++ a.extractLsb' 16 8 ++ a.drop 24
-      next (s.setReg dst (v.setWidth _))
+      .done (s.setReg dst (v.setWidth _), .next)
     | .W64 =>
       let v := a.take 8 ++ a.extractLsb' 8 8 ++ a.extractLsb' 16 8 ++ a.extractLsb' 24 8
             ++ a.extractLsb' 32 8 ++ a.extractLsb' 40 8 ++ a.extractLsb' 48 8 ++ a.drop 56
-      next (s.setReg dst (v.setWidth _))
-    | _ => undefined (fun v => next (s.setReg dst v))
+      .done (s.setReg dst (v.setWidth _), .next)
+    | _ => do
+      let v ← Effects.undef
+      pure (s.setReg dst v, .next)
   | .jcc cc l =>
     if cc.interp s.status
-    then jmp (label l) s
-    else next s
-  | .jmp tgt =>
-    tgt.interp s p (fun a s =>
-    jmp (.ofBitVec a) s)
-  | .call tgt =>
-    tgt.interp s p (fun a s =>
+    then .done (s, .jmp (label l))
+    else .done (s, .next)
+  | .jmp tgt => do
+    let (a, s) ← tgt.interp s p
+    pure (s, .jmp (.ofBitVec a))
+  | .call tgt => do
+    let (a, s) ← tgt.interp s p
     let rsp := s.regs.get64 .rsp - Width.W64.bytesv
-    { s with regs := s.regs.set64 .rsp rsp }.store rsp (w:=.W64) p.upper.toBitVec (jmp (.ofBitVec a)))
-  | .ret =>
+    let s ← { s with regs := s.regs.set64 .rsp rsp }.store rsp (w:=.W64) p.upper.toBitVec
+    pure (s, .jmp (.ofBitVec a))
+  | .ret => do
     let rsp := s.regs.get64 .rsp
-    s.load rsp .W64 (fun ra s =>
-    jmp (.ofBitVec ra) { s with regs := s.regs.set64 .rsp (rsp + 8) })
-  | nop _ | nopalign _ _ => next s
+    let (ra, s) ← s.load rsp .W64
+    pure ({ s with regs := s.regs.set64 .rsp (rsp + 8) }, .jmp (.ofBitVec ra))
+  | nop _ | nopalign _ _ => .done (s, .next)
 
 -- AVX Operations Interpreter
-def AvxOperation.interp {α : Type} [Labels] [address_size : AddressSize]
-  {w} (i : AvxOperation w) (p : Std.Rco Int64) (s : MachineData)
-  (next : MachineData → Effects α) : Effects α :=
+def AvxOperation.interp [Labels] [address_size : AddressSize]
+  {w} (i : AvxOperation w) (p : Std.Rco Int64) (s : MachineData) : Effects (MachineData × Ctrl) :=
 match i with
-  | .movups dst src => src.interp s p (fun val s => s.setAvxLegacy dst val p next)
-  | .vmovups dst src => src.interp s p (fun val s => s.setAvx dst val p next)
-  | .movaps dst src =>
-    src.interp s p (checkAlign := true)
-      (fun val s => s.setAvxLegacy dst val p (checkAlign := true) next)
+  | .movups dst src => do
+    let (val, s) ← src.interp s p
+    let s ← s.setAvxLegacy dst val p
+    pure (s, .next)
+  | .vmovups dst src => do
+    let (val, s) ← src.interp s p
+    let s ← s.setAvx dst val p
+    pure (s, .next)
+  | .movaps dst src => do
+    let (val, s) ← src.interp s p (checkAlign := true)
+    let s ← s.setAvxLegacy dst val p (checkAlign := true)
+    pure (s, .next)
   -- TODO: MXCSR
-  | .subps dst src =>
-    src.interp s p (checkAlign := true) (fun a s =>
-    dst.interp s p (fun b s =>
-      let v := BitVec.packedBinOp 32 (fun dst_chunk src_chunk =>
-        let f_dst := BitVec.toFloat32 dst_chunk
-        let f_src := BitVec.toFloat32 src_chunk
-        Float32.toBitVec (f_dst - f_src)
-      ) b a
-      s.setAvxLegacy dst v p next))
-  | .addps dst src =>
-    src.interp s p (checkAlign := true) (fun a s =>
-    dst.interp s p (fun b s =>
-      let v := BitVec.packedBinOp 32 (fun dst_chunk src_chunk =>
-        let f_dst := BitVec.toFloat32 dst_chunk
-        let f_src := BitVec.toFloat32 src_chunk
-        Float32.toBitVec (f_dst + f_src)
-      ) b a
-      s.setAvxLegacy dst v p next))
+  | .subps dst src => do
+    let (a, s) ← src.interp s p (checkAlign := true)
+    let (b, s) ← dst.interp s p
+    let v := BitVec.packedBinOp 32 (fun dst_chunk src_chunk =>
+      let f_dst := BitVec.toFloat32 dst_chunk
+      let f_src := BitVec.toFloat32 src_chunk
+      Float32.toBitVec (f_dst - f_src)
+    ) b a
+    let s ← s.setAvxLegacy dst v p
+    pure (s, .next)
+  | .addps dst src => do
+    let (a, s) ← src.interp s p (checkAlign := true)
+    let (b, s) ← dst.interp s p
+    let v := BitVec.packedBinOp 32 (fun dst_chunk src_chunk =>
+      let f_dst := BitVec.toFloat32 dst_chunk
+      let f_src := BitVec.toFloat32 src_chunk
+      Float32.toBitVec (f_dst + f_src)
+    ) b a
+    let s ← s.setAvxLegacy dst v p
+    pure (s, .next)
 
-@[kstep]
-def Instr.interp {α : Type} [Labels]
-  (i : Instr) (s : MachineData) (p : Std.Rco Int64)
-  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
+@[kstep] def Instr.interp [Labels]
+  (i : Instr) (s : MachineData) (p : Std.Rco Int64) : Effects (MachineData × Ctrl) :=
   require_exec_access p (fun _unit =>
     match i with
       | .regular addr_sz op_sz op =>
-          Operation.interp (w := op_sz) (address_size := .mk addr_sz) op p s next jmp
+          Operation.interp (w := op_sz) (address_size := .mk addr_sz) op p s
       | .avx addr_sz op_sz op =>
-          AvxOperation.interp (w := op_sz) (address_size := .mk addr_sz) op p s next
+          AvxOperation.interp (w := op_sz) (address_size := .mk addr_sz) op p s
   )
 
-@[kstep] def Directive.interp {α : Type} [Labels]
-  (d : Directive) (s : MachineData) (p : Std.Rco Int64)
-  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
+@[kstep] def Directive.interp [Labels]
+  (d : Directive) (s : MachineData) (p : Std.Rco Int64) : Effects (MachineData × Ctrl) :=
   match d with
-  | .label _ => next s
-  | .instr i => i.interp s p next jmp
+  | .label _ => .done (s, .next)
+  | .instr i => i.interp s p
   | .byteArray _ => .unimplemented s!"Unimplemented: execution reached data block at {p.1}"
 
-def Directives.interp {α : Type} [Labels]
-  (ds : List (Directive × Nat)) (s : MachineData) (pc : Int64)
-  (ret : Int64 → MachineData → Effects α) : Effects α :=
+/-- How control leaves a list of directives. -/
+inductive BlockExit : Type
+  | fallthrough (next : Int64)
+  | jump (target : Int64)
+  deriving Repr, BEq, DecidableEq
+
+/-- The program counter after the exit, forgetting how control got there. -/
+@[kstep] def BlockExit.pc : BlockExit → Int64
+  | .fallthrough next => next
+  | .jump target => target
+
+/-- Run directives in order until the list ends or an instruction jumps. -/
+def Directives.interp [Labels]
+  (ds : List (Directive × Nat)) (s : MachineData) (pc : Int64) : Effects (MachineData × BlockExit) :=
   match ds with
-  | [] => ret pc s
-  | (d, sz) :: ds =>
-    d.interp s (.mk pc (pc+.ofNat sz)) (jmp:=ret) (next := (fun s =>
-    interp ds s (pc+.ofNat sz) ret))
+  | [] => .done (s, .fallthrough pc)
+  | (d, sz) :: ds => do
+    let (s, c) ← d.interp s (.mk pc (pc+.ofNat sz))
+    match c with
+    | .next => interp ds s (pc+.ofNat sz)
+    | .jmp target => pure (s, .jump target)
 
 abbrev Layout := Kraken.Layout Directive
 
@@ -847,15 +904,30 @@ def Executable.directivesFromLabel (e : Executable) (l : Label) : List (Directiv
 
 abbrev MachineState := MachineData × Int64
 
+/-- Execute one positive-sized instruction, together with any leading
+zero-sized directives, passing the state and block exit to the continuation.
+The block is delimited by the size table (`takeBlock`); on a layout whose
+sizes wrap modulo 2^64 this can be a proper prefix of the directives whose
+assigned address equals the pc. -/
+def Executable.stepWithExit {α : Type} (e : Executable) (s : MachineState)
+    (ret : MachineData → BlockExit → Effects α) : Effects α :=
+  let := e.labels
+  (Directives.interp (Kraken.Directives.takeBlock (e.directivesFromAddress s.2)) s.1 s.2).bind
+    fun (s', ex) => ret s' ex
+
 def Executable.step {α : Type} (e : Executable) (s : MachineState)
     (ret : MachineState → Effects α) : Effects α :=
-  let := e.labels
-  Directives.interp (e.directivesAtAddress s.2) s.1 s.2 (fun pc s => ret (s, pc))
+  e.stepWithExit s (fun s' ex => ret (s', ex.pc))
 
+/-- Run from the current address to the first taken jump or the end of the
+listing. Derived from the same monadic core as `step`, with the exit's
+program counter forgotten — behaviorally the semantics `Executable.eval`
+and the specs have always had. -/
 def Executable.straightline {α : Type} (e : Executable) (s : MachineState)
     (ret : MachineState → Effects α) : Effects α :=
   let := e.labels
-  Directives.interp (e.directivesFromAddress s.2) s.1 s.2 (fun pc s => ret (s, pc))
+  (Directives.interp (e.directivesFromAddress s.2) s.1 s.2).bind
+    fun (s', ex) => ret (s', ex.pc)
 
 -- -- Concrete evaluators for expedient testing
 

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -243,25 +243,71 @@ instance (w : AvxWidth) : NondetSupportingType w.type := .avx_bitvec w
 instance : NondetSupportingType Bool := .bool
 instance : NondetSupportingType StatusFlags := .statusFlags
 
-inductive Effects
-  | done (a : MachineData × Int64)
+/-- The instruction effect tree: a computation that reads and writes machine
+state, requests access checks, draws nondeterministic values, or fails,
+producing a result of the given type. -/
+inductive Effects (α : Type) : Type 1
+  | done (a : α)
   | unimplemented (msg : String)
   | gp_unaligned (addr : BitVec 64) (w : Nat)
   -- loads and stores *outside* the data memory, eg. MMIO, might still affect the data memory:
   -- for instance, MMIO reads/writes at certain device register addresses might change what
   -- data memory the process logically owns vs what memory is owned by devices
-  | nonmem_load (dmem : DataMem) (addr : BitVec 64) (w : Width) (ret : w.type → DataMem → Effects)
-  | nonmem_store (dmem : DataMem) (addr : BitVec 64) {w : Width} (v : w.type) (ret: DataMem → Effects)
-  | undefined {α : Type} [NondetSupportingType α] (ret : α → Effects)
-  | require_read_access (addr : BitVec 64) (w : Width) (ok : Unit → Effects)
-  | require_write_access (addr : BitVec 64) (w : Width) (ok : Unit → Effects)
-  | require_exec_access (p: Std.Rco Int64) (ok : Unit → Effects)
+  | nonmem_load (dmem : DataMem) (addr : BitVec 64) (w : Width)
+      (ret : w.type → DataMem → Effects α)
+  | nonmem_store (dmem : DataMem) (addr : BitVec 64) {w : Width} (v : w.type)
+      (ret : DataMem → Effects α)
+  | undefined {β : Type} [NondetSupportingType β] (ret : β → Effects α)
+  | require_read_access (addr : BitVec 64) (w : Width) (ok : Unit → Effects α)
+  | require_write_access (addr : BitVec 64) (w : Width) (ok : Unit → Effects α)
+  | require_exec_access (p : Std.Rco Int64) (ok : Unit → Effects α)
 export Effects (unimplemented nonmem_load nonmem_store undefined require_read_access require_write_access require_exec_access)
+
+def Effects.bind {α β : Type} : Effects α → (α → Effects β) → Effects β
+  | .done a, k => k a
+  | .unimplemented msg, _ => .unimplemented msg
+  | .gp_unaligned addr w, _ => .gp_unaligned addr w
+  | .nonmem_load dmem addr w ret, k =>
+      .nonmem_load dmem addr w fun v dmem => (ret v dmem).bind k
+  | .nonmem_store dmem addr v ret, k =>
+      .nonmem_store dmem addr v fun dmem => (ret dmem).bind k
+  | @Effects.undefined _ γ inst ret, k =>
+      @Effects.undefined _ γ inst fun v => (ret v).bind k
+  | .require_read_access addr w ok, k =>
+      .require_read_access addr w fun u => (ok u).bind k
+  | .require_write_access addr w ok, k =>
+      .require_write_access addr w fun u => (ok u).bind k
+  | .require_exec_access p ok, k =>
+      .require_exec_access p fun u => (ok u).bind k
+
+instance : Monad Effects where
+  pure := .done
+  bind := .bind
+
+@[simp] theorem Effects.pure_eq {α : Type} (a : α) :
+    (pure a : Effects α) = .done a := rfl
+
+@[simp] theorem Effects.bind_eq {α β : Type} (m : Effects α) (k : α → Effects β) :
+    m >>= k = m.bind k := rfl
+
+theorem Effects.bind_done {α : Type} (m : Effects α) : m.bind .done = m := by
+  induction m <;> simp [Effects.bind, *]
+
+theorem Effects.bind_assoc {α β γ : Type} (m : Effects α)
+    (k₁ : α → Effects β) (k₂ : β → Effects γ) :
+    (m.bind k₁).bind k₂ = m.bind fun a => (k₁ a).bind k₂ := by
+  induction m <;> simp [Effects.bind, *]
+
+instance : LawfulMonad Effects :=
+  LawfulMonad.mk'
+    (id_map := Effects.bind_done)
+    (pure_bind := fun _ _ => rfl)
+    (bind_assoc := Effects.bind_assoc)
 
 -- the unused `Std.Rco Int64` argument and the unmodified `MachineData` return
 -- value are present for uniformity with RegOrMem.interp
-@[kstep] def Reg.interp {w} (r : Reg w) (s : MachineData) (_ : Std.Rco Int64)
-  (ret : w.type → MachineData → Effects) : Effects :=
+@[kstep] def Reg.interp {α : Type} {w} (r : Reg w) (s : MachineData) (_ : Std.Rco Int64)
+  (ret : w.type → MachineData → Effects α) : Effects α :=
   ret (s.regs.get r) s
 
 -- Since MMIO can cause devices to do arbitrary actions, a load might actually
@@ -277,8 +323,8 @@ export Effects (unimplemented nonmem_load nonmem_store undefined require_read_ac
 -- Instead of writing `fun v dmem => ... { s with dmem } ...` everywhere, we
 -- can just write `fun v s => ...` and the new `s` will shadow the old `s`.
 def MachineData.load
-  (s : MachineData) (addr : BitVec 64) (w : Width)
-  (ret : w.type → MachineData → Effects): Effects :=
+  {α : Type} (s : MachineData) (addr : BitVec 64) (w : Width)
+  (ret : w.type → MachineData → Effects α) : Effects α :=
   require_read_access addr w (fun _unit =>
     match Mem.loadInt s.dmem addr w.bytes with
     | .some i => ret (.ofInt _ i) s
@@ -294,8 +340,8 @@ def isAligned (bytes : Nat) (addr : BitVec 64) : Bool :=
 -- addresses (https://discourse.llvm.org/t/memory-alignment-model-on-avx-avx2-and-avx-512-targets/34705).
 -- For this reason we default checkAlign to false.
 def MachineData.loadAvx
-  (s : MachineData) (addr : BitVec 64) (w : AvxWidth)
-  (ret : w.type → MachineData → Effects) (checkAlign : Bool := false) : Effects :=
+  {α : Type} (s : MachineData) (addr : BitVec 64) (w : AvxWidth)
+  (ret : w.type → MachineData → Effects α) (checkAlign : Bool := false) : Effects α :=
   if checkAlign && !(isAligned w.bytes addr) then
     .gp_unaligned addr w.bytes
   else
@@ -304,14 +350,17 @@ def MachineData.loadAvx
       | .some i => ret (.ofInt _ i) s
       | .none => unimplemented "AVX nonmem load not supported")
 
-def MachineData.store (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.type) (ret: MachineData → Effects) : Effects :=
+def MachineData.store {α : Type} (s : MachineData) (addr : BitVec 64)
+    {w : Width} (v : w.type) (ret : MachineData → Effects α) : Effects α :=
   require_write_access addr w (fun _unit =>
     match Mem.loadInt s.dmem addr w.bytes with
     | .some _ =>
         ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
     | .none => nonmem_store s.dmem addr v (fun dmem' => ret { s with dmem := dmem' }))
 
-def MachineData.storeAvx (s : MachineData) (addr : BitVec 64) {w : AvxWidth} (v : w.type) (ret: MachineData → Effects) (checkAlign : Bool := false) : Effects :=
+def MachineData.storeAvx {α : Type} (s : MachineData) (addr : BitVec 64)
+    {w : AvxWidth} (v : w.type) (ret : MachineData → Effects α)
+    (checkAlign : Bool := false) : Effects α :=
   if checkAlign && !(isAligned w.bytes addr) then
     .gp_unaligned addr w.bytes
   else
@@ -342,16 +391,16 @@ export Labels (label)
              | .none => 0
   BitVec.ofInt address_size.address_size.bits (base + idx + (a.disp.interp p).toInt)
 
-@[kstep] def RegOrMem.interp {w} [Labels] [AddressSize]
+@[kstep] def RegOrMem.interp {α : Type} {w} [Labels] [AddressSize]
   (o : RegOrMem w) (s : MachineData) (p : Std.Rco Int64)
-  (ret : w.type → MachineData → Effects) :=
+  (ret : w.type → MachineData → Effects α) : Effects α :=
 match o with
   | .reg r => ret (s.regs.get r) s
   | .mem a => s.load ((a.interp s.regs p).zeroExtend _) w ret
 
-def AvxRegOrMem.interp {w} [Labels] [AddressSize]
+def AvxRegOrMem.interp {α : Type} {w} [Labels] [AddressSize]
   (o : AvxRegOrMem w) (s : MachineData) (p : Std.Rco Int64)
-  (ret : w.type → MachineData → Effects) (checkAlign : Bool := false) :=
+  (ret : w.type → MachineData → Effects α) (checkAlign : Bool := false) : Effects α :=
 match o with
   | .avx r => ret (s.zmms.get r) s
   | .mem a => s.loadAvx ((a.interp s.regs p).zeroExtend _) w ret checkAlign
@@ -367,32 +416,38 @@ def MachineData.setAvxLegacyReg (s : MachineData) {w : AvxWidth} (r : AvxReg w) 
   { s with zmms := s.zmms.setLegacy r v }
 
 @[kstep]
-def MachineData.set {w} [Labels] [AddressSize] (s : MachineData) (d : Dst w) (v : w.type) (p : Std.Rco Int64) (ret : MachineData → Effects) : Effects :=
+def MachineData.set {α : Type} {w} [Labels] [AddressSize] (s : MachineData)
+    (d : Dst w) (v : w.type) (p : Std.Rco Int64)
+    (ret : MachineData → Effects α) : Effects α :=
   match d with
   | .reg r => ret (s.setReg r v)
   | .mem a => s.store ((a.interp s.regs p).zeroExtend _) v ret
 
-def MachineData.setAvx {aw} [Labels] [AddressSize] (s : MachineData) (d : AvxDst aw) (v : aw.type) (p : Std.Rco Int64) (ret : MachineData → Effects) (checkAlign : Bool := false) : Effects :=
+def MachineData.setAvx {α : Type} {aw} [Labels] [AddressSize] (s : MachineData)
+    (d : AvxDst aw) (v : aw.type) (p : Std.Rco Int64)
+    (ret : MachineData → Effects α) (checkAlign : Bool := false) : Effects α :=
 match d with
   | .avx r => ret (s.setAvxReg r v)
   | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v ret checkAlign
 
-def MachineData.setAvxLegacy {w} [Labels] [AddressSize] (s : MachineData) (d : AvxDst w) (v : w.type) (p : Std.Rco Int64) (ret : MachineData → Effects) (checkAlign : Bool := false) : Effects :=
+def MachineData.setAvxLegacy {α : Type} {w} [Labels] [AddressSize] (s : MachineData)
+    (d : AvxDst w) (v : w.type) (p : Std.Rco Int64)
+    (ret : MachineData → Effects α) (checkAlign : Bool := false) : Effects α :=
 match d with
   | .avx r => ret (s.setAvxLegacyReg r v)
   | .mem a => s.storeAvx ((a.interp s.regs p).zeroExtend _) v ret checkAlign
 
-@[kstep] def Operand.interp {w} [Labels] [AddressSize]
+@[kstep] def Operand.interp {α : Type} {w} [Labels] [AddressSize]
   (o : Operand w) (s : MachineData) (p : Std.Rco Int64)
-  (ret : w.type → MachineData → Effects) :=
+  (ret : w.type → MachineData → Effects α) : Effects α :=
   match o with
   | regOrMem rm => rm.interp s p ret
   | .imm v => ret ((v.interp p).toBitVec.truncate _) s
   -- we rely on assemblers erroring out on too-large immediates in uniform ops
 
-def AvxOperand.interp {aw} [Labels] [AddressSize]
+def AvxOperand.interp {α : Type} {aw} [Labels] [AddressSize]
   (o : AvxOperand aw) (s : MachineData) (p : Std.Rco Int64)
-  (ret : aw.type → MachineData → Effects) (checkAlign : Bool := false) :=
+  (ret : aw.type → MachineData → Effects α) (checkAlign : Bool := false) : Effects α :=
 match o with
   | regOrMem rm => rm.interp s p ret checkAlign
 
@@ -408,9 +463,9 @@ def CondCode.interp (cc : CondCode) (s : StatusFlags) : Bool := match cc with
 @[kstep] def ShiftCountExpr.interpMasked [Labels] (c : ShiftCountExpr) (s : MachineData) (p : Std.Rco Int64) (w : Width) : Nat :=
   (c.interp s p).toNat &&& match w with | .W64 => 0x3f | _ => 0x1f -- "masked to 5 bits (or 6 bits with a 64-bit operand)"
 
-def RelRegOrMem.interp [Labels] [AddressSize]
+def RelRegOrMem.interp {α : Type} [Labels] [AddressSize]
   (o : RelRegOrMem) (s : MachineData) (p : Std.Rco Int64)
-  (ret : BitVec 64 → MachineData → Effects) :=
+  (ret : BitVec 64 → MachineData → Effects α) : Effects α :=
   match o with
   | .rel c => ret (p.upper + c.interp p).toBitVec s
   | .reg r => ret (s.regs.get r) s
@@ -441,10 +496,10 @@ end BitVec
 
 
 set_option maxHeartbeats 1000000
-@[kstep] def Operation.interp [Labels] [address_size : AddressSize]
+@[kstep] def Operation.interp {α : Type} [Labels] [address_size : AddressSize]
   {w} (i : Operation w) (p : Std.Rco Int64) (s : MachineData)
-  (next : MachineData → Effects) (jmp : Int64 → MachineData → Effects) : Effects :=
-  match (generalizing := false) (motive := Operation w → Effects) i with
+  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
+  match (generalizing := false) (motive := Operation w → Effects α) i with
   | .mov dst src => src.interp s p (fun val s => s.set dst val p next)
   | .movsx dst src => src.interp s p (fun val s => s.set dst (val.signExtend _) p next)
   | .movzx dst src => src.interp s p (fun val s => s.set dst (val.zeroExtend _) p next)
@@ -695,7 +750,7 @@ set_option maxHeartbeats 1000000
     { s with status := { s.status with cf, of } }.set dst v p next))
   | .bswap dst =>
     let a := s.regs.get dst
-    match (generalizing := false) (motive := Width → Effects) w with
+    match (generalizing := false) (motive := Width → Effects α) w with
     | .W32 =>
       let v := a.take 8 ++ a.extractLsb' 8 8 ++ a.extractLsb' 16 8 ++ a.drop 24
       next (s.setReg dst (v.setWidth _))
@@ -722,9 +777,9 @@ set_option maxHeartbeats 1000000
   | nop _ | nopalign _ _ => next s
 
 -- AVX Operations Interpreter
-def AvxOperation.interp [Labels] [address_size : AddressSize]
+def AvxOperation.interp {α : Type} [Labels] [address_size : AddressSize]
   {w} (i : AvxOperation w) (p : Std.Rco Int64) (s : MachineData)
-  (next : MachineData → Effects) : Effects :=
+  (next : MachineData → Effects α) : Effects α :=
 match i with
   | .movups dst src => src.interp s p (fun val s => s.setAvxLegacy dst val p next)
   | .vmovups dst src => src.interp s p (fun val s => s.setAvx dst val p next)
@@ -752,9 +807,9 @@ match i with
       s.setAvxLegacy dst v p next))
 
 @[kstep]
-def Instr.interp [Labels]
+def Instr.interp {α : Type} [Labels]
   (i : Instr) (s : MachineData) (p : Std.Rco Int64)
-  (next : MachineData → Effects) (jmp : Int64 → MachineData → Effects) : Effects :=
+  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
   require_exec_access p (fun _unit =>
     match i with
       | .regular addr_sz op_sz op =>
@@ -763,17 +818,17 @@ def Instr.interp [Labels]
           AvxOperation.interp (w := op_sz) (address_size := .mk addr_sz) op p s next
   )
 
-@[kstep] def Directive.interp [Labels]
+@[kstep] def Directive.interp {α : Type} [Labels]
   (d : Directive) (s : MachineData) (p : Std.Rco Int64)
-  (next : MachineData → Effects) (jmp : Int64 → MachineData → Effects) : Effects :=
+  (next : MachineData → Effects α) (jmp : Int64 → MachineData → Effects α) : Effects α :=
   match d with
   | .label _ => next s
   | .instr i => i.interp s p next jmp
   | .byteArray _ => .unimplemented s!"Unimplemented: execution reached data block at {p.1}"
 
-def Directives.interp [Labels]
+def Directives.interp {α : Type} [Labels]
   (ds : List (Directive × Nat)) (s : MachineData) (pc : Int64)
-  (ret : Int64 → MachineData → Effects) : Effects :=
+  (ret : Int64 → MachineData → Effects α) : Effects α :=
   match ds with
   | [] => ret pc s
   | (d, sz) :: ds =>
@@ -792,12 +847,14 @@ def Executable.directivesFromLabel (e : Executable) (l : Label) : List (Directiv
 
 abbrev MachineState := MachineData × Int64
 
-def Executable.step (e : Executable) (s : MachineState) (ret : MachineState → Effects) : Effects :=
-  let := Executable.labels e
+def Executable.step {α : Type} (e : Executable) (s : MachineState)
+    (ret : MachineState → Effects α) : Effects α :=
+  let := e.labels
   Directives.interp (e.directivesAtAddress s.2) s.1 s.2 (fun pc s => ret (s, pc))
 
-def Executable.straightline (e : Executable) (s : MachineState) (ret : MachineState → Effects) : Effects :=
-  let := Executable.labels e
+def Executable.straightline {α : Type} (e : Executable) (s : MachineState)
+    (ret : MachineState → Effects α) : Effects α :=
+  let := e.labels
   Directives.interp (e.directivesFromAddress s.2) s.1 s.2 (fun pc s => ret (s, pc))
 
 -- -- Concrete evaluators for expedient testing
@@ -815,7 +872,7 @@ where
     | .require_exec_access _ ok => handleEffects (ok ())
     | .nonmem_load _ addr _ _ => .error s!"Load at unmapped address {repr addr}"
     | .nonmem_store _ addr _ _ => .error s!"Store at unmapped address {repr addr}"
-    | @Effects.undefined _ t cont => handleEffects (cont (t.from_hash (hash s.1.regs)))
+    | @Effects.undefined _ _ t cont => handleEffects (cont (t.from_hash (hash s.1.regs)))
 
 def Directive.fakeSize (hashOfProgram : UInt64) (d : Directive) : Nat :=
   match d with

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -920,9 +920,8 @@ def Executable.step {α : Type} (e : Executable) (s : MachineState)
   e.stepWithExit s (fun s' ex => ret (s', ex.pc))
 
 /-- Run from the current address to the first taken jump or the end of the
-listing. Derived from the same monadic core as `step`, with the exit's
-program counter forgotten — behaviorally the semantics `Executable.eval`
-and the specs have always had. -/
+listing. Built on the same core as `step`; the continuation sees only the
+exit's program counter. -/
 def Executable.straightline {α : Type} (e : Executable) (s : MachineState)
     (ret : MachineState → Effects α) : Effects α :=
   let := e.labels

--- a/Kraken/X64/Sep.lean
+++ b/Kraken/X64/Sep.lean
@@ -8,25 +8,26 @@ open List
 
 @[kspec]
 theorem store_sep {α : Type} (s : MachineData) (addr : BitVec 64) (w : Width)
-    (v : w.type) (ret : MachineData → Effects α)
+    (v : w.type) (k : MachineData → Effects α)
     (bs : List UInt8) (R : DataMem → Prop)
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :
     have mem' := Mem.storeInt s.dmem addr w.bytes v.toInt
-    MachineData.store s addr v ret =
+    (MachineData.store s addr v).bind k =
       require_write_access addr w (fun _ =>
-        ret { s with dmem := mem' }) := by
+        k { s with dmem := mem' }) := by
   have h_load : Mem.loadInt s.dmem addr w.bytes = some (Int.ofBytes bs) :=
     Mem.loadInt_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)
-  simp only [MachineData.store, h_load]
+  simp only [MachineData.store, h_load, Effects.bind]
 
 @[kspec]
 theorem load_sep {α : Type} (s : MachineData) (addr : BitVec 64) (w : Width)
-    (ret : w.type → MachineData → Effects α)
+    (k : w.type × MachineData → Effects α)
     (bs : List UInt8) (R : DataMem → Prop)
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :
-    MachineData.load s addr w ret =
-      require_read_access addr w (fun _ => ret (.ofInt w.bits (Int.ofBytes bs)) s) := by
+    (MachineData.load s addr w).bind k =
+      require_read_access addr w (fun _ => k (.ofInt w.bits (Int.ofBytes bs), s)) := by
   simp only [MachineData.load,
-    Mem.loadInt_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)]
+    Mem.loadInt_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide),
+    Effects.bind]

--- a/Kraken/X64/Sep.lean
+++ b/Kraken/X64/Sep.lean
@@ -7,7 +7,8 @@ open Std.ExtHashMap
 open List
 
 @[kspec]
-theorem store_sep (s : MachineData) (addr : BitVec 64) (w : Width) (v : w.type) (ret : MachineData → Effects)
+theorem store_sep {α : Type} (s : MachineData) (addr : BitVec 64) (w : Width)
+    (v : w.type) (ret : MachineData → Effects α)
     (bs : List UInt8) (R : DataMem → Prop)
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :
@@ -20,7 +21,8 @@ theorem store_sep (s : MachineData) (addr : BitVec 64) (w : Width) (v : w.type) 
   simp only [MachineData.store, h_load]
 
 @[kspec]
-theorem load_sep (s : MachineData) (addr : BitVec 64) (w : Width) (ret : w.type → MachineData → Effects)
+theorem load_sep {α : Type} (s : MachineData) (addr : BitVec 64) (w : Width)
+    (ret : w.type → MachineData → Effects α)
     (bs : List UInt8) (R : DataMem → Prop)
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :

--- a/Kraken/X64/TacticsTests.lean
+++ b/Kraken/X64/TacticsTests.lean
@@ -22,3 +22,19 @@ error: kprologue: refusing to shadow existing locals: rax
 example [layout : Layout] (rax : UInt64) (s : MachineData) :
     straightlineStep (layout kprologueTestProgram) (s, layout.start) (fun _ => True) := by
   kprologue kprologueTestProgram with s
+
+-- The `kstep n` step budget errors on shortfall. Two instructions plus the
+-- end of the listing consume three `Directives.interp` unfolds, so a budget
+-- of five leaves two.
+private def budgetTestProgram : Program :=
+  [.instr (.regular .W64 .W64 (.nop 1)), .instr (.regular .W64 .W64 (.nop 1))]
+
+/--
+error: kstep could not step through the remaining 2 steps
+-/
+#guard_msgs (error, drop all) in
+example [layout : Layout] (s : MachineData) :
+    straightlineStep (layout budgetTestProgram) (s, layout.start) (fun _ => True) := by
+  kprologue budgetTestProgram with s
+  sym =>
+  kstep 5

--- a/Kraken/X64/TacticsTests.lean
+++ b/Kraken/X64/TacticsTests.lean
@@ -38,3 +38,16 @@ example [layout : Layout] (s : MachineData) :
   kprologue budgetTestProgram with s
   sym =>
   kstep 5
+
+-- The stepping gate only normalizes the canonical monad instance. A goal
+-- mentioning a different `Bind Effects` instance is left alone, so its
+-- meaning survives `kstep` and the definitional closing step below.
+private def customBind : Bind Effects := ⟨fun _ _ => .unimplemented "custom"⟩
+
+example : ¬ Effects.All (fun _ : Nat => True)
+    (@Bind.bind Effects customBind _ _ (.done 0) (fun n => .done n)) := by
+  sym =>
+  kstep
+  tactic =>
+  intro h
+  exact h


### PR DESCRIPTION
Long PR description incoming, but I felt being quite explicit was warranted given the size of this PR.

In #137, the suggested next step was to resolve #140 and use it to prove p3 from the examples with `kstep`. This does both, by changing the interpreters rather than relating the two CPS views after the fact: `Operation.interp` now produces `Effects (MachineData × Ctrl)`, `Directives.interp` folds a listing into `Effects (MachineData × BlockExit)`, and `Effects` is a lawful monad. `step` and `straightline` are continuation shells over that core, so `step1`, `straightlineStep`, `kprologue`, `eval`, and the runners keep their shapes, and every example statement and proof replays unchanged on both ISAs, except p3 (below).

With the exit as data, appending directives is an equation (`Directives.interp_append`) rather than the implication #140 got stuck on: its `hjmp` obligation asked a jump exit and an end-of-list exit to coincide, which fails whenever there's still work after the jump target. `straightline_eq_step` and the `Eventually`-level transfer from #104 follow. They carry a fetch-coherence side condition, and it's a substantive one since `Layout.size` permits aliasing (the bit #155 quarantines with `SaneP3Layout`); `Executable.Resolves` abstracts this and reduces to a finite check per program.

p3 is now proven. The old statement was false (its binder shadowed the initial state) and had been sorried since #18, so I adopted the corrected statement from @aferr's #155 and proved it with `kstep` and his address lemmas. Either landing order with #155 works.

The tactic layer is the same #144/#150 machinery but now it can walk binds: `kstep` proofs look exactly like they did before, the step budget gets its first regression test, and there's a new `kcut` that runs a bounded prefix and leaves a resume goal of the same shape.

Some evidence this is meaning-preserving: the old and new runners are bit-identical on all 34 x64 and 63 AArch64 test programs, every commit builds on its own, the new theorems use only the standard axioms, and elaboration times are roughly flat (the shared x64 examples pick up about 10%). One caveat: `step` fetches by the size table, which differs from address-equality fetch only on layouts whose sizes wrap mod 2^64. The AArch64 conversion mirrors x64 case by case; the spots that deserve SDM eyes are LDP/LDPSW load order, STP's pre-store reads, and BLR's target-before-X30 write.

Left for later: the dynamic-stack sorry (a curated ksimp set should get it), a general `Resolves` witness from a total-size bound, and deduplicating `Effects` across the ISAs. This code was written mostly by a variety of AI assistants, while I steered the design and reviewed everything in detail (as opposed to #137, where I was a bit over my skis). The final copy was finished with Claude Fable 5 after many iterations with GPT 5.6 Sol and Claude Fable 5.

Happy to make this smaller or do it more incrementally if desired, but I figured this was a good place to cut it and get feedback where it gives you an idea of how this impacts the design as a whole.