### PR TITLE
Refactor semantics to use BitVec instead of unbounded integers

### DIFF
--- a/Kraken/AArch64/Examples/Examples.lean
+++ b/Kraken/AArch64/Examples/Examples.lean
@@ -120,11 +120,11 @@ theorem move_2_regs_to_heap_correct [layout : Layout] (s₀ : MachineData)
 
   have h_bs1 : v1.toBytes.length = 8 := UInt64.toBytes_length v1
   have h_bs2 : v2.toBytes.length = 8 := UInt64.toBytes_length v2
-  have h_mem1 := Mem.storeInt_sep X2.toBitVec 8 v1.toBytes (Eq (v2.At (X2.toBitVec + 8#64)) ⋆ R) mem ⟨by ecancel, h_bs1⟩ X0.toBitVec.toInt
-  have h_mem1' : (Eq (v2.At (X2.toBitVec + 8#64)) ⋆ (Eq ((Int.toBytes 8 X0.toBitVec.toInt).At X2) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem1
-  have h_mem2 := Mem.storeInt_sep (X2.toBitVec + 8#64) 8 v2.toBytes _ _ ⟨h_mem1', h_bs2⟩ X1.toBitVec.toInt
-  have h_mem2' : (Eq ((Int.toBytes 8 X0.toBitVec.toInt).At X2) ⋆ (Eq ((Int.toBytes 8 X1.toBitVec.toInt).At (X2.toBitVec + 8#64)) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem2
-  have h_mem2'' : (Eq ((Int.toBytes 8 X1.toBitVec.toInt).At (X2.toBitVec + 8#64)) ⋆ (Eq ((Int.toBytes 8 X0.toBitVec.toInt).At X2.toBitVec) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem2'
+  have h_mem1 := Mem.storeBV_sep X2.toBitVec 8 v1.toBytes (Eq (v2.At (X2.toBitVec + 8#64)) ⋆ R) mem ⟨by ecancel, h_bs1⟩ X0.toBitVec
+  have h_mem1' : (Eq (v2.At (X2.toBitVec + 8#64)) ⋆ (Eq ((BitVec.toBytes 8 X0.toBitVec).At X2) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem1
+  have h_mem2 := Mem.storeBV_sep (X2.toBitVec + 8#64) 8 v2.toBytes _ _ ⟨h_mem1', h_bs2⟩ X1.toBitVec
+  have h_mem2' : (Eq ((BitVec.toBytes 8 X0.toBitVec).At X2) ⋆ (Eq ((BitVec.toBytes 8 X1.toBitVec).At (X2.toBitVec + 8#64)) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem2
+  have h_mem2'' : (Eq ((BitVec.toBytes 8 X1.toBitVec).At (X2.toBitVec + 8#64)) ⋆ (Eq ((BitVec.toBytes 8 X0.toBitVec).At X2.toBitVec) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem2'
   simp at h_mem
   sym =>
   kstep
@@ -142,7 +142,7 @@ theorem move_2_regs_to_heap_correct [layout : Layout] (s₀ : MachineData)
   kstep
   tactic =>
   apply Eventually.done
-  rw [BitVec.ofInt_ofBytes_toBytes 64 8 rfl, BitVec.ofInt_ofBytes_toBytes 64 8 rfl]
+  rw [BitVec.ofBytes_toBytes 64 8 rfl, BitVec.ofBytes_toBytes 64 8 rfl]
   exact ⟨rfl, rfl, rfl⟩
 
 -- Example 6: Memory access with shifted register offset [x1, x2, lsl #3]
@@ -155,7 +155,7 @@ def reg_offset_example : Program := parseAArch64("
 
 theorem reg_offset_example_correct [layout : Layout] (s₀ : MachineData)
     (v : UInt64) (R : DataMem → Prop)
-    (h_mem : s₀.dmem =⋆ Eq (v.At (s₀.regs.X1.toBitVec + BitVec.ofInt 64 (s₀.regs.X2.toBitVec.toNat <<< 3))) ⋆ R) :
+    (h_mem : s₀.dmem =⋆ Eq (v.At (s₀.regs.X1.toBitVec + s₀.regs.X2.toBitVec <<< 3)) ⋆ R) :
     Eventually (straightlineStep (layout reg_offset_example))
       (fun s' => s'.1.regs.X3 = 42)
       (s₀, layout.start) := by
@@ -163,7 +163,7 @@ theorem reg_offset_example_correct [layout : Layout] (s₀ : MachineData)
   kprologue reg_offset_example with s₀
   have h_bs : v.toBytes.length = 8 := UInt64.toBytes_length v
   simp at h_mem
-  have h_mem' := Mem.storeInt_sep (X1.toBitVec + BitVec.ofInt 64 (X2.toBitVec.toNat <<< 3)) 8 v.toBytes R mem ⟨h_mem, h_bs⟩ 42
+  have h_mem' := Mem.storeBV_sep (X1.toBitVec + X2.toBitVec <<< 3) 8 v.toBytes R mem ⟨h_mem, h_bs⟩ 42#64
   sym =>
   kstep
   case h_mem => tactic => simp; exact h_mem

--- a/Kraken/AArch64/Parser.lean
+++ b/Kraken/AArch64/Parser.lean
@@ -409,11 +409,11 @@ Validate an optional shift amount for register operands:
 - Must be in `[0, 31]` for 32-bit instructions (`.W32`).
 - Must be in `[0, 63]` for 64-bit instructions (`.W64`).
 -/
-def checkShiftAmount (w : RegWidth) (amt : Int64) : Except String Unit :=
+def checkShiftAmount (w : RegWidth) (amt : Int64) : Except String Nat :=
   let maxAmt := w.bits - 1
   if amt.toInt < 0 || amt.toInt > maxAmt then
     .error s!"shift amount {amt.toInt} out of range [0, {maxAmt}] for {w.bits}-bit instruction"
-  else .ok ()
+  else .ok amt.toInt.toNat
 
 /--
 Validate a signed immediate byte offset for load/store pair instructions (`LDP`/`STP`):
@@ -616,11 +616,11 @@ def checkCcmpImmediate (imm : Nat) : Except String Unit :=
     .error s!"ccmp/ccmn immediate {imm} out of range [0, 31]"
   else .ok ()
 
-/-- Validate NZCV condition flags immediate operand (`[0, 15]`). -/
-def checkNzcvFlags (nzcv : Nat) : Except String Unit :=
+/-- Validate the NZCV condition flags immediate operand (`[0, 15]`) and return it as a 4-bit flags field. -/
+def checkNzcvFlags (nzcv : Nat) : Except String (BitVec 4) :=
   if nzcv > 15 then
     .error s!"nzcv immediate {nzcv} out of range [0, 15]"
-  else .ok ()
+  else .ok (BitVec.ofNat 4 nzcv)
 
 /-- Validate a 12-bit unsigned arithmetic immediate (for ADD/SUB immediate operands). -/
 def checkArithmeticImmediate (imm : Int64) : Except String Unit :=
@@ -951,8 +951,8 @@ def parseShiftRegExpr (w : RegWidth) (allowRor : Bool := false) : Parser (ShiftR
       | _ => fail s!"unknown shift type: {shiftName}"
     skipHWs
     let amt ← parseInt64
-    liftExcept (checkShiftAmount w amt)
-    pure { reg := reg, amount := amt, shift := shiftType }
+    let amount ← liftExcept (checkShiftAmount w amt)
+    pure { reg := reg, amount := amount, shift := shiftType }
   else
     pure { reg := reg, amount := 0, shift := ShiftType.LSL }
 
@@ -1846,8 +1846,8 @@ or immediate second operand.
 - Validates that `#imm` is in range `[0, 31]` and `#nzcv` flags immediate is in range `[0, 15]`.
 -/
 def parseCondCompare
-    (mkReg : {w : RegWidth} → RegOrZr w → RegOrZr w → Nat → CondCode → Operation w)
-    (mkImm : {w : RegWidth} → RegOrZr w → Nat → Nat → CondCode → Operation w) : Parser Instr := do
+    (mkReg : {w : RegWidth} → RegOrZr w → RegOrZr w → BitVec 4 → CondCode → Operation w)
+    (mkImm : {w : RegWidth} → RegOrZr w → Nat → BitVec 4 → CondCode → Operation w) : Parser Instr := do
   let src1W ← parseRegOrZrW
   let w := src1W.w
   parseComma
@@ -1856,16 +1856,16 @@ def parseCondCompare
     let imm ← parseImmNat
     liftExcept (checkCcmpImmediate imm)
     parseComma
-    let nzcv ← parseImmNat
-    liftExcept (checkNzcvFlags nzcv)
+    let nzcvNat ← parseImmNat
+    let nzcv ← liftExcept (checkNzcvFlags nzcvNat)
     parseComma
     let cond ← parseCondArg
     pure ⟨w, mkImm src1W.reg imm nzcv cond⟩
   else
     let src2 ← parseRegOrZr w
     parseComma
-    let nzcv ← parseImmNat
-    liftExcept (checkNzcvFlags nzcv)
+    let nzcvNat ← parseImmNat
+    let nzcv ← liftExcept (checkNzcvFlags nzcvNat)
     parseComma
     let cond ← parseCondArg
     pure ⟨w, mkReg src1W.reg src2 nzcv cond⟩

--- a/Kraken/AArch64/Parser.lean
+++ b/Kraken/AArch64/Parser.lean
@@ -121,6 +121,17 @@ def parseImmNat : Parser Nat := do
     fail s!"expected non-negative immediate, got {i}"
   pure i.toNat
 
+/--
+Parse an unsigned immediate integer value fitting into a bitvector of width `w`.
+- Fails if the parsed integer is negative or exceeds `2^w - 1`.
+-/
+def parseBitVec (w : Nat) : Parser (BitVec w) := do
+  let n ← parseImmNat
+  let maxVal := 2^w - 1
+  if n > maxVal then
+    fail s!"immediate {n} out of range [0, {maxVal}]"
+  pure (BitVec.ofNat w n)
+
 /-- Parse a raw label name as a string identifier. -/
 def parseLabelRaw : Parser Label := parseName
 
@@ -409,11 +420,11 @@ Validate an optional shift amount for register operands:
 - Must be in `[0, 31]` for 32-bit instructions (`.W32`).
 - Must be in `[0, 63]` for 64-bit instructions (`.W64`).
 -/
-def checkShiftAmount (w : RegWidth) (amt : Int64) : Except String Nat :=
+def checkShiftAmount (w : RegWidth) (amt : Nat) : Except String Unit :=
   let maxAmt := w.bits - 1
-  if amt.toInt < 0 || amt.toInt > maxAmt then
-    .error s!"shift amount {amt.toInt} out of range [0, {maxAmt}] for {w.bits}-bit instruction"
-  else .ok amt.toInt.toNat
+  if amt > maxAmt then
+    .error s!"shift amount {amt} out of range [0, {maxAmt}] for {w.bits}-bit instruction"
+  else .ok ()
 
 /--
 Validate a signed immediate byte offset for load/store pair instructions (`LDP`/`STP`):
@@ -615,12 +626,6 @@ def checkCcmpImmediate (imm : Nat) : Except String Unit :=
   if imm > 31 then
     .error s!"ccmp/ccmn immediate {imm} out of range [0, 31]"
   else .ok ()
-
-/-- Validate the NZCV condition flags immediate operand (`[0, 15]`) and return it as a 4-bit flags field. -/
-def checkNzcvFlags (nzcv : Nat) : Except String (BitVec 4) :=
-  if nzcv > 15 then
-    .error s!"nzcv immediate {nzcv} out of range [0, 15]"
-  else .ok (BitVec.ofNat 4 nzcv)
 
 /-- Validate a 12-bit unsigned arithmetic immediate (for ADD/SUB immediate operands). -/
 def checkArithmeticImmediate (imm : Int64) : Except String Unit :=
@@ -950,9 +955,9 @@ def parseShiftRegExpr (w : RegWidth) (allowRor : Bool := false) : Parser (ShiftR
         else fail "arithmetic instructions do not support ROR shift"
       | _ => fail s!"unknown shift type: {shiftName}"
     skipHWs
-    let amt ← parseInt64
-    let amount ← liftExcept (checkShiftAmount w amt)
-    pure { reg := reg, amount := amount, shift := shiftType }
+    let amt ← parseImmNat
+    liftExcept (checkShiftAmount w amt)
+    pure { reg := reg, amount := amt, shift := shiftType }
   else
     pure { reg := reg, amount := 0, shift := ShiftType.LSL }
 
@@ -1856,16 +1861,14 @@ def parseCondCompare
     let imm ← parseImmNat
     liftExcept (checkCcmpImmediate imm)
     parseComma
-    let nzcvNat ← parseImmNat
-    let nzcv ← liftExcept (checkNzcvFlags nzcvNat)
+    let nzcv ← parseBitVec 4
     parseComma
     let cond ← parseCondArg
     pure ⟨w, mkImm src1W.reg imm nzcv cond⟩
   else
     let src2 ← parseRegOrZr w
     parseComma
-    let nzcvNat ← parseImmNat
-    let nzcv ← liftExcept (checkNzcvFlags nzcvNat)
+    let nzcv ← parseBitVec 4
     parseComma
     let cond ← parseCondArg
     pure ⟨w, mkReg src1W.reg src2 nzcv cond⟩

--- a/Kraken/AArch64/ParserTests.lean
+++ b/Kraken/AArch64/ParserTests.lean
@@ -1424,7 +1424,7 @@ info: [Directive.instr
 info: [Directive.instr
     { operation_size := RegWidth.W64,
       operation :=
-        Operation.CCMP_reg (↑↑XReg.X0 RegWidth.W64) (↑↑XReg.X1 RegWidth.W64) 4 CondCode.EQ }] : List Directive
+        Operation.CCMP_reg (↑↑XReg.X0 RegWidth.W64) (↑↑XReg.X1 RegWidth.W64) (4#4) CondCode.EQ }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("ccmp x0, x1, #4, eq")
@@ -1433,7 +1433,7 @@ info: [Directive.instr
 /--
 info: [Directive.instr
     { operation_size := RegWidth.W64,
-      operation := Operation.CCMP_imm (↑↑XReg.X0 RegWidth.W64) 10 2 CondCode.NE }] : List Directive
+      operation := Operation.CCMP_imm (↑↑XReg.X0 RegWidth.W64) 10 (2#4) CondCode.NE }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("ccmp x0, #10, #2, ne")
@@ -1443,7 +1443,7 @@ info: [Directive.instr
 info: [Directive.instr
     { operation_size := RegWidth.W32,
       operation :=
-        Operation.CCMN_reg (↑↑XReg.X0 RegWidth.W32) (↑↑XReg.X1 RegWidth.W32) 0 CondCode.EQ }] : List Directive
+        Operation.CCMN_reg (↑↑XReg.X0 RegWidth.W32) (↑↑XReg.X1 RegWidth.W32) (0#4) CondCode.EQ }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("ccmn w0, w1, #0, eq")
@@ -1452,7 +1452,7 @@ info: [Directive.instr
 /--
 info: [Directive.instr
     { operation_size := RegWidth.W32,
-      operation := Operation.CCMN_imm (↑↑XReg.X0 RegWidth.W32) 1 0 CondCode.NE }] : List Directive
+      operation := Operation.CCMN_imm (↑↑XReg.X0 RegWidth.W32) 1 (0#4) CondCode.NE }] : List Directive
 -/
 #guard_msgs in
 #check parseAArch64("ccmn w0, #1, #0, ne")
@@ -1822,6 +1822,10 @@ section error_reporting
 #guard_msgs in
 #check parseAArch64("ccmp x0, x1, #16, eq")
 
+/-- error: line 1: nzcv immediate 31 out of range [0, 15] -/
+#guard_msgs in
+#check parseAArch64("ccmn x0, x1, #31, ne")
+
 /-- error: line 1: immediate 18446744073709551616 out of 64-bit range -/
 #guard_msgs in
 #check parseAArch64("mov x0, #0x10000000000000000")
@@ -1853,6 +1857,18 @@ section error_reporting
 /-- error: line 1: shift immediate 32 out of range [0, 31] -/
 #guard_msgs in
 #check parseAArch64("lsl w0, w1, #32")
+
+/-- error: line 1: shift amount 64 out of range [0, 63] for 64-bit instruction -/
+#guard_msgs in
+#check parseAArch64("orr x0, x1, x2, lsl #64")
+
+/-- error: line 1: shift amount 32 out of range [0, 31] for 32-bit instruction -/
+#guard_msgs in
+#check parseAArch64("orr w0, w1, w2, lsl #32")
+
+/-- error: line 1: shift amount -1 out of range [0, 63] for 64-bit instruction -/
+#guard_msgs in
+#check parseAArch64("orr x0, x1, x2, lsl #-1")
 
 --
 -- Memory Addressing, Offset Bounds & Alignment Errors

--- a/Kraken/AArch64/ParserTests.lean
+++ b/Kraken/AArch64/ParserTests.lean
@@ -1457,6 +1457,25 @@ info: [Directive.instr
 #guard_msgs in
 #check parseAArch64("ccmn w0, #1, #0, ne")
 
+-- Test: CCMP with hex and binary nzcv flags
+/--
+info: [Directive.instr
+    { operation_size := RegWidth.W64,
+      operation :=
+        Operation.CCMP_reg (↑↑XReg.X0 RegWidth.W64) (↑↑XReg.X1 RegWidth.W64) (15#4) CondCode.EQ }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("ccmp x0, x1, #0xf, eq")
+
+/--
+info: [Directive.instr
+    { operation_size := RegWidth.W64,
+      operation :=
+        Operation.CCMP_reg (↑↑XReg.X0 RegWidth.W64) (↑↑XReg.X1 RegWidth.W64) (10#4) CondCode.EQ }] : List Directive
+-/
+#guard_msgs in
+#check parseAArch64("ccmp x0, x1, #0b1010, eq")
+
 -- ============================================================================
 -- 9. PC-Relative Addressing & Relocation Modifiers (ADR, ADRP, :lo12:, :pg_hi21:)
 -- ============================================================================
@@ -1818,13 +1837,17 @@ section error_reporting
 #guard_msgs in
 #check parseAArch64("ccmp x0, #32, #0, eq")
 
-/-- error: line 1: nzcv immediate 16 out of range [0, 15] -/
+/-- error: line 1: immediate 16 out of range [0, 15] -/
 #guard_msgs in
 #check parseAArch64("ccmp x0, x1, #16, eq")
 
-/-- error: line 1: nzcv immediate 31 out of range [0, 15] -/
+/-- error: line 1: immediate 31 out of range [0, 15] -/
 #guard_msgs in
 #check parseAArch64("ccmn x0, x1, #31, ne")
+
+/-- error: line 1: expected non-negative immediate, got -1 -/
+#guard_msgs in
+#check parseAArch64("ccmp x0, x1, #-1, eq")
 
 /-- error: line 1: immediate 18446744073709551616 out of 64-bit range -/
 #guard_msgs in
@@ -1866,7 +1889,7 @@ section error_reporting
 #guard_msgs in
 #check parseAArch64("orr w0, w1, w2, lsl #32")
 
-/-- error: line 1: shift amount -1 out of range [0, 63] for 64-bit instruction -/
+/-- error: line 1: expected non-negative immediate, got -1 -/
 #guard_msgs in
 #check parseAArch64("orr x0, x1, x2, lsl #-1")
 

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -215,7 +215,8 @@ export Labels (label)
     let lo := val &&& 0xFFF#64
     Int64.ofBitVec lo
 
-def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64) : Int64 :=
+-- Evaluate a PC-relative target expression (used by branches, `ADR`/`ADRP`).
+@[kstep, simp] def ConstExpr.evalTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64) : Int64 :=
   match target with
   | .int64 imm => p.lower + imm
   | _ => target.interp p
@@ -413,14 +414,9 @@ structure StatusFlags.from_result.Remaining where
   val &&& BitVec.ofNat w.bits (w.bits - 1)
 
 @[kstep, simp] def maskOfLen {w : RegWidth} (len : Nat) : w.type :=
-  if len >= w.bits then
-    ~~~(0 : w.type)
-  else
-    ((1 : w.type) <<< len) - 1
+  ((1 : w.type) <<< len) - 1
 
 @[kstep, simp] def evalUBFM {w : RegWidth} (src : w.type) (immr imms : Nat) : w.type :=
-  let immr := immr % w.bits
-  let imms := imms % w.bits
   if imms >= immr then
     let len := imms - immr + 1
     let field := (src >>> immr).take len
@@ -432,8 +428,6 @@ structure StatusFlags.from_result.Remaining where
     (field.zeroExtend w.bits) <<< pos
 
 @[kstep, simp] def evalSBFM {w : RegWidth} (src : w.type) (immr imms : Nat) : w.type :=
-  let immr := immr % w.bits
-  let imms := imms % w.bits
   if imms >= immr then
     let len := imms - immr + 1
     let field := (src >>> immr).take len
@@ -445,8 +439,6 @@ structure StatusFlags.from_result.Remaining where
     (field.signExtend (w.bits - pos)).zeroExtend w.bits <<< pos
 
 @[kstep, simp] def evalBFM {w : RegWidth} (dst src : w.type) (immr imms : Nat) : w.type :=
-  let immr := immr % w.bits
-  let imms := imms % w.bits
   if imms >= immr then
     let len := imms - immr + 1
     let mask : w.type := maskOfLen (w := w) len
@@ -630,12 +622,12 @@ set_option maxHeartbeats 1000000
   | .SDIV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
-    let res := if val2 == 0 then (0 : w.type) else val1.sdiv val2
+    let res := val1.sdiv val2
     s.setRegOrZr dst res next
   | .UDIV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
-    let res := if val2 == 0 then (0 : w.type) else val1 / val2
+    let res := val1 / val2
     s.setRegOrZr dst res next
   | .SMADDL dst src1 src2 src3 =>
     let val1 := s.regs.getRegOrZr src1
@@ -770,7 +762,6 @@ set_option maxHeartbeats 1000000
   | .EXTR dst src1 src2 lsb =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
-    let lsb := lsb % w.bits
     let res := (val1 <<< (w.bits - lsb)) ||| (val2 >>> lsb)
     s.setRegOrZr dst res next
   | .MOVZ dst imm shift =>
@@ -856,25 +847,21 @@ set_option maxHeartbeats 1000000
         StatusFlags.ofBitVec nzcv
     next { s with status := status' }
   | .ADR dst target =>
-    let val := match target with
-      | .int64 imm => (p.lower + imm).toBitVec
-      | _ => (target.interp p).toBitVec
+    let val := (target.evalTarget p).toBitVec
     s.setRegOrZr dst val next
   | .ADRP dst target =>
-    let val := match target with
-      | .int64 imm => (p.lower + imm).toBitVec
-      | _ => (target.interp p).toBitVec
+    let val := (target.evalTarget p).toBitVec
     s.setRegOrZr dst (val &&& ~~~0xFFF#64) next
   | .B target =>
-    jmp (target.evalBranchTarget p) s
+    jmp (target.evalTarget p) s
   | .B_cond cond target =>
     if cond.interp s.status then
-      jmp (target.evalBranchTarget p) s
+      jmp (target.evalTarget p) s
     else
       next s
   | .BL target =>
     let lr_val := p.upper.toBitVec
-    s.setRegOrZr RegOrZr.X30 lr_val (fun s' => jmp (target.evalBranchTarget p) s')
+    s.setRegOrZr RegOrZr.X30 lr_val (fun s' => jmp (target.evalTarget p) s')
   | .BLR target =>
     let lr_val := p.upper.toBitVec
     let target_val := Int64.ofBitVec (s.regs.getRegOrZr target)
@@ -887,26 +874,26 @@ set_option maxHeartbeats 1000000
     jmp target_val s
   | .CBZ reg target =>
     let val := s.regs.getRegOrZr reg
-    if val == 0 then
-      jmp (target.evalBranchTarget p) s
+    if val == 0#w.bits then
+      jmp (target.evalTarget p) s
     else
       next s
   | .CBNZ reg target =>
     let val := s.regs.getRegOrZr reg
-    if val != 0 then
-      jmp (target.evalBranchTarget p) s
+    if val != 0#w.bits then
+      jmp (target.evalTarget p) s
     else
       next s
   | .TBZ reg bit target =>
     let val := s.regs.getRegOrZr reg
-    if val.getLsbD bit == false then
-      jmp (target.evalBranchTarget p) s
+    if !val.getLsbD bit then
+      jmp (target.evalTarget p) s
     else
       next s
   | .TBNZ reg bit target =>
     let val := s.regs.getRegOrZr reg
-    if val.getLsbD bit == true then
-      jmp (target.evalBranchTarget p) s
+    if val.getLsbD bit then
+      jmp (target.evalTarget p) s
     else
       next s
   | .NOP => next s

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -1,24 +1,10 @@
 import Kraken.AArch64.Syntax
 import Kraken.Attribute
+import Kraken.BitVec
+import Kraken.Flags
 import Kraken.Mem
 import Lean
 import Std
-
--- injective coercions only
-attribute [-instance] BitVec.instNatCast
-attribute [-instance] BitVec.instIntCast
-instance : Coe Bool Nat where coe := Bool.toNat
-
-@[kstep] def BitVec.unsigned {w} (x : BitVec w) : Int := x.toNat
-@[kstep] def BitVec.signed {w} (x : BitVec w) : Int := x.toInt
-@[kstep] def BitVec.take {w} (x : BitVec w) (n : Nat) : BitVec n := x.extractLsb' 0 n
-@[kstep] def BitVec.drop {w} (x : BitVec w) (n : Nat) : BitVec (w - n) := x.extractLsb' n (w-n)
-
-attribute [kstep]
-  BitVec.ofInt_add
-  BitVec.ofInt_toInt
-  BitVec.signed
-  BitVec.truncate
 
 namespace RegOrSp
 @[kstep] def base {w} (r : RegOrSp w) : XRegOrSp := match r with
@@ -199,15 +185,15 @@ def MachineData.load
   (s : MachineData) (addr : BitVec 64) (w : MemWidth)
   (ret : w.type → MachineData → Effects): Effects :=
   require_read_access addr w (fun _unit =>
-    match Mem.loadInt s.dmem addr w.bytes with
-    | .some i => ret (.ofInt _ i) s
+    match Mem.loadBV s.dmem addr w.bits w.bytes with
+    | .some v => ret v s
     | .none => nonmem_load s.dmem addr w (fun v dmem => ret v { s with dmem }))
 
 def MachineData.store (s : MachineData) (addr : BitVec 64) {w : MemWidth} (v : w.type) (ret: MachineData → Effects) : Effects :=
   require_write_access addr w (fun _unit =>
-    match Mem.loadInt s.dmem addr w.bytes with
+    match Mem.loadBytes s.dmem addr w.bytes with
     | .some _ =>
-        ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
+        ret { s with dmem := Mem.storeBV s.dmem addr w.bytes v }
     | .none => nonmem_store s.dmem addr v (fun dmem' => ret { s with dmem := dmem' }))
 
 class Labels where label : Label → Int64
@@ -221,29 +207,29 @@ export Labels (label)
   | .add e1 e2, p => e1.interp p + e2.interp p
   | .sub e1 e2, p => e1.interp p - e2.interp p
   | .pg_hi21 e, p =>
-    let val := BitVec.ofInt 64 (Int64.toInt (e.interp p))
+    let val := (e.interp p).toBitVec
     let page := val &&& ~~~0xFFF#64
-    Int64.ofNat page.toNat
+    Int64.ofBitVec page
   | .lo12 e, p =>
-    let val := BitVec.ofInt 64 (Int64.toInt (e.interp p))
+    let val := (e.interp p).toBitVec
     let lo := val &&& 0xFFF#64
-    Int64.ofNat lo.toNat
+    Int64.ofBitVec lo
 
 def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64) : Int64 :=
   match target with
   | .int64 imm => p.lower + imm
   | _ => target.interp p
 
-@[kstep] def BitVec.apply_extend (v : BitVec 64) (ext : Extend) :=
+@[kstep] def BitVec.apply_extend (v : BitVec 64) (ext : Extend) : BitVec 64 :=
   let extended := match ext.type with
-               | .UXTB => (v.take MemWidth.W8.bits).unsigned
-               | .SXTB => (v.take MemWidth.W8.bits).signed
-               | .UXTH => (v.take MemWidth.W16.bits).unsigned
-               | .SXTH => (v.take MemWidth.W16.bits).signed
-               | .UXTW => (v.take MemWidth.W32.bits).unsigned
-               | .SXTW => (v.take MemWidth.W32.bits).signed
-               | .UXTX => v.unsigned
-               | .SXTX => v.signed
+               | .UXTB => (v.take MemWidth.W8.bits).setWidth 64
+               | .SXTB => (v.take MemWidth.W8.bits).signExtend 64
+               | .UXTH => (v.take MemWidth.W16.bits).setWidth 64
+               | .SXTH => (v.take MemWidth.W16.bits).signExtend 64
+               | .UXTW => (v.take MemWidth.W32.bits).setWidth 64
+               | .SXTW => (v.take MemWidth.W32.bits).signExtend 64
+               | .UXTX => v
+               | .SXTX => v
   let shifted := match ext.amount with
                  | .E0 => extended
                  | .E1 => extended <<< 1
@@ -252,12 +238,12 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
                  | .E4 => extended <<< 4
   shifted
 
-@[kstep] def BitVec.apply_mem_extend (v : BitVec 64) (ext : MemExtend) :=
+@[kstep] def BitVec.apply_mem_extend (v : BitVec 64) (ext : MemExtend) : BitVec 64 :=
   let extended := match ext.type with
-               | .UXTW => (v.take MemWidth.W32.bits).unsigned
-               | .SXTW => (v.take MemWidth.W32.bits).signed
-               | .UXTX => v.unsigned
-               | .SXTX => v.signed
+               | .UXTW => (v.take MemWidth.W32.bits).setWidth 64
+               | .SXTW => (v.take MemWidth.W32.bits).signExtend 64
+               | .UXTX => v
+               | .SXTX => v
   let shifted := match ext.amount with
                  | .E0 => extended
                  | .E1 => extended <<< 1
@@ -276,16 +262,16 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
 @[kstep] def ExtOrImmReg.interp [Labels] {w : RegWidth} (expr : ExtOrImmReg) (s : Reg64s) (p : Std.Rco Int64) : w.type :=
   match expr with
   | .ext e =>
-    BitVec.ofInt w.bits (e.interp s p)
+    (e.interp s p).setWidth w.bits
   | .imm i =>
-    let imm := Int64.toInt (i.imm.interp p)
+    let imm := (i.imm.interp p).toBitVec
     match i.shift with
-    | .S0 => BitVec.ofInt w.bits (imm)
-    | .S12 => BitVec.ofInt w.bits (imm <<< 12)
+    | .S0 => imm.setWidth w.bits
+    | .S12 => (imm <<< 12).setWidth w.bits
 
 @[kstep] def ShiftRegExpr.interp {w} (expr : ShiftRegExpr w) (s : Reg64s) (_ : Std.Rco Int64) : w.type :=
   let base := s.getRegOrZr expr.reg
-  let amount := (Int64.toInt expr.amount).toNat
+  let amount := expr.amount
   match expr.shift with
   | .LSL => base <<< amount
   | .LSR => base.ushiftRight amount
@@ -293,18 +279,18 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
   | .ROR => base.rotateRight amount
 
 @[kstep] def AddrExpr.eval [Labels] (mem : AddrExpr) (s : MachineData) (p : Std.Rco Int64) : BitVec 64 × MachineData :=
-  let base := (s.regs.getRegOrSp mem.base).signed
+  let base := s.regs.getRegOrSp mem.base
   match mem.off with
   | .reg r =>
     let off := r.interp s.regs p
-    (BitVec.ofInt 64 (base + off), s)
+    (base + off, s)
   | .imm i =>
-    let off := Int64.toInt (i.imm.interp p)
+    let off := (i.imm.interp p).toBitVec
     let addr := match i.index with
-      | some .Post => BitVec.ofInt 64 base
-      | _ => BitVec.ofInt 64 (base + off)
+      | some .Post => base
+      | _ => base + off
     let s' := match i.index with
-      | some _ => { s with regs := s.regs.setRegOrSp mem.base (BitVec.ofInt 64 (base + off)) }
+      | some _ => { s with regs := s.regs.setRegOrSp mem.base (base + off) }
       | none => s
     (addr, s')
 
@@ -330,9 +316,9 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
     s'.store addr (w := w) val next)
 
 @[kstep] def UnscaledAddrExpr.eval [Labels] (mem : UnscaledAddrExpr) (s : MachineData) (p : Std.Rco Int64) : BitVec 64 :=
-  let base := (s.regs.getRegOrSp mem.base).signed
-  let off := Int64.toInt (mem.imm.interp p)
-  BitVec.ofInt 64 (base + off)
+  let base := s.regs.getRegOrSp mem.base
+  let off := (mem.imm.interp p).toBitVec
+  base + off
 
 -- AArch64 mandates 16-byte alignment when accessing memory through SP.
 @[kstep] def UnscaledAddrExpr.checkSPAlignment (mem : UnscaledAddrExpr) (s : MachineData) (ok : Unit → Effects) : Effects :=
@@ -359,11 +345,11 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
   match expr with
   | .addr addr_expr => -- Load from address.
     let addr_val := Labels.label addr_expr.label
-    let addr := BitVec.ofInt 64 (Int64.toInt addr_val)
+    let addr := addr_val.toBitVec
     s.load addr w ret
   | .pool litpool_expr => -- Bypass loading and return value directly.
     let val := litpool_expr.expr.interp p
-    let val_bv : w.type := BitVec.ofInt w.bits (Int64.toInt val)
+    let val_bv : w.type := val.toBitVec.setWidth w.bits
     ret val_bv s
 
 @[kstep] def AddrOrLit.interpLoad [Labels] {w : MemWidth} (expr : AddrOrLit) (s : MachineData) (p : Std.Rco Int64) (ret : w.type → MachineData → Effects) :=
@@ -402,25 +388,29 @@ structure StatusFlags.from_result.Remaining where
 
 @[kstep, simp] def StatusFlags.from_result {w} (result : BitVec w) (f : from_result.Remaining) : StatusFlags :=
   { n := result.msb
-    z := result == BitVec.zero _
+    z := result == 0#w -- bv_decide abstracts `BitVec.zero w` as an opaque variable
     c := f.c
     v := f.v }
 
 @[kstep, simp] def StatusFlags.adds {w} (res val1 val2 : BitVec w) : StatusFlags :=
   StatusFlags.from_result res {
-    c := res.unsigned != val1.unsigned + val2.unsigned
-    v := res.signed != val1.signed + val2.signed }
+    c := Kraken.Flags.addCarry val1 val2 false
+    v := Kraken.Flags.addOverflow val1 val2 false }
 
+-- For AArch64 the `C` flag of a subtraction is the complement of the borrow.
 @[kstep, simp] def StatusFlags.subs {w} (res val1 val2 : BitVec w) : StatusFlags :=
   StatusFlags.from_result res {
-    c := res.unsigned == val1.unsigned - val2.unsigned
-    v := res.signed != val1.signed - val2.signed }
+    c := !Kraken.Flags.subBorrow val1 val2 false
+    v := Kraken.Flags.subOverflow val1 val2 false }
 
-def StatusFlags.ofNat (nzcv : Nat) : StatusFlags :=
-  { n := (nzcv &&& 8) != 0
-    z := (nzcv &&& 4) != 0
-    c := (nzcv &&& 2) != 0
-    v := (nzcv &&& 1) != 0 }
+def StatusFlags.ofBitVec (nzcv : BitVec 4) : StatusFlags :=
+  { n := nzcv.getLsbD 3
+    z := nzcv.getLsbD 2
+    c := nzcv.getLsbD 1
+    v := nzcv.getLsbD 0 }
+
+def shiftAmount {w : RegWidth} (val : w.type) : w.type :=
+  val &&& BitVec.ofNat w.bits (w.bits - 1)
 
 @[kstep, simp] def maskOfLen {w : RegWidth} (len : Nat) : w.type :=
   if len >= w.bits then
@@ -593,10 +583,9 @@ set_option maxHeartbeats 1000000
     let val2 := s.regs.getRegOrZr src2
     let carry : w.type := s.status.c
     let res := val1 + val2 + carry
-    let carry_int : Int := if s.status.c then 1 else 0
     let status := StatusFlags.from_result res {
-      c := res.unsigned != val1.unsigned + val2.unsigned + carry_int
-      v := res.signed != val1.signed + val2.signed + carry_int }
+      c := Kraken.Flags.addCarry val1 val2 s.status.c
+      v := Kraken.Flags.addOverflow val1 val2 s.status.c }
     { s with status }.setRegOrZr dst res next
   | .SBC dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
@@ -609,10 +598,10 @@ set_option maxHeartbeats 1000000
     let val2 := s.regs.getRegOrZr src2
     let borrow : w.type := !s.status.c
     let res := val1 - val2 - borrow
-    let borrow_int : Int := if s.status.c then 0 else 1
+    -- For AArch64 the `C` flag is the complement of the borrow (see `subs`).
     let status := StatusFlags.from_result res {
-      c := val1.unsigned >= val2.unsigned + borrow_int
-      v := res.signed != val1.signed - val2.signed - borrow_int }
+      c := !Kraken.Flags.subBorrow val1 val2 (!s.status.c)
+      v := Kraken.Flags.subOverflow val1 val2 (!s.status.c) }
     { s with status }.setRegOrZr dst res next
   | .MADD dst src1 src2 src3 =>
     let val1 := s.regs.getRegOrZr src1
@@ -629,14 +618,14 @@ set_option maxHeartbeats 1000000
   | .SMULH dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
-    let prod := val1.signed * val2.signed
-    let res := (BitVec.ofInt (RegWidth.W64.bits + RegWidth.W64.bits) prod).extractLsb' RegWidth.W64.bits RegWidth.W64.bits
+    let prod := val1.signExtend 128 * val2.signExtend 128
+    let res := prod.extractLsb' RegWidth.W64.bits RegWidth.W64.bits
     s.setRegOrZr dst res next
   | .UMULH dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
-    let prod := val1.unsigned * val2.unsigned
-    let res := (BitVec.ofInt (RegWidth.W64.bits + RegWidth.W64.bits) prod).extractLsb' RegWidth.W64.bits RegWidth.W64.bits
+    let prod := val1.setWidth 128 * val2.setWidth 128
+    let res := prod.extractLsb' RegWidth.W64.bits RegWidth.W64.bits
     s.setRegOrZr dst res next
   | .SDIV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
@@ -652,29 +641,29 @@ set_option maxHeartbeats 1000000
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let val3 := s.regs.getRegOrZr src3
-    let res := BitVec.ofInt RegWidth.W64.bits (val1.signed * val2.signed + val3.signed)
+    let res := val1.signExtend RegWidth.W64.bits * val2.signExtend RegWidth.W64.bits + val3
     s.setRegOrZr dst res next
   | .UMADDL dst src1 src2 src3 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let val3 := s.regs.getRegOrZr src3
-    let res := BitVec.ofInt RegWidth.W64.bits (val1.unsigned * val2.unsigned + val3.unsigned)
+    let res := val1.setWidth RegWidth.W64.bits * val2.setWidth RegWidth.W64.bits + val3
     s.setRegOrZr dst res next
   | .SMSUBL dst src1 src2 src3 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let val3 := s.regs.getRegOrZr src3
-    let res := BitVec.ofInt RegWidth.W64.bits (val3.signed - val1.signed * val2.signed)
+    let res := val3 - val1.signExtend RegWidth.W64.bits * val2.signExtend RegWidth.W64.bits
     s.setRegOrZr dst res next
   | .UMSUBL dst src1 src2 src3 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let val3 := s.regs.getRegOrZr src3
-    let res := BitVec.ofInt RegWidth.W64.bits (val3.unsigned - val1.unsigned * val2.unsigned)
+    let res := val3 - val1.setWidth RegWidth.W64.bits * val2.setWidth RegWidth.W64.bits
     s.setRegOrZr dst res next
   | .AND_i dst src1 imm =>
     let val1 := s.regs.getRegOrZr src1
-    let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
+    let val2 := (imm.interp p).toBitVec.setWidth w.bits
     let res := val1 &&& val2
     s.setRegOrSp dst res next
   | .AND_s dst src1 src2 =>
@@ -684,7 +673,7 @@ set_option maxHeartbeats 1000000
     s.setRegOrZr dst res next
   | .ANDS_i dst src1 imm =>
     let val1 := s.regs.getRegOrZr src1
-    let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
+    let val2 := (imm.interp p).toBitVec.setWidth w.bits
     let res := val1 &&& val2
     let flags := StatusFlags.from_result res { c := false, v := false }
     { s with status := flags }.setRegOrZr dst res next
@@ -696,7 +685,7 @@ set_option maxHeartbeats 1000000
     { s with status := flags }.setRegOrZr dst res next
   | .ORR_i dst src1 imm =>
     let val1 := s.regs.getRegOrZr src1
-    let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
+    let val2 := (imm.interp p).toBitVec.setWidth w.bits
     let res := val1 ||| val2
     s.setRegOrSp dst res next
   | .ORR_s dst src1 src2 =>
@@ -711,7 +700,7 @@ set_option maxHeartbeats 1000000
     s.setRegOrZr dst res next
   | .EOR_i dst src1 imm =>
     let val1 := s.regs.getRegOrZr src1
-    let val2 := BitVec.ofInt w.bits (Int64.toInt (imm.interp p))
+    let val2 := (imm.interp p).toBitVec.setWidth w.bits
     let res := val1 ^^^ val2
     s.setRegOrSp dst res next
   | .EOR_s dst src1 src2 =>
@@ -785,42 +774,38 @@ set_option maxHeartbeats 1000000
     let res := if lsb == 0 then val2 else (val1 <<< (w.bits - lsb)) ||| (val2 >>> lsb)
     s.setRegOrZr dst res next
   | .MOVZ dst imm shift =>
-    let val16 := (BitVec.ofInt w.bits (Int64.toInt (imm.interp p))) &&& 0xFFFF#w.bits
+    let val16 := ((imm.interp p).toBitVec.setWidth w.bits) &&& 0xFFFF#w.bits
     let res := val16 <<< shift.toNat
     s.setRegOrZr dst res next
   | .MOVK dst imm shift =>
     let oldVal := s.regs.getRegOrZr dst
     let mask := ~~~(0xFFFF#w.bits <<< shift.toNat)
-    let val16 := (BitVec.ofInt w.bits (Int64.toInt (imm.interp p))) &&& 0xFFFF#w.bits
+    let val16 := ((imm.interp p).toBitVec.setWidth w.bits) &&& 0xFFFF#w.bits
     let res := (oldVal &&& mask) ||| (val16 <<< shift.toNat)
     s.setRegOrZr dst res next
   | .MOVN dst imm shift =>
-    let val16 := (BitVec.ofInt w.bits (Int64.toInt (imm.interp p))) &&& 0xFFFF#w.bits
+    let val16 := ((imm.interp p).toBitVec.setWidth w.bits) &&& 0xFFFF#w.bits
     let res := ~~~(val16 <<< shift.toNat)
     s.setRegOrZr dst res next
   | .LSLV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
-    let shift := val2.toNat % w.bits
-    let res := val1 <<< shift
+    let res := val1 <<< shiftAmount val2
     s.setRegOrZr dst res next
   | .LSRV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
-    let shift := val2.toNat % w.bits
-    let res := val1.ushiftRight shift
+    let res := val1 >>> shiftAmount val2
     s.setRegOrZr dst res next
   | .ASRV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
-    let shift := val2.toNat % w.bits
-    let res := val1.sshiftRight shift
+    let res := val1.sshiftRight' (shiftAmount val2)
     s.setRegOrZr dst res next
   | .RORV dst src1 src2 =>
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
-    let shift := val2.toNat % w.bits
-    let res := val1.rotateRight shift
+    let res := val1.rorBV (shiftAmount val2)
     s.setRegOrZr dst res next
   | .CSEL dst src1 src2 cond =>
     let val := if cond.interp s.status then s.regs.getRegOrZr src1 else s.regs.getRegOrZr src2
@@ -841,7 +826,7 @@ set_option maxHeartbeats 1000000
         let res := val1 - val2
         StatusFlags.subs res val1 val2
       else
-        StatusFlags.ofNat nzcv
+        StatusFlags.ofBitVec nzcv
     next { s with status := status' }
   | .CCMP_imm src1 imm nzcv cond =>
     let status' := if cond.interp s.status then
@@ -850,7 +835,7 @@ set_option maxHeartbeats 1000000
         let res := val1 - val2
         StatusFlags.subs res val1 val2
       else
-        StatusFlags.ofNat nzcv
+        StatusFlags.ofBitVec nzcv
     next { s with status := status' }
   | .CCMN_reg src1 src2 nzcv cond =>
     let status' := if cond.interp s.status then
@@ -859,7 +844,7 @@ set_option maxHeartbeats 1000000
         let res := val1 + val2
         StatusFlags.adds res val1 val2
       else
-        StatusFlags.ofNat nzcv
+        StatusFlags.ofBitVec nzcv
     next { s with status := status' }
   | .CCMN_imm src1 imm nzcv cond =>
     let status' := if cond.interp s.status then
@@ -868,17 +853,17 @@ set_option maxHeartbeats 1000000
         let res := val1 + val2
         StatusFlags.adds res val1 val2
       else
-        StatusFlags.ofNat nzcv
+        StatusFlags.ofBitVec nzcv
     next { s with status := status' }
   | .ADR dst target =>
     let val := match target with
-      | .int64 imm => BitVec.ofInt 64 (Int64.toInt p.lower + Int64.toInt imm)
-      | _ => BitVec.ofInt 64 (Int64.toInt (target.interp p))
+      | .int64 imm => (p.lower + imm).toBitVec
+      | _ => (target.interp p).toBitVec
     s.setRegOrZr dst val next
   | .ADRP dst target =>
     let val := match target with
-      | .int64 imm => BitVec.ofInt 64 (Int64.toInt p.lower + Int64.toInt imm)
-      | _ => BitVec.ofInt 64 (Int64.toInt (target.interp p))
+      | .int64 imm => (p.lower + imm).toBitVec
+      | _ => (target.interp p).toBitVec
     s.setRegOrZr dst (val &&& ~~~0xFFF#64) next
   | .B target =>
     jmp (target.evalBranchTarget p) s
@@ -888,17 +873,17 @@ set_option maxHeartbeats 1000000
     else
       next s
   | .BL target =>
-    let lr_val := BitVec.ofInt 64 (Int64.toInt p.upper)
+    let lr_val := p.upper.toBitVec
     s.setRegOrZr RegOrZr.X30 lr_val (fun s' => jmp (target.evalBranchTarget p) s')
   | .BLR target =>
-    let lr_val := BitVec.ofInt 64 (Int64.toInt p.upper)
-    let target_val := Int64.ofInt (s.regs.getRegOrZr target).signed
+    let lr_val := p.upper.toBitVec
+    let target_val := Int64.ofBitVec (s.regs.getRegOrZr target)
     s.setRegOrZr RegOrZr.X30 lr_val (fun s' => jmp target_val s')
   | .BR target =>
-    let target_val := Int64.ofInt (s.regs.getRegOrZr target).signed
+    let target_val := Int64.ofBitVec (s.regs.getRegOrZr target)
     jmp target_val s
   | .RET target =>
-    let target_val := Int64.ofInt (s.regs.getRegOrZr target).signed
+    let target_val := Int64.ofBitVec (s.regs.getRegOrZr target)
     jmp target_val s
   | .CBZ reg target =>
     let val := s.regs.getRegOrZr reg
@@ -1010,7 +995,7 @@ abbrev eval [layout : Layout] (prog : Program) := Executable.eval (layout prog)
     .instr ⟨.W64, .STR .X1 { base := .SP, off := 0 }⟩,
     .instr ⟨.W64, .LDR .X2 (.addr { base := .SP, off := 0 })⟩]
   let start := (Executable.labels exe).label "main"
-  let data : MachineData := { dmem := Mem.storeInt {} 0x100 8 42, regs := {SP := 0x100} }
+  let data : MachineData := { dmem := Mem.storeBV {} 0x100 8 (42 : BitVec 64), regs := {SP := 0x100} }
   (Executable.eval exe (data, start) (fun (_, pc) => (exe.directivesFromAddress pc).isEmpty)).bind (fun s => .ok s.1.regs.X2)
 
 /-- info: Except.ok (42, 264) -/
@@ -1020,7 +1005,7 @@ abbrev eval [layout : Layout] (prog : Program) := Executable.eval (layout prog)
     .label "main",
     .instr ⟨.W64, .LDR .X1 (.addr { base := .SP, off := .imm { imm := 8, index := some .Pre } })⟩ ]
   let start := (Executable.labels exe).label "main"
-  let data : MachineData := { dmem := Mem.storeInt {} 0x108 8 42, regs := { SP := 0x100 } }
+  let data : MachineData := { dmem := Mem.storeBV {} 0x108 8 (42 : BitVec 64), regs := { SP := 0x100 } }
   (Executable.eval exe (data, start) (fun (_, pc) => (exe.directivesFromAddress pc).isEmpty)).bind (fun s => .ok (s.1.regs.X1, s.1.regs.SP))
 
 /-- info: Except.ok (42, 264) -/
@@ -1030,9 +1015,9 @@ abbrev eval [layout : Layout] (prog : Program) := Executable.eval (layout prog)
     .label "main",
     .instr ⟨.W64, .STR .X1 { base := .SP, off := .imm { imm := 8, index := some .Post } }⟩ ]
   let start := (Executable.labels exe).label "main"
-  let data : MachineData := { dmem := Mem.storeInt {} 0x100 8 0, regs := { SP := 0x100, X1 := 42 } }
+  let data : MachineData := { dmem := Mem.storeBV {} 0x100 8 (0 : BitVec 64), regs := { SP := 0x100, X1 := 42 } }
   (Executable.eval exe (data, start) (fun (_, pc) => (exe.directivesFromAddress pc).isEmpty)).bind (fun s =>
-    match Mem.loadInt s.1.dmem 0x100 8 with
-    | some v => .ok (v, s.1.regs.SP)
+    match Mem.loadBV s.1.dmem 0x100 64 8 with
+    | some v => .ok (v.toNat, s.1.regs.SP)
     | none => .error "Memory store failed"
   )

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -298,7 +298,7 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
 @[kstep] def AddrExpr.checkSPAlignment (mem : AddrExpr) (s : MachineData) (ok : Unit → Effects) : Effects :=
   match mem.base with
   | .SP =>
-    if s.regs.getRegOrSp .SP % 16#64 != 0#64 then
+    if (s.regs.getRegOrSp .SP &&& 0xF#64) != 0#64 then
       .unaligned_sp (s.regs.getRegOrSp .SP)
     else
       ok ()
@@ -324,7 +324,7 @@ def ConstExpr.evalBranchTarget [Labels] (target : ConstExpr) (p : Std.Rco Int64)
 @[kstep] def UnscaledAddrExpr.checkSPAlignment (mem : UnscaledAddrExpr) (s : MachineData) (ok : Unit → Effects) : Effects :=
   match mem.base with
   | .SP =>
-    if s.regs.getRegOrSp .SP % 16#64 != 0#64 then
+    if (s.regs.getRegOrSp .SP &&& 0xF#64) != 0#64 then
       .unaligned_sp (s.regs.getRegOrSp .SP)
     else
       ok ()
@@ -403,13 +403,13 @@ structure StatusFlags.from_result.Remaining where
     c := !Kraken.Flags.subBorrow val1 val2 false
     v := Kraken.Flags.subOverflow val1 val2 false }
 
-def StatusFlags.ofBitVec (nzcv : BitVec 4) : StatusFlags :=
+@[kstep, simp] def StatusFlags.ofBitVec (nzcv : BitVec 4) : StatusFlags :=
   { n := nzcv.getLsbD 3
     z := nzcv.getLsbD 2
     c := nzcv.getLsbD 1
     v := nzcv.getLsbD 0 }
 
-def shiftAmount {w : RegWidth} (val : w.type) : w.type :=
+@[kstep, simp] def shiftAmount {w : RegWidth} (val : w.type) : w.type :=
   val &&& BitVec.ofNat w.bits (w.bits - 1)
 
 @[kstep, simp] def maskOfLen {w : RegWidth} (len : Nat) : w.type :=
@@ -771,7 +771,7 @@ set_option maxHeartbeats 1000000
     let val1 := s.regs.getRegOrZr src1
     let val2 := s.regs.getRegOrZr src2
     let lsb := lsb % w.bits
-    let res := if lsb == 0 then val2 else (val1 <<< (w.bits - lsb)) ||| (val2 >>> lsb)
+    let res := (val1 <<< (w.bits - lsb)) ||| (val2 >>> lsb)
     s.setRegOrZr dst res next
   | .MOVZ dst imm shift =>
     let val16 := ((imm.interp p).toBitVec.setWidth w.bits) &&& 0xFFFF#w.bits
@@ -995,7 +995,7 @@ abbrev eval [layout : Layout] (prog : Program) := Executable.eval (layout prog)
     .instr ⟨.W64, .STR .X1 { base := .SP, off := 0 }⟩,
     .instr ⟨.W64, .LDR .X2 (.addr { base := .SP, off := 0 })⟩]
   let start := (Executable.labels exe).label "main"
-  let data : MachineData := { dmem := Mem.storeBV {} 0x100 8 (42 : BitVec 64), regs := {SP := 0x100} }
+  let data : MachineData := { dmem := Mem.storeBV {} 0x100 8 42#64, regs := {SP := 0x100} }
   (Executable.eval exe (data, start) (fun (_, pc) => (exe.directivesFromAddress pc).isEmpty)).bind (fun s => .ok s.1.regs.X2)
 
 /-- info: Except.ok (42, 264) -/
@@ -1005,7 +1005,7 @@ abbrev eval [layout : Layout] (prog : Program) := Executable.eval (layout prog)
     .label "main",
     .instr ⟨.W64, .LDR .X1 (.addr { base := .SP, off := .imm { imm := 8, index := some .Pre } })⟩ ]
   let start := (Executable.labels exe).label "main"
-  let data : MachineData := { dmem := Mem.storeBV {} 0x108 8 (42 : BitVec 64), regs := { SP := 0x100 } }
+  let data : MachineData := { dmem := Mem.storeBV {} 0x108 8 42#64, regs := { SP := 0x100 } }
   (Executable.eval exe (data, start) (fun (_, pc) => (exe.directivesFromAddress pc).isEmpty)).bind (fun s => .ok (s.1.regs.X1, s.1.regs.SP))
 
 /-- info: Except.ok (42, 264) -/
@@ -1015,7 +1015,7 @@ abbrev eval [layout : Layout] (prog : Program) := Executable.eval (layout prog)
     .label "main",
     .instr ⟨.W64, .STR .X1 { base := .SP, off := .imm { imm := 8, index := some .Post } }⟩ ]
   let start := (Executable.labels exe).label "main"
-  let data : MachineData := { dmem := Mem.storeBV {} 0x100 8 (0 : BitVec 64), regs := { SP := 0x100, X1 := 42 } }
+  let data : MachineData := { dmem := Mem.storeBV {} 0x100 8 0#64, regs := { SP := 0x100, X1 := 42 } }
   (Executable.eval exe (data, start) (fun (_, pc) => (exe.directivesFromAddress pc).isEmpty)).bind (fun s =>
     match Mem.loadBV s.1.dmem 0x100 64 8 with
     | some v => .ok (v.toNat, s.1.regs.SP)

--- a/Kraken/AArch64/Semantics.lean
+++ b/Kraken/AArch64/Semantics.lean
@@ -185,7 +185,7 @@ def MachineData.load
   (s : MachineData) (addr : BitVec 64) (w : MemWidth)
   (ret : w.type → MachineData → Effects): Effects :=
   require_read_access addr w (fun _unit =>
-    match Mem.loadBV s.dmem addr w.bits w.bytes with
+    match Mem.loadBV s.dmem addr w.bytes with
     | .some v => ret v s
     | .none => nonmem_load s.dmem addr w (fun v dmem => ret v { s with dmem }))
 
@@ -1017,7 +1017,7 @@ abbrev eval [layout : Layout] (prog : Program) := Executable.eval (layout prog)
   let start := (Executable.labels exe).label "main"
   let data : MachineData := { dmem := Mem.storeBV {} 0x100 8 0#64, regs := { SP := 0x100, X1 := 42 } }
   (Executable.eval exe (data, start) (fun (_, pc) => (exe.directivesFromAddress pc).isEmpty)).bind (fun s =>
-    match Mem.loadBV s.1.dmem 0x100 64 8 with
+    match Mem.loadBV s.1.dmem 0x100 8 with
     | some v => .ok (v.toNat, s.1.regs.SP)
     | none => .error "Memory store failed"
   )

--- a/Kraken/AArch64/Sep.lean
+++ b/Kraken/AArch64/Sep.lean
@@ -11,12 +11,12 @@ theorem store_sep (s : MachineData) (addr : BitVec 64) (w : MemWidth) (v : w.typ
     (bs : List UInt8) (R : DataMem → Prop)
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :
-    have mem' := Mem.storeInt s.dmem addr w.bytes v.toInt
+    have mem' := Mem.storeBV s.dmem addr w.bytes v
     MachineData.store s addr v ret =
       require_write_access addr w (fun _ =>
         ret { s with dmem := mem' }) := by
-  have h_load : Mem.loadInt s.dmem addr w.bytes = some (Int.ofBytes bs) :=
-    Mem.loadInt_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)
+  have h_load : Mem.loadBytes s.dmem addr w.bytes = some bs :=
+    Mem.loadBytes_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)
   simp only [MachineData.store, h_load]
 
 @[kspec]
@@ -25,6 +25,6 @@ theorem load_sep (s : MachineData) (addr : BitVec 64) (w : MemWidth) (ret : w.ty
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :
     MachineData.load s addr w ret =
-      require_read_access addr w (fun _ => ret (.ofInt w.bits (Int.ofBytes bs)) s) := by
+      require_read_access addr w (fun _ => ret (BitVec.ofBytes w.bits bs) s) := by
   simp only [MachineData.load,
-    Mem.loadInt_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)]
+    Mem.loadBV_sep bs addr w.bits w.bytes R s.dmem h_mem h_len (by cases w <;> decide)]

--- a/Kraken/AArch64/Sep.lean
+++ b/Kraken/AArch64/Sep.lean
@@ -27,4 +27,4 @@ theorem load_sep (s : MachineData) (addr : BitVec 64) (w : MemWidth) (ret : w.ty
     MachineData.load s addr w ret =
       require_read_access addr w (fun _ => ret (BitVec.ofBytes w.bits bs) s) := by
   simp only [MachineData.load,
-    Mem.loadBV_sep bs addr w.bits w.bytes R s.dmem h_mem h_len (by cases w <;> decide)]
+    Mem.loadBV_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)]

--- a/Kraken/AArch64/Syntax.lean
+++ b/Kraken/AArch64/Syntax.lean
@@ -17,7 +17,7 @@ namespace MemWidth
 @[kstep, simp, reducible] def bytes : MemWidth → Nat | W8 => 1 | W16 => 2 | W32 => 4 | W64 => 8
 @[kstep] abbrev bytesv (w : MemWidth) {n} : BitVec n := BitVec.ofNat n w.bytes
 @[kstep] abbrev type (w : MemWidth) : Type := BitVec w.bits
-instance {w : MemWidth} : Coe Bool w.type where coe := fun b : Bool => BitVec.ofNat _ b.toNat
+instance {w : MemWidth} : Coe Bool w.type where coe := fun b : Bool => (BitVec.ofBool b).setWidth _
 end MemWidth
 
 unif_hint (w : MemWidth) where
@@ -51,7 +51,7 @@ instance : Coe RegWidth MemWidth where coe := fun w : RegWidth =>
 @[kstep, simp, reducible] def bytes (w : RegWidth) : Nat := (w : MemWidth).bytes
 @[kstep] abbrev bytesv (w : RegWidth) {n} : BitVec n := (w : MemWidth).bytesv
 @[kstep] abbrev type (w : RegWidth) : Type := (w : MemWidth).type
-instance {w : RegWidth} : Coe Bool w.type where coe := fun b : Bool => BitVec.ofNat _ b.toNat
+instance {w : RegWidth} : Coe Bool w.type where coe := fun b : Bool => (BitVec.ofBool b).setWidth _
 end RegWidth
 
 unif_hint (w : RegWidth) where
@@ -247,7 +247,7 @@ Shifted register operand for logical and arithmetic instructions (`Xm, <shift> #
 -/
 structure ShiftRegExpr (w : RegWidth) where
   reg : RegOrZr w
-  amount : Int64 -- Must be in the range $[0, 31]$ for 32-bit instructions and [0, 63] for 64-bit instructions.
+  amount : Nat -- Must be in the range $[0, 31]$ for 32-bit instructions and [0, 63] for 64-bit instructions.
   shift : ShiftType
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
@@ -445,10 +445,10 @@ inductive Operation : RegWidth → Type
   | CSNEG {w} (dst : RegOrZr w) (src1 src2 : RegOrZr w) (cond : CondCode) : Operation w
   --
   -- Conditional Compare (instructions have a reg (_r) and immediate (_i) form).
-  | CCMP_reg {w} (src1 : RegOrZr w) (src2 : RegOrZr w) (nzcv : Nat) (cond : CondCode) : Operation w
-  | CCMP_imm {w} (src1 : RegOrZr w) (imm : Nat) (nzcv : Nat) (cond : CondCode) : Operation w
-  | CCMN_reg {w} (src1 : RegOrZr w) (src2 : RegOrZr w) (nzcv : Nat) (cond : CondCode) : Operation w
-  | CCMN_imm {w} (src1 : RegOrZr w) (imm : Nat) (nzcv : Nat) (cond : CondCode) : Operation w
+  | CCMP_reg {w} (src1 : RegOrZr w) (src2 : RegOrZr w) (nzcv : BitVec 4) (cond : CondCode) : Operation w
+  | CCMP_imm {w} (src1 : RegOrZr w) (imm : Nat) (nzcv : BitVec 4) (cond : CondCode) : Operation w
+  | CCMN_reg {w} (src1 : RegOrZr w) (src2 : RegOrZr w) (nzcv : BitVec 4) (cond : CondCode) : Operation w
+  | CCMN_imm {w} (src1 : RegOrZr w) (imm : Nat) (nzcv : BitVec 4) (cond : CondCode) : Operation w
   --
   -- Addressing.
   | ADR (dst : RegOrZr .W64) (target : ConstExpr) : Operation .W64

--- a/Kraken/AArch64/Syntax.lean
+++ b/Kraken/AArch64/Syntax.lean
@@ -13,8 +13,8 @@ instance : ToString MemWidth where
   toString | .W8 => "w8" | .W16 => "w16" | .W32 => "w32" | .W64 => "w64"
 
 namespace MemWidth
-@[kstep, simp, reducible] def bits : MemWidth → Nat | W8 => 8 | W16 => 16 | W32 => 32 | W64 => 64
 @[kstep, simp, reducible] def bytes : MemWidth → Nat | W8 => 1 | W16 => 2 | W32 => 4 | W64 => 8
+@[kstep, simp, reducible] def bits (w : MemWidth) := 8 * w.bytes
 @[kstep] abbrev bytesv (w : MemWidth) {n} : BitVec n := BitVec.ofNat n w.bytes
 @[kstep] abbrev type (w : MemWidth) : Type := BitVec w.bits
 instance {w : MemWidth} : Coe Bool w.type where coe := fun b : Bool => (BitVec.ofBool b).setWidth _

--- a/Kraken/BitVec.lean
+++ b/Kraken/BitVec.lean
@@ -1,0 +1,92 @@
+import Kraken.Attribute
+import Kraken.StdLibCandidates
+import Std
+
+-- injective coercions only
+attribute [-instance] BitVec.instNatCast
+attribute [-instance] BitVec.instIntCast
+instance : Coe Bool Nat where coe := Bool.toNat
+
+namespace BitVec
+
+@[kstep] def take {w : Nat} (x : BitVec w) (n : Nat) : BitVec n := x.extractLsb' 0 n
+@[kstep] def drop {w : Nat} (x : BitVec w) (n : Nat) : BitVec (w - n) := x.extractLsb' n (w - n)
+
+end BitVec
+
+attribute [kstep]
+  BitVec.ofInt_add
+  BitVec.ofInt_toInt
+  BitVec.truncate
+
+-- Conversion helpers to relate semantics expressed in terms of `BitVec` to `Int`/`Nat`.
+namespace BitVec
+
+def unsigned {w : Nat} (x : BitVec w) : Int := x.toNat
+def signed {w : Nat} (x : BitVec w) : Int := x.toInt
+
+-- AArch64 specific lemmas.
+
+-- `SMULH`/`UMULH`, `*MADDL`/`*MSUBL`
+theorem signExtend_mul_signExtend_eq_ofInt {w n : Nat} (hw : 0 < w) (hn : w + w ≤ n)
+    (a b : BitVec w) :
+    a.signExtend n * b.signExtend n = BitVec.ofInt n (a.signed * b.signed) :=
+  (BitVec.ofInt_mul_toInt hw hn a b).symm
+
+theorem setWidth_mul_setWidth_eq_ofInt {w n : Nat} (hn : w + w ≤ n) (a b : BitVec w) :
+    a.setWidth n * b.setWidth n = BitVec.ofInt n (a.unsigned * b.unsigned) :=
+  (BitVec.ofInt_mul_toNat hn a b).symm
+
+-- `SMADDL`/`UMADDL`, `SMSUBL`/`UMSUBL`
+theorem signExtend_mul_add_eq_ofInt (a b : BitVec 32) (c : BitVec 64) :
+    a.signExtend 64 * b.signExtend 64 + c
+      = BitVec.ofInt 64 (a.signed * b.signed + c.signed) := by
+  simp only [BitVec.signed]
+  rw [BitVec.ofInt_add, ← BitVec.ofInt_mul_toInt (by omega) (by omega),
+    BitVec.ofInt_toInt]
+
+theorem setWidth_mul_add_eq_ofInt (a b : BitVec 32) (c : BitVec 64) :
+    a.setWidth 64 * b.setWidth 64 + c
+      = BitVec.ofInt 64 (a.unsigned * b.unsigned + c.unsigned) := by
+  simp only [BitVec.unsigned]
+  rw [BitVec.ofInt_add, ← BitVec.ofInt_mul_toNat (by omega),
+    BitVec.ofInt_toNat_setWidth, BitVec.setWidth_eq]
+
+theorem sub_signExtend_mul_eq_ofInt (a b : BitVec 32) (c : BitVec 64) :
+    c - a.signExtend 64 * b.signExtend 64
+      = BitVec.ofInt 64 (c.signed - a.signed * b.signed) := by
+  simp only [BitVec.signed]
+  rw [BitVec.ofInt_sub, ← BitVec.ofInt_mul_toInt (by omega) (by omega),
+    BitVec.ofInt_toInt]
+
+theorem sub_setWidth_mul_eq_ofInt (a b : BitVec 32) (c : BitVec 64) :
+    c - a.setWidth 64 * b.setWidth 64
+      = BitVec.ofInt 64 (c.unsigned - a.unsigned * b.unsigned) := by
+  simp only [BitVec.unsigned]
+  rw [BitVec.ofInt_sub, ← BitVec.ofInt_mul_toNat (by omega),
+    BitVec.ofInt_toNat_setWidth, BitVec.setWidth_eq]
+
+-- x64 specific lemmas.
+
+-- `mul` and `mulx`
+theorem mul_widen_unsigned {w n : Nat} (hn : w + w ≤ n) (a b : BitVec w) :
+    a.setWidth n * b.setWidth n = BitVec.ofInt n (a.unsigned * b.unsigned) :=
+  (BitVec.ofInt_mul_toNat hn a b).symm
+
+-- `imul`
+theorem mul_widen_signed {w n : Nat} (hw : 0 < w) (hn : w + w ≤ n) (a b : BitVec w) :
+    a.signExtend n * b.signExtend n = BitVec.ofInt n (a.signed * b.signed) :=
+  (BitVec.ofInt_mul_toInt hw hn a b).symm
+
+-- `mul` flags
+theorem mul_unsigned_flags_spec {w : Nat} (a b : BitVec w) :
+    BitVec.umulOverflow a b = true ↔ (a * b).unsigned ≠ a.unsigned * b.unsigned := by
+  rw [BitVec.umulOverflow_iff]
+  simp only [BitVec.unsigned, ne_eq, ← Int.natCast_mul, Int.natCast_inj]
+
+-- `imul` flags
+theorem mul_signed_flags_spec {w : Nat} (hw : 0 < w) (a b : BitVec w) :
+    BitVec.smulOverflow a b = true ↔ (a * b).signed ≠ a.signed * b.signed :=
+  BitVec.smulOverflow_iff hw a b
+
+end BitVec

--- a/Kraken/BitVec.lean
+++ b/Kraken/BitVec.lean
@@ -41,30 +41,22 @@ theorem setWidth_mul_setWidth_eq_ofInt {w n : Nat} (hn : w + w ≤ n) (a b : Bit
 theorem signExtend_mul_add_eq_ofInt (a b : BitVec 32) (c : BitVec 64) :
     a.signExtend 64 * b.signExtend 64 + c
       = BitVec.ofInt 64 (a.signed * b.signed + c.signed) := by
-  simp only [BitVec.signed]
-  rw [BitVec.ofInt_add, ← BitVec.ofInt_mul_toInt (by omega) (by omega),
-    BitVec.ofInt_toInt]
+  simp [signed, ofInt_add, ofInt_mul_toInt]
 
 theorem setWidth_mul_add_eq_ofInt (a b : BitVec 32) (c : BitVec 64) :
     a.setWidth 64 * b.setWidth 64 + c
       = BitVec.ofInt 64 (a.unsigned * b.unsigned + c.unsigned) := by
-  simp only [BitVec.unsigned]
-  rw [BitVec.ofInt_add, ← BitVec.ofInt_mul_toNat (by omega),
-    BitVec.ofInt_toNat_setWidth, BitVec.setWidth_eq]
+  simp [unsigned, ofInt_add, ofInt_mul_toNat]
 
 theorem sub_signExtend_mul_eq_ofInt (a b : BitVec 32) (c : BitVec 64) :
     c - a.signExtend 64 * b.signExtend 64
       = BitVec.ofInt 64 (c.signed - a.signed * b.signed) := by
-  simp only [BitVec.signed]
-  rw [BitVec.ofInt_sub, ← BitVec.ofInt_mul_toInt (by omega) (by omega),
-    BitVec.ofInt_toInt]
+  simp [signed, ofInt_sub, ofInt_mul_toInt]
 
 theorem sub_setWidth_mul_eq_ofInt (a b : BitVec 32) (c : BitVec 64) :
     c - a.setWidth 64 * b.setWidth 64
       = BitVec.ofInt 64 (c.unsigned - a.unsigned * b.unsigned) := by
-  simp only [BitVec.unsigned]
-  rw [BitVec.ofInt_sub, ← BitVec.ofInt_mul_toNat (by omega),
-    BitVec.ofInt_toNat_setWidth, BitVec.setWidth_eq]
+  simp [unsigned, ofInt_sub, ofInt_mul_toNat]
 
 -- x64 specific lemmas.
 

--- a/Kraken/Flags.lean
+++ b/Kraken/Flags.lean
@@ -1,0 +1,242 @@
+import Std.Tactic.BVDecide
+
+/-!
+# Arithmetic flag computation
+
+x86 and AArch64 both derive carry/borrow and signed-overflow flags from the
+same three quantities. The natural (arithmetic) specification reads as:
+
+    cf := v.unsigned != a.unsigned + b.unsigned
+    of := v.signed   != a.signed   + b.signed
+
+Here we define the same flags in `BitVec` terms. The idea is to widen by one bit
+and look at the carry position, or compare sign bits. The `BitVec` forms are what
+the semantics evaluate. The `_spec` theorems are provided for arithmetic reasoning
+that is more natural over `Int`.
+
+TODO: `bv_decide` does not reduce `BitVec.carry` and abstracts it as an
+opaque variable. We use `setWidth`/`msb` instead which are recognized.
+
+TODO: `bv_decide` does not reduce `Bool.toNat` and  abstracts it as an
+opaque variable. We use `ofBool`/`setWidth` instead for a carry input.
+-/
+
+namespace Kraken.Flags
+
+/-- Unsigned carry out of `a + b + c`: widen by one bit and read the top bit. -/
+def addCarry {w} (a b : BitVec w) (c : Bool) : Bool :=
+  (a.setWidth (w + 1) + b.setWidth (w + 1) + (BitVec.ofBool c).setWidth (w + 1)).msb
+
+/-- The carry-in as a bitvector. -/
+abbrev carryBit (w : Nat) (c : Bool) : BitVec w := (BitVec.ofBool c).setWidth w
+
+theorem carryBit_eq_ofNat (w : Nat) (c : Bool) :
+    carryBit w c = BitVec.ofNat w c.toNat := by
+  cases c <;> cases w <;> simp [carryBit] <;> rfl
+
+/-- Signed overflow of `a + b + c`. -/
+def addOverflow {w} (a b : BitVec w) (c : Bool) : Bool :=
+  let v := a + b + carryBit w c
+  (a.msb == b.msb) && (v.msb != a.msb)
+
+/-- Unsigned borrow out of `b - a - c`. -/
+def subBorrow {w} (b a : BitVec w) (c : Bool) : Bool :=
+  BitVec.ult (b.setWidth (w + 1)) (a.setWidth (w + 1) + (BitVec.ofBool c).setWidth (w + 1))
+
+/-- Signed overflow of `b - a - c`. -/
+def subOverflow {w} (b a : BitVec w) (c : Bool) : Bool :=
+  let v := b - a - carryBit w c
+  (b.msb != a.msb) && (v.msb != b.msb)
+
+private theorem pow_succ_eq {w : Nat} : 2 ^ (w + 1) = 2 * 2 ^ w := by
+  rw [Nat.pow_succ]; omega
+
+private theorem pow_eq_two_mul {w : Nat} (hw : 0 < w) : 2 ^ w = 2 * 2 ^ (w - 1) := by
+  cases w with
+  | zero => omega
+  | succ n => simp only [Nat.add_sub_cancel, Nat.pow_succ]; omega
+
+private theorem toNat_ofBool_setWidth {w : Nat} (c : Bool) :
+    ((BitVec.ofBool c).setWidth (w + 1)).toNat = c.toNat := by
+  cases c <;> simp
+
+private theorem toNat_setWidth_succ {w : Nat} (x : BitVec w) :
+    (x.setWidth (w + 1)).toNat = x.toNat := by
+  have := x.isLt
+  rw [BitVec.toNat_setWidth,
+    Nat.mod_eq_of_lt (show x.toNat < 2 ^ (w + 1) by rw [pow_succ_eq]; omega)]
+
+private theorem toNat_widened_add {w} (a b : BitVec w) (c : Bool) :
+    (a.setWidth (w+1) + b.setWidth (w+1) + (BitVec.ofBool c).setWidth (w+1)).toNat
+      = a.toNat + b.toNat + c.toNat := by
+  have ha := a.isLt
+  have hb := b.isLt
+  have hpow : 2 ^ (w + 1) = 2 * 2 ^ w := pow_succ_eq
+  have hct : c.toNat ≤ 1 := by cases c <;> simp
+  rw [BitVec.toNat_add, BitVec.toNat_add, toNat_setWidth_succ, toNat_setWidth_succ,
+    toNat_ofBool_setWidth,
+    Nat.mod_eq_of_lt (show a.toNat + b.toNat < 2 ^ (w+1) by omega),
+    Nat.mod_eq_of_lt (show a.toNat + b.toNat + c.toNat < 2 ^ (w+1) by omega)]
+
+theorem addCarry_eq {w} (a b : BitVec w) (c : Bool) :
+    addCarry a b c = decide (a.toNat + b.toNat + c.toNat ≥ 2 ^ w) := by
+  rw [addCarry, BitVec.msb_eq_decide, toNat_widened_add]
+  simp
+
+theorem addCarry_spec {w} (hw : 0 < w) (a b : BitVec w) (c : Bool) :
+    addCarry a b c
+      = ((((a + b + BitVec.ofNat w c.toNat).toNat : Int))
+          != (a.toNat : Int) + (b.toNat : Int) + (c.toNat : Int)) := by
+  have hpow : 1 < 2 ^ w := Nat.one_lt_two_pow_iff.mpr (by omega)
+  have hct : c.toNat < 2 ^ w := by cases c <;> simp <;> omega
+  have ha := a.isLt
+  have hb := b.isLt
+  have hc : (BitVec.ofNat w c.toNat).toNat = c.toNat := by simp [Nat.mod_eq_of_lt hct]
+  have hv : (a + b + BitVec.ofNat w c.toNat).toNat
+      = (a.toNat + b.toNat + c.toNat) % 2 ^ w := by
+    rw [BitVec.toNat_add, BitVec.toNat_add, hc, Nat.mod_add_mod]
+  rw [addCarry_eq, Bool.eq_iff_iff]
+  simp only [hv, decide_eq_true_eq, bne_iff_ne, ne_eq]
+  by_cases h : a.toNat + b.toNat + c.toNat < 2 ^ w
+  · rw [Nat.mod_eq_of_lt h]; omega
+  · have := Nat.mod_lt (a.toNat + b.toNat + c.toNat) (show 0 < 2 ^ w by omega)
+    omega
+
+theorem addOverflow_spec {w} (hw : 0 < w) (a b : BitVec w) (c : Bool) :
+    addOverflow a b c
+      = (((a + b + BitVec.ofNat w c.toNat).toInt)
+          != a.toInt + b.toInt + (c.toNat : Int)) := by
+  have h1 : 1 < 2 ^ w := Nat.one_lt_two_pow_iff.mpr (by omega)
+  have ha := a.isLt
+  have hb := b.isLt
+  have hct : c.toNat ≤ 1 := by cases c <;> simp
+  have hcw : (BitVec.ofNat w c.toNat).toNat = c.toNat := by
+    simp [Nat.mod_eq_of_lt (show c.toNat < 2 ^ w by omega)]
+  have hv : (a + b + BitVec.ofNat w c.toNat).toNat
+      = (a.toNat + b.toNat + c.toNat) % 2 ^ w := by
+    rw [BitVec.toNat_add, BitVec.toNat_add, hcw, Nat.mod_add_mod]
+  have hvc : (a + b + BitVec.ofNat w c.toNat).toNat = a.toNat + b.toNat + c.toNat
+      ∨ (a + b + BitVec.ofNat w c.toNat).toNat + 2 ^ w = a.toNat + b.toNat + c.toNat := by
+    rw [hv]
+    rcases Nat.lt_or_ge (a.toNat + b.toNat + c.toNat) (2 ^ w) with h | h
+    · exact Or.inl (Nat.mod_eq_of_lt h)
+    · exact Or.inr (by rw [Nat.mod_eq_sub_mod h, Nat.mod_eq_of_lt (by omega)]; omega)
+  have hvlt := (a + b + BitVec.ofNat w c.toNat).isLt
+  have hNe := pow_eq_two_mul hw
+  clear hv hcw
+  have kA : a.msb = false ↔ 2 * a.toNat < 2 ^ w := BitVec.msb_eq_false_iff_two_mul_lt
+  have kB : b.msb = false ↔ 2 * b.toNat < 2 ^ w := BitVec.msb_eq_false_iff_two_mul_lt
+  have kV : (a + b + BitVec.ofNat w c.toNat).msb = false
+      ↔ 2 * (a + b + BitVec.ofNat w c.toNat).toNat < 2 ^ w :=
+    BitVec.msb_eq_false_iff_two_mul_lt
+  rw [addOverflow, carryBit_eq_ofNat, Bool.eq_iff_iff]
+  simp only [Bool.and_eq_true, beq_iff_eq, bne_iff_ne, ne_eq, BitVec.toInt_eq_msb_cond]
+  rcases hvc with hvc | hvc <;>
+    cases hA' : a.msb <;> cases hB' : b.msb <;>
+    cases hV' : (a + b + BitVec.ofNat w c.toNat).msb <;>
+    simp only [hA', hB', hV', reduceIte, and_true, and_false, true_iff, false_iff,
+      Decidable.not_not, Bool.true_eq_false, Bool.false_eq_true,
+      not_true_eq_false, not_false_eq_true] at kA kB kV ⊢ <;>
+    omega
+
+private theorem toNat_widened_add2 {w} (a : BitVec w) (c : Bool) :
+    (a.setWidth (w+1) + (BitVec.ofBool c).setWidth (w+1)).toNat = a.toNat + c.toNat := by
+  have ha := a.isLt
+  have hpow : 2 ^ (w + 1) = 2 * 2 ^ w := pow_succ_eq
+  have hct : c.toNat ≤ 1 := by cases c <;> simp
+  rw [BitVec.toNat_add, toNat_setWidth_succ, toNat_ofBool_setWidth,
+    Nat.mod_eq_of_lt (by omega)]
+
+private theorem sub_toNat_cases {w} (hw : 0 < w) (b a : BitVec w) (c : Bool) :
+    (b - a - BitVec.ofNat w c.toNat).toNat + a.toNat + c.toNat = b.toNat
+      ∨ (b - a - BitVec.ofNat w c.toNat).toNat + a.toNat + c.toNat = b.toNat + 2 ^ w := by
+  have hpow : 1 < 2 ^ w := Nat.one_lt_two_pow_iff.mpr (by omega)
+  have ha := a.isLt
+  have hb := b.isLt
+  have hct : c.toNat ≤ 1 := by cases c <;> simp
+  have hc : (BitVec.ofNat w c.toNat).toNat = c.toNat := by
+    simp [Nat.mod_eq_of_lt (show c.toNat < 2 ^ w by omega)]
+  have h : (b - a - BitVec.ofNat w c.toNat).toNat
+      = ((2 ^ w - c.toNat) + ((2 ^ w - a.toNat) + b.toNat) % 2 ^ w) % 2 ^ w := by
+    rw [BitVec.toNat_sub, BitVec.toNat_sub, hc]
+  rw [h]
+  by_cases hba : b.toNat < a.toNat
+  · rw [Nat.mod_eq_of_lt (show (2 ^ w - a.toNat) + b.toNat < 2 ^ w by omega)]
+    by_cases hcc : 2 ^ w - a.toNat + b.toNat < c.toNat
+    · rw [Nat.mod_eq_of_lt (by omega)]; omega
+    · rw [Nat.mod_eq_sub_mod (by omega), Nat.mod_eq_of_lt (by omega)]; omega
+  · rw [Nat.mod_eq_sub_mod (show 2 ^ w ≤ (2 ^ w - a.toNat) + b.toNat by omega),
+      Nat.mod_eq_of_lt (show (2 ^ w - a.toNat) + b.toNat - 2 ^ w < 2 ^ w by omega)]
+    by_cases hcc : b.toNat - a.toNat < c.toNat
+    · rw [Nat.mod_eq_of_lt (by omega)]; omega
+    · rw [Nat.mod_eq_sub_mod (by omega), Nat.mod_eq_of_lt (by omega)]; omega
+
+theorem subBorrow_eq {w} (b a : BitVec w) (c : Bool) :
+    subBorrow b a c = decide (b.toNat < a.toNat + c.toNat) := by
+  rw [subBorrow, BitVec.ult, toNat_setWidth_succ, toNat_widened_add2]
+
+theorem subBorrow_spec {w} (hw : 0 < w) (b a : BitVec w) (c : Bool) :
+    subBorrow b a c
+      = ((((b - a - BitVec.ofNat w c.toNat).toNat : Int))
+          != (b.toNat : Int) - (a.toNat : Int) - (c.toNat : Int)) := by
+  have hpow : 1 < 2 ^ w := Nat.one_lt_two_pow_iff.mpr (by omega)
+  have hct : c.toNat < 2 ^ w := by cases c <;> simp <;> omega
+  have ha := a.isLt
+  have hb := b.isLt
+  have hvlt := (b - a - BitVec.ofNat w c.toNat).isLt
+  have hvc : (b - a - BitVec.ofNat w c.toNat).toNat + a.toNat + c.toNat = b.toNat
+      ∨ (b - a - BitVec.ofNat w c.toNat).toNat + a.toNat + c.toNat = b.toNat + 2 ^ w :=
+    sub_toNat_cases hw b a c
+  rw [subBorrow_eq, Bool.eq_iff_iff]
+  simp only [decide_eq_true_eq, bne_iff_ne, ne_eq]
+  omega
+
+theorem subOverflow_spec {w} (hw : 0 < w) (b a : BitVec w) (c : Bool) :
+    subOverflow b a c
+      = (((b - a - BitVec.ofNat w c.toNat).toInt)
+          != b.toInt - a.toInt - (c.toNat : Int)) := by
+  have h1 : 1 < 2 ^ w := Nat.one_lt_two_pow_iff.mpr (by omega)
+  have ha := a.isLt
+  have hb := b.isLt
+  have hct : c.toNat ≤ 1 := by cases c <;> simp
+  have hvlt := (b - a - BitVec.ofNat w c.toNat).isLt
+  have hvc := sub_toNat_cases hw b a c
+  have hNe := pow_eq_two_mul hw
+  have kA : a.msb = false ↔ 2 * a.toNat < 2 ^ w := BitVec.msb_eq_false_iff_two_mul_lt
+  have kB : b.msb = false ↔ 2 * b.toNat < 2 ^ w := BitVec.msb_eq_false_iff_two_mul_lt
+  have kV : (b - a - BitVec.ofNat w c.toNat).msb = false
+      ↔ 2 * (b - a - BitVec.ofNat w c.toNat).toNat < 2 ^ w :=
+    BitVec.msb_eq_false_iff_two_mul_lt
+  rw [subOverflow, carryBit_eq_ofNat, Bool.eq_iff_iff]
+  simp only [Bool.and_eq_true, bne_iff_ne, ne_eq, BitVec.toInt_eq_msb_cond]
+  rcases hvc with hvc | hvc <;>
+    cases hA' : a.msb <;> cases hB' : b.msb <;>
+    cases hV' : (b - a - BitVec.ofNat w c.toNat).msb <;>
+    simp only [hA', hB', hV', reduceIte, and_true, and_false, true_iff, false_iff,
+      Decidable.not_not, Bool.true_eq_false, Bool.false_eq_true,
+      not_true_eq_false, not_false_eq_true] at kA kB kV ⊢ <;>
+    omega
+
+/-- Regression tests to ensure terms are solvable by `bv_decide`. -/
+
+example (a : BitVec 64) : addCarry a 0 false = false := by
+  unfold addCarry; bv_decide
+
+example (a b : BitVec 64) : subBorrow a b false = BitVec.ult a b := by
+  unfold subBorrow; bv_decide
+
+example (a : BitVec 64) : addOverflow a 0 false = false := by
+  unfold addOverflow; bv_decide
+
+example (a : BitVec 64) : subOverflow a 0 false = false := by
+  unfold subOverflow; bv_decide
+
+/-- `INC` overflows exactly at `intMax`. -/
+example (a : BitVec 64) : addOverflow a 1 false = (a == BitVec.intMax 64) := by
+  unfold addOverflow; bv_decide
+
+/-- Carry-in is bitblasted too, not just the `c = false` case. -/
+example (a : BitVec 64) (c : Bool) : addCarry a 0 c = (c && (a == BitVec.allOnes 64)) := by
+  unfold addCarry; bv_decide
+
+end Kraken.Flags

--- a/Kraken/Mem.lean
+++ b/Kraken/Mem.lean
@@ -21,8 +21,9 @@ abbrev Mem (w) := ExtHashMap (BitVec w) UInt8
 def Mem.loadBytes {w} (m : Mem w) (a : BitVec w) (n : Nat) : Option (List UInt8) :=
   ((List.range n).map (fun i => m.get? (a + .ofNat _ i))).allSome
 
-def Mem.loadInt {w} (m : Mem w) (a : BitVec w) (n : Nat) : Option Int :=
-  (loadBytes m a n).map Int.ofBytes
+/-- Read `n` bytes at `a` and assemble them into a `bits`-wide value. -/
+def Mem.loadBV {w} (m : Mem w) (a : BitVec w) (bits n : Nat) : Option (BitVec bits) :=
+  (loadBytes m a n).map (BitVec.ofBytes bits)
 
 
 -- JP: can't use the Mem abbreviation here because it resolves to List.Mem (the
@@ -33,8 +34,9 @@ def List.At {w} (bs : List UInt8) (a : BitVec w) : ExtHashMap (BitVec w) UInt8 :
 def Mem.storeBytes {w} (m : Mem w) (a : BitVec w) (bs : List UInt8) : Mem w :=
   m.union (bs.At a)
 
-def Mem.storeInt {w} (m : Mem w) (a : BitVec w) (n : Nat) (v : Int) : Mem w :=
-  storeBytes m a (Int.toBytes n v)
+/-- Write the low `n` bytes of `v` at `a`. -/
+def Mem.storeBV {w bits} (m : Mem w) (a : BitVec w) (n : Nat) (v : BitVec bits) : Mem w :=
+  storeBytes m a (BitVec.toBytes n v)
 
 
 def UInt64.At {w} (val : UInt64) (a : BitVec w) : Mem w :=

--- a/Kraken/Mem.lean
+++ b/Kraken/Mem.lean
@@ -21,9 +21,9 @@ abbrev Mem (w) := ExtHashMap (BitVec w) UInt8
 def Mem.loadBytes {w} (m : Mem w) (a : BitVec w) (n : Nat) : Option (List UInt8) :=
   ((List.range n).map (fun i => m.get? (a + .ofNat _ i))).allSome
 
-/-- Read `n` bytes at `a` and assemble them into a `bits`-wide value. -/
-def Mem.loadBV {w} (m : Mem w) (a : BitVec w) (bits n : Nat) : Option (BitVec bits) :=
-  (loadBytes m a n).map (BitVec.ofBytes bits)
+/-- Read `n` bytes at `a` and assemble them into a `8 * n`-wide value. -/
+def Mem.loadBV {w} (m : Mem w) (a : BitVec w) (n : Nat) : Option (BitVec (8 * n)) :=
+  (loadBytes m a n).map (BitVec.ofBytes (8 * n))
 
 
 -- JP: can't use the Mem abbreviation here because it resolves to List.Mem (the

--- a/Kraken/SeparationMem.lean
+++ b/Kraken/SeparationMem.lean
@@ -96,11 +96,11 @@ theorem storeBytes_sep {w : Nat} (a : BitVec w) (n : Nat) (_bs bs : List UInt8)
   rw [sep_comm]
   exact ⟨m2, bs.At a, rfl, disjoint_symm (disjoint_Atsame_l_same_r _bs bs a m2 h_inter (by omega)), hR, rfl⟩
 
-theorem loadBV_sep {w : Nat} (bs : List UInt8) (a : BitVec w) (bits n : Nat) (R : Mem w → Prop) (m : Mem w)
+theorem loadBV_sep {w : Nat} (bs : List UInt8) (a : BitVec w) (n : Nat) (R : Mem w → Prop) (m : Mem w)
     (Hsep : m =⋆ Eq (bs.At a) ⋆ R)
     (Hl : bs.length = n)
     (Hlw : n ≤ 2 ^ w) :
-    m.loadBV a bits n = some (BitVec.ofBytes bits bs) := by
+    m.loadBV a n = some (BitVec.ofBytes (8 * n) bs) := by
   simp [loadBV, loadBytes_sep bs a n R m Hsep Hl Hlw]
 
 theorem storeBV_sep {w : Nat} (a : BitVec w) (n : Nat) (_bs : List UInt8)

--- a/Kraken/SeparationMem.lean
+++ b/Kraken/SeparationMem.lean
@@ -96,19 +96,19 @@ theorem storeBytes_sep {w : Nat} (a : BitVec w) (n : Nat) (_bs bs : List UInt8)
   rw [sep_comm]
   exact ⟨m2, bs.At a, rfl, disjoint_symm (disjoint_Atsame_l_same_r _bs bs a m2 h_inter (by omega)), hR, rfl⟩
 
-theorem loadInt_sep {w : Nat} (bs : List UInt8) (a : BitVec w) (n : Nat) (R : Mem w → Prop) (m : Mem w)
+theorem loadBV_sep {w : Nat} (bs : List UInt8) (a : BitVec w) (bits n : Nat) (R : Mem w → Prop) (m : Mem w)
     (Hsep : m =⋆ Eq (bs.At a) ⋆ R)
     (Hl : bs.length = n)
     (Hlw : n ≤ 2 ^ w) :
-    m.loadInt a n = some (Int.ofBytes bs) := by
-  simp [loadInt, loadBytes_sep bs a n R m Hsep Hl Hlw]
+    m.loadBV a bits n = some (BitVec.ofBytes bits bs) := by
+  simp [loadBV, loadBytes_sep bs a n R m Hsep Hl Hlw]
 
-theorem storeInt_sep {w : Nat} (a : BitVec w) (n : Nat) (_bs : List UInt8)
+theorem storeBV_sep {w : Nat} (a : BitVec w) (n : Nat) (_bs : List UInt8)
     (R : Mem w → Prop) (m : Mem w)
-    (H : (m =⋆ Eq (_bs.At a) ⋆ R) ∧ _bs.length = n) (v : Int) :
-    m.storeInt a n v =⋆ Eq ((Int.toBytes n v).At a) ⋆ R := by
-  simpa only [storeInt] using
-    storeBytes_sep a n _bs (Int.toBytes n v) R m ⟨H.1, H.2, Int.toBytes_length n v⟩
+    (H : (m =⋆ Eq (_bs.At a) ⋆ R) ∧ _bs.length = n) {bits : Nat} (v : BitVec bits) :
+    m.storeBV a n v =⋆ Eq ((BitVec.toBytes n v).At a) ⋆ R := by
+  simpa only [storeBV] using
+    storeBytes_sep a n _bs (BitVec.toBytes n v) R m ⟨H.1, H.2, BitVec.toBytes_length n v⟩
 
 theorem At_append_sep {w : Nat} (bs1 bs2 : List UInt8) (a : BitVec w)
     (h_len : bs1.length + bs2.length ≤ 2 ^ w) :

--- a/Kraken/SeparationTests.lean
+++ b/Kraken/SeparationTests.lean
@@ -19,12 +19,12 @@ example {w} (A B C D : Mem w → Prop) : A ⋆ (B ⋆ C) ⋆ D = (D ⋆ B) ⋆ (
 example {w} (A B C : Mem w → Prop) (m : Mem w) (h : (A ⋆ (B ⋆ C)) m) : ((C ⋆ A) ⋆ B) m := by ecancel
 
 example (v2 rax rdi : UInt64) (R : Mem 64 → Prop) (mem : Mem 64)
-    (h : (Eq ((Int.toBytes 8 rax.toBitVec.toInt).At rdi.toBitVec) ⋆
+    (h : (Eq ((BitVec.toBytes 8 rax.toBitVec).At rdi.toBitVec) ⋆
       (Eq (v2.At (rdi.toBitVec + 8#64)) ⋆ R))
-      (Mem.storeInt mem rdi.toBitVec 8 rax.toBitVec.toInt)) :
+      (Mem.storeBV mem rdi.toBitVec 8 rax.toBitVec)) :
     (Eq (v2.At (rdi.toBitVec + 8#64)) ⋆
-      (Eq ((Int.toBytes 8 rax.toBitVec.toInt).At rdi.toBitVec) ⋆ R))
-      (Mem.storeInt mem rdi.toBitVec 8 rax.toBitVec.toInt) := by
+      (Eq ((BitVec.toBytes 8 rax.toBitVec).At rdi.toBitVec) ⋆ R))
+      (Mem.storeBV mem rdi.toBitVec 8 rax.toBitVec) := by
   ecancel
 
 example (v : UInt64) (a : BitVec 64) (R : Mem 64 → Prop) :

--- a/Kraken/StdLibCandidates.lean
+++ b/Kraken/StdLibCandidates.lean
@@ -1,0 +1,215 @@
+/-!
+# Standard library candidates
+
+Lemmas that are needed in more than one place in Kraken and that are stated
+generally enough to be (potentially) upstreamed.
+
+See `DEVELOPER.md` for details on the policy.
+-/
+
+namespace BitVec
+
+/-- Reducing a two's-complement value modulo `2 ^ n` is truncation to `n` bits,
+provided `n ≤ m`.
+
+`BitVec.ofInt_toInt` covers `n = m`. The side condition is necessary. For
+`m < n` the left-hand side sign-extends while `setWidth` zero-extends. -/
+theorem ofInt_toInt_setWidth {m n : Nat} (h : n ≤ m) (y : BitVec m) :
+    BitVec.ofInt n y.toInt = y.setWidth n := by
+  have hd : ((2 ^ n : Nat) : Int) ∣ ((2 ^ m : Nat) : Int) :=
+    Int.natCast_dvd_natCast.mpr (Nat.pow_dvd_pow 2 h)
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_ofInt, BitVec.toNat_setWidth, BitVec.toInt_eq_toNat_bmod,
+    ← Int.emod_emod_of_dvd _ hd, Int.bmod_emod, Int.emod_emod_of_dvd _ hd]
+  omega
+
+/-- Reducing an unsigned value modulo `2 ^ n` is truncation to `n` bits. Unlike
+`ofInt_toInt_setWidth` this needs no side condition. Both sides zero-extend when
+`n` exceeds the source width.
+
+The signed counterpart needs no lemma at all, `BitVec.signExtend` is defined
+as `ofInt v x.toInt`. -/
+theorem ofInt_toNat_setWidth {m n : Nat} (y : BitVec m) :
+    BitVec.ofInt n (y.toNat : Int) = y.setWidth n := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_ofInt, BitVec.toNat_setWidth]
+  omega
+
+/-- `BitVec.ofInt` commutes with left shift. Shifting an unbounded integer and
+then reducing gives the same result as reducing first and shifting inside the
+bitvector, because both discard the bits above `w`. -/
+theorem ofInt_shiftLeft {w : Nat} (hw : 0 < w) (i : Int) (n : Nat) :
+    BitVec.ofInt w (i <<< n) = BitVec.ofInt w i <<< n := by
+  have h1 : 1 % 2 ^ w = 1 := Nat.mod_eq_of_lt (Nat.one_lt_two_pow_iff.mpr (by omega))
+  rw [Int.shiftLeft_eq', BitVec.shiftLeft_eq_mul_twoPow, BitVec.ofInt_mul]
+  congr 1
+  rw [BitVec.twoPow_eq]
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_ofInt, BitVec.toNat_shiftLeft, BitVec.toNat_ofNat,
+    Nat.shiftLeft_eq, h1, Nat.one_mul]
+  omega
+
+/-- `BitVec.ofInt` commutes with subtraction. The `add` and `mul` counterparts
+are in core while this one is not. -/
+theorem ofInt_sub {n : Nat} (x y : Int) :
+    BitVec.ofInt n (x - y) = BitVec.ofInt n x - BitVec.ofInt n y := by
+  simp [Int.sub_eq_add_neg, BitVec.ofInt_add, BitVec.sub_eq_add_neg, BitVec.ofInt_neg]
+
+/-- Zero-extending before multiplying loses nothing. The unsigned product fits. -/
+theorem toNat_setWidth_mul_setWidth {w n : Nat} (hn : w + w ≤ n) (a b : BitVec w) :
+    ((a.setWidth n) * (b.setWidth n)).toNat = a.toNat * b.toNat := by
+  have hmono : (2:Nat) ^ (w + w) ≤ 2 ^ n := Nat.pow_le_pow_right (by omega) hn
+  have hw : (2:Nat) ^ w ≤ 2 ^ (w + w) := Nat.pow_le_pow_right (by omega) (by omega)
+  have ha : a.toNat < 2 ^ w := a.isLt
+  have hb : b.toNat < 2 ^ w := b.isLt
+  have hlt : a.toNat * b.toNat < 2 ^ (w + w) := by
+    rw [Nat.pow_add]; exact Nat.mul_lt_mul_of_lt_of_lt ha hb
+  rw [BitVec.toNat_mul, BitVec.toNat_setWidth, BitVec.toNat_setWidth,
+    Nat.mod_eq_of_lt (by omega : a.toNat < 2 ^ n),
+    Nat.mod_eq_of_lt (by omega : b.toNat < 2 ^ n),
+    Nat.mod_eq_of_lt (by omega : a.toNat * b.toNat < 2 ^ n)]
+
+/-- Sign-extending before multiplying loses nothing. The signed product fits.
+
+The bound is not tight -- the signed product of two `w`-bit values is at most
+`2 ^ (2 * w - 2)` in absolute value, which is why the `w + w`-bit result never
+saturates. `w` must be positive for `BitVec w` to have a sign bit at all. -/
+theorem toInt_signExtend_mul_signExtend {w n : Nat} (hw : 0 < w) (hn : w + w ≤ n)
+    (a b : BitVec w) :
+    ((a.signExtend n) * (b.signExtend n)).toInt = a.toInt * b.toInt := by
+  have ha := a.toInt_lt; have ha' := a.le_toInt
+  have hb := b.toInt_lt; have hb' := b.le_toInt
+  have hc1 : ((2 ^ (w - 1) : Nat) : Int) = (2:Int) ^ (w - 1) := by push_cast; rfl
+  have hc2 : ((2 ^ n : Nat) : Int) = (2:Int) ^ n := by push_cast; rfl
+  have hhalf : (2:Nat) ^ (w - 1) * 2 = 2 ^ w := by rw [← Nat.pow_succ]; congr 1; omega
+  have habs : (a.toInt * b.toInt).natAbs ≤ 2 ^ (w - 1) * 2 ^ (w - 1) := by
+    rw [Int.natAbs_mul]; exact Nat.mul_le_mul (by omega) (by omega)
+  have hfit : ((2 ^ (w - 1) * 2 ^ (w - 1) : Nat) : Int) * 2 < ((2 ^ n : Nat) : Int) := by
+    have : (2:Nat) ^ (w - 1) * 2 ^ (w - 1) * 2 < 2 ^ n := by
+      rw [← Nat.pow_add, ← Nat.pow_succ]
+      exact Nat.pow_lt_pow_right (by omega) (by omega)
+    exact_mod_cast this
+  rw [BitVec.toInt_mul, BitVec.toInt_signExtend, BitVec.toInt_signExtend,
+    show min n w = w by omega]
+  rw [Int.bmod_eq_of_le_mul_two (x := a.toInt) (by omega) (by omega),
+    Int.bmod_eq_of_le_mul_two (x := b.toInt) (by omega) (by omega)]
+  rw [Int.bmod_eq_of_le_mul_two (by omega) (by omega)]
+
+/-- The unsigned widening product. -/
+theorem ofInt_mul_toNat {w n : Nat} (hn : w + w ≤ n) (a b : BitVec w) :
+    BitVec.ofInt n ((a.toNat : Int) * (b.toNat : Int))
+      = a.setWidth n * b.setWidth n := by
+  rw [← Int.natCast_mul, ← toNat_setWidth_mul_setWidth hn a b, ofInt_toNat_setWidth,
+    BitVec.setWidth_eq]
+
+/-- The signed widening product. -/
+theorem ofInt_mul_toInt {w n : Nat} (hw : 0 < w) (hn : w + w ≤ n) (a b : BitVec w) :
+    BitVec.ofInt n (a.toInt * b.toInt) = a.signExtend n * b.signExtend n := by
+  rw [← toInt_signExtend_mul_signExtend hw hn, BitVec.ofInt_toInt]
+
+/-- The high half of an unsigned widening product. Shifting the `Int` product
+down by `w` and truncating is the same as slicing bits `w ..< w + w` out of the
+`BitVec` product. -/
+theorem ofInt_shiftRight_mul_toNat {w n : Nat} (hn : w + w ≤ n) (a b : BitVec w) :
+    BitVec.ofInt w (((a.toNat : Int) * (b.toNat : Int)) >>> w)
+      = (a.setWidth n * b.setWidth n).extractLsb' w w := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.extractLsb'_toNat, toNat_setWidth_mul_setWidth hn, ← Int.natCast_mul,
+    ← Int.natCast_shiftRight, BitVec.ofInt_natCast, BitVec.toNat_ofNat]
+
+theorem umulOverflow_iff {w : Nat} (a b : BitVec w) :
+    BitVec.umulOverflow a b = true ↔ (a * b).toNat ≠ a.toNat * b.toNat := by
+  rw [BitVec.toNat_mul]
+  simp only [BitVec.umulOverflow, ge_iff_le, decide_eq_true_eq]
+  have hM : 0 < 2 ^ w := Nat.two_pow_pos w
+  generalize a.toNat * b.toNat = P
+  have hlt := Nat.mod_lt P hM
+  exact ⟨fun h heq => by omega,
+    fun h => Nat.le_of_not_lt (fun hlt2 => h (Nat.mod_eq_of_lt hlt2))⟩
+
+theorem smulOverflow_iff {w : Nat} (hw : 0 < w) (a b : BitVec w) :
+    BitVec.smulOverflow a b = true ↔ (a * b).toInt ≠ a.toInt * b.toInt := by
+  rw [BitVec.toInt_mul]
+  simp only [BitVec.smulOverflow, Bool.or_eq_true, decide_eq_true_eq]
+  generalize a.toInt * b.toInt = P
+  obtain ⟨v, rfl⟩ : ∃ v, w = v + 1 := ⟨w - 1, by omega⟩
+  have hpow : ((2 ^ (v + 1) : Nat) : Int) = 2 * ((2 ^ v : Nat) : Int) := by
+    rw [Nat.pow_succ]; push_cast; omega
+  have hcast : ((2 ^ v : Nat) : Int) = (2:Int) ^ v := by push_cast; rfl
+  rw [Ne, Int.bmod_eq_iff (Nat.two_pow_pos _)]
+  simp only [Nat.add_sub_cancel, Int.sub_self, Int.dvd_zero, and_true]
+  omega
+
+/-- Rotate right by a bitvector amount, expressed with shifts. -/
+def rorBV {w : Nat} (x : BitVec w) (m : BitVec w) : BitVec w :=
+  (x >>> m) ||| (x <<< (BitVec.ofNat w w - m))
+
+/-- Rotate left by a bitvector amount, expressed with shifts. -/
+def rolBV {w : Nat} (x : BitVec w) (m : BitVec w) : BitVec w :=
+  (x <<< m) ||| (x >>> (BitVec.ofNat w w - m))
+
+theorem rolBV_eq_rotateLeft {w : Nat} (x m : BitVec w) (hm : m.toNat < w) :
+    x.rolBV m = x.rotateLeft m.toNat := by
+  have hwlt : w < 2 ^ w := Nat.lt_two_pow_self
+  have hwBV : (BitVec.ofNat w w).toNat = w := by
+    rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt hwlt]
+  have hsub : ((BitVec.ofNat w w) - m).toNat = w - m.toNat := by
+    rw [BitVec.toNat_sub, hwBV]
+    have hm2 := m.isLt
+    rw [show (2 ^ w - m.toNat) + w = 2 ^ w + (w - m.toNat) by omega,
+      Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
+  rw [BitVec.rotateLeft_def, Nat.mod_eq_of_lt hm]
+  show (x <<< m.toNat) ||| (x >>> ((BitVec.ofNat w w) - m).toNat) = _
+  rw [hsub]
+
+theorem rotateLeft_mod {w : Nat} (x : BitVec w) (n : Nat) :
+    x.rotateLeft (n % w) = x.rotateLeft n := by
+  simp [BitVec.rotateLeft_def]
+
+theorem rotateRight_mod {w : Nat} (x : BitVec w) (n : Nat) :
+    x.rotateRight (n % w) = x.rotateRight n := by
+  simp [BitVec.rotateRight_def]
+
+theorem rorBV_eq_rotateRight {w : Nat} (x m : BitVec w) (hm : m.toNat < w) :
+    x.rorBV m = x.rotateRight m.toNat := by
+  have hwlt : w < 2 ^ w := Nat.lt_two_pow_self
+  have hwBV : (BitVec.ofNat w w).toNat = w := by
+    rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt hwlt]
+  have hsub : ((BitVec.ofNat w w) - m).toNat = w - m.toNat := by
+    rw [BitVec.toNat_sub, hwBV]
+    have hm2 := m.isLt
+    rw [show (2 ^ w - m.toNat) + w = 2 ^ w + (w - m.toNat) by omega,
+      Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
+  rw [BitVec.rotateRight_def, Nat.mod_eq_of_lt hm]
+  show (x >>> m.toNat) ||| (x <<< ((BitVec.ofNat w w) - m).toNat) = _
+  rw [hsub]
+
+end BitVec
+
+namespace Int64
+
+/-- `Int64.toInt` is by definition its bitvector's `toInt`, so reducing it
+modulo `2 ^ n` is truncation of that bitvector. -/
+theorem ofInt_toInt_setWidth {n : Nat} (h : n ≤ 64) (x : Int64) :
+    BitVec.ofInt n x.toInt = x.toBitVec.setWidth n :=
+  BitVec.ofInt_toInt_setWidth h x.toBitVec
+
+/-- At the full width there is nothing to truncate. -/
+theorem ofInt_toInt_eq_toBitVec (x : Int64) :
+    BitVec.ofInt 64 x.toInt = x.toBitVec :=
+  BitVec.ofInt_toInt
+
+/-- Reconstructing an `Int64` from the signed value of a 64-bit bitvector gives
+that bitvector back. -/
+theorem ofInt_toInt_eq_ofBitVec (y : BitVec 64) :
+    Int64.ofInt y.toInt = Int64.ofBitVec y := by
+  simp [Int64.ofInt, Int64.ofBitVec, BitVec.ofInt_toInt]
+
+/-- Adding two `Int64`s over `Int` and truncating is `Int64` addition, which
+wraps. -/
+theorem ofInt_add_toInt (x y : Int64) :
+    BitVec.ofInt 64 (x.toInt + y.toInt) = (x + y).toBitVec := by
+  rw [BitVec.ofInt_add, ofInt_toInt_eq_toBitVec, ofInt_toInt_eq_toBitVec,
+    Int64.toBitVec_add]
+
+end Int64

--- a/Kraken/StdLibCandidates.lean
+++ b/Kraken/StdLibCandidates.lean
@@ -31,9 +31,7 @@ The signed counterpart needs no lemma at all, `BitVec.signExtend` is defined
 as `ofInt v x.toInt`. -/
 theorem ofInt_toNat_setWidth {m n : Nat} (y : BitVec m) :
     BitVec.ofInt n (y.toNat : Int) = y.setWidth n := by
-  apply BitVec.eq_of_toNat_eq
-  rw [BitVec.toNat_ofInt, BitVec.toNat_setWidth]
-  omega
+  simp
 
 /-- `BitVec.ofInt` commutes with left shift. Shifting an unbounded integer and
 then reducing gives the same result as reducing first and shifting inside the
@@ -150,17 +148,14 @@ def rolBV {w : Nat} (x : BitVec w) (m : BitVec w) : BitVec w :=
 
 theorem rolBV_eq_rotateLeft {w : Nat} (x m : BitVec w) (hm : m.toNat < w) :
     x.rolBV m = x.rotateLeft m.toNat := by
-  have hwlt : w < 2 ^ w := Nat.lt_two_pow_self
   have hwBV : (BitVec.ofNat w w).toNat = w := by
-    rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt hwlt]
+    rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt Nat.lt_two_pow_self]
   have hsub : ((BitVec.ofNat w w) - m).toNat = w - m.toNat := by
     rw [BitVec.toNat_sub, hwBV]
     have hm2 := m.isLt
     rw [show (2 ^ w - m.toNat) + w = 2 ^ w + (w - m.toNat) by omega,
       Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
-  rw [BitVec.rotateLeft_def, Nat.mod_eq_of_lt hm]
-  show (x <<< m.toNat) ||| (x >>> ((BitVec.ofNat w w) - m).toNat) = _
-  rw [hsub]
+  simp [rolBV, BitVec.rotateLeft_def, Nat.mod_eq_of_lt hm, hsub]
 
 theorem rotateLeft_mod {w : Nat} (x : BitVec w) (n : Nat) :
     x.rotateLeft (n % w) = x.rotateLeft n := by
@@ -172,17 +167,14 @@ theorem rotateRight_mod {w : Nat} (x : BitVec w) (n : Nat) :
 
 theorem rorBV_eq_rotateRight {w : Nat} (x m : BitVec w) (hm : m.toNat < w) :
     x.rorBV m = x.rotateRight m.toNat := by
-  have hwlt : w < 2 ^ w := Nat.lt_two_pow_self
   have hwBV : (BitVec.ofNat w w).toNat = w := by
-    rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt hwlt]
+    rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt Nat.lt_two_pow_self]
   have hsub : ((BitVec.ofNat w w) - m).toNat = w - m.toNat := by
     rw [BitVec.toNat_sub, hwBV]
     have hm2 := m.isLt
     rw [show (2 ^ w - m.toNat) + w = 2 ^ w + (w - m.toNat) by omega,
       Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
-  rw [BitVec.rotateRight_def, Nat.mod_eq_of_lt hm]
-  show (x >>> m.toNat) ||| (x <<< ((BitVec.ofNat w w) - m).toNat) = _
-  rw [hsub]
+  simp [rorBV, BitVec.rotateRight_def, Nat.mod_eq_of_lt hm, hsub]
 
 end BitVec
 

--- a/Kraken/ToBytes.lean
+++ b/Kraken/ToBytes.lean
@@ -6,6 +6,43 @@ instance : Coe UInt16 (BitVec 16) := ⟨UInt16.toBitVec⟩
 instance : Coe UInt32 (BitVec 32) := ⟨UInt32.toBitVec⟩
 instance : Coe UInt64 (BitVec 64) := ⟨UInt64.toBitVec⟩
 
+def BitVec.toBytes {w} (n : Nat) (v : BitVec w) : List UInt8 :=
+  match n with
+  | 0 => []
+  | n' + 1 => UInt8.ofBitVec (v.setWidth 8) :: BitVec.toBytes n' (v >>> 8)
+
+def BitVec.ofBytes (w : Nat) (bs : List UInt8) : BitVec w :=
+  match bs with
+  | [] => 0#w
+  | b :: bs' => (BitVec.ofBytes w bs' <<< 8) ||| b.toBitVec.setWidth w
+
+@[simp] theorem BitVec.toBytes_length {w} (n : Nat) (v : BitVec w) :
+    (BitVec.toBytes n v).length = n := by
+  induction n generalizing v <;> simp [BitVec.toBytes, *]
+
+theorem BitVec.getLsbD_ofBytes_toBytes {w} (n : Nat) (v : BitVec w) (i : Nat) :
+    (BitVec.ofBytes w (BitVec.toBytes n v)).getLsbD i = (decide (i < 8 * n) && v.getLsbD i) := by
+  induction n generalizing v i with
+  | zero => simp [BitVec.toBytes, BitVec.ofBytes]
+  | succ n ih =>
+    simp only [BitVec.toBytes, BitVec.ofBytes, BitVec.getLsbD_or, BitVec.getLsbD_shiftLeft,
+      BitVec.getLsbD_setWidth, ih, BitVec.getLsbD_ushiftRight]
+    by_cases hw : i < w
+    · by_cases h : i < 8
+      · simp [h, hw, show i < 8 * (n + 1) by omega]
+      · simp [h, hw, show 8 + (i - 8) = i by omega, show (i - 8 < 8 * n) = (i < 8 * (n + 1)) by
+          simp; omega]
+    · rw [BitVec.getLsbD_of_ge v i (by omega)]
+      by_cases h : i < 8 <;>
+        simp [h, hw, BitVec.getLsbD_of_ge v (8 + (i - 8)) (by omega)]
+
+@[simp] theorem BitVec.ofBytes_toBytes (w n : Nat) (h : w = 8 * n) (v : BitVec w) :
+    BitVec.ofBytes w (BitVec.toBytes n v) = v := by
+  rw [BitVec.eq_of_getLsbD_eq_iff]
+  intro i hi
+  rw [BitVec.getLsbD_ofBytes_toBytes]
+  simp [show i < 8 * n by omega]
+
 def Int.ofBytes (bs : List UInt8) : Int :=
   bs.foldr (fun b acc => acc * 256 + b.toNat) 0
 
@@ -102,7 +139,7 @@ private theorem pow_256_eq_pow_2 (n : Nat) (w : Nat) (h : w = 8 * n) : (256 : In
 
 theorem BitVec.ofInt_ofBytes_toBytes (w : Nat) (n : Nat) (h_wn : w = 8 * n) (val : BitVec w) :
     BitVec.ofInt w (Int.ofBytes (Int.toBytes n val.toInt)) = val := by
-  rw [ofBytes_toBytes, show 8 * n = w from h_wn.symm, Int.take, BitVec.ofInt_emod_self]
+  rw [_root_.ofBytes_toBytes, show 8 * n = w from h_wn.symm, Int.take, BitVec.ofInt_emod_self]
   exact BitVec.ofInt_toInt
 
 theorem Int.ofBytes_ge_zero (bs : List UInt8) : 0 <= Int.ofBytes bs := by
@@ -352,3 +389,30 @@ theorem UInt64.ofBytes_toBytes (val : UInt64) : UInt64.ofBytes val.toBytes = val
 
 theorem UInt64.toBytes_ofBytes (bs : List UInt8) (h : 8 ≤ bs.length) : (UInt64.ofBytes bs).toBytes = bs.take 8 := by
   exact BitVec.toBytes_ofBytes 64 8 rfl bs h
+
+theorem BitVec.ofBytes_eq_ofInt_ofBytes (w : Nat) (bs : List UInt8) :
+    BitVec.ofBytes w bs = BitVec.ofInt w (Int.ofBytes bs) := by
+  induction bs with
+  | nil => simp [BitVec.ofBytes, Int.ofBytes]
+  | cons b bs ih =>
+    rw [BitVec.ofBytes, ih, Int.ofBytes_cons, BitVec.ofInt_add, BitVec.ofInt_mul]
+    have hb : (BitVec.ofInt w (b.toNat : Int)) = b.toBitVec.setWidth w := by
+      apply BitVec.eq_of_toNat_eq
+      simp [BitVec.toNat_setWidth]
+    rw [hb]
+    have hshift : BitVec.ofInt w (Int.ofBytes bs) * BitVec.ofInt w 256
+        = BitVec.ofInt w (Int.ofBytes bs) <<< 8 := by
+      rw [BitVec.shiftLeft_eq_mul_twoPow]
+      congr 1
+      apply BitVec.eq_of_toNat_eq
+      simp
+    rw [hshift]
+    -- the low 8 bits of the shifted value are zero, so `+` and `|||` agree
+    rw [BitVec.add_eq_or_of_and_eq_zero]
+    apply BitVec.eq_of_getLsbD_eq
+    intro i
+    simp only [BitVec.getLsbD_and, BitVec.getLsbD_shiftLeft, BitVec.getLsbD_setWidth,
+      BitVec.getLsbD_zero]
+    by_cases h : (i : Nat) < 8
+    · simp [h]
+    · simp [h, BitVec.getLsbD_of_ge b.toBitVec i (by omega)]

--- a/Kraken/X64/Examples/Examples.lean
+++ b/Kraken/X64/Examples/Examples.lean
@@ -263,12 +263,12 @@ theorem p6_correct [layout : Layout] (s₀ : MachineData)
   apply step_cps
   kprologue p6 with s₀
   have h_bs : stack.length = 8 := h_len
-  have h_mem1 := Mem.storeInt_sep (rsp.toBitVec - 8#64) 8 stack R mem ⟨h_mem, h_bs⟩ rax.toBitVec.toInt
+  have h_mem1 := Mem.storeBV_sep (rsp.toBitVec - 8#64) 8 stack R mem ⟨h_mem, h_bs⟩ rax.toBitVec
   sym =>
   kstep
   tactic =>
   apply Eventually.done
-  rw [BitVec.ofInt_ofBytes_toBytes 64 8 rfl]
+  rw [BitVec.ofBytes_toBytes 64 8 rfl]
   bv_decide
 
 -- def bigp := parseFile("./ecc-secp521r1-modp.S")
@@ -322,11 +322,11 @@ theorem move_2_regs_to_heap_correct [layout : Layout] (s₀ : MachineData)
 
   have h_bs1 : v1.toBytes.length = 8 := UInt64.toBytes_length v1
   have h_bs2 : v2.toBytes.length = 8 := UInt64.toBytes_length v2
-  have h_mem1 := Mem.storeInt_sep rdi.toBitVec 8 v1.toBytes (Eq (v2.At (rdi.toBitVec + 8#64)) ⋆ R) mem ⟨by ecancel, h_bs1⟩ rax.toBitVec.toInt
-  have h_mem1' : (Eq (v2.At (rdi.toBitVec + 8#64)) ⋆ (Eq ((Int.toBytes 8 rax.toBitVec.toInt).At rdi) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem1
-  have h_mem2 := Mem.storeInt_sep (rdi.toBitVec + 8#64) 8 v2.toBytes _ _ ⟨h_mem1', h_bs2⟩ rcx.toBitVec.toInt
-  have h_mem2' : (Eq ((Int.toBytes 8 rax.toBitVec.toInt).At rdi) ⋆ (Eq ((Int.toBytes 8 rcx.toBitVec.toInt).At (rdi.toBitVec + 8#64)) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem2
-  have h_mem2'' : (Eq ((Int.toBytes 8 rcx.toBitVec.toInt).At (rdi.toBitVec + 8#64)) ⋆ (Eq ((Int.toBytes 8 rax.toBitVec.toInt).At rdi.toBitVec) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem2'
+  have h_mem1 := Mem.storeBV_sep rdi.toBitVec 8 v1.toBytes (Eq (v2.At (rdi.toBitVec + 8#64)) ⋆ R) mem ⟨by ecancel, h_bs1⟩ rax.toBitVec
+  have h_mem1' : (Eq (v2.At (rdi.toBitVec + 8#64)) ⋆ (Eq ((BitVec.toBytes 8 rax.toBitVec).At rdi) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem1
+  have h_mem2 := Mem.storeBV_sep (rdi.toBitVec + 8#64) 8 v2.toBytes _ _ ⟨h_mem1', h_bs2⟩ rcx.toBitVec
+  have h_mem2' : (Eq ((BitVec.toBytes 8 rax.toBitVec).At rdi) ⋆ (Eq ((BitVec.toBytes 8 rcx.toBitVec).At (rdi.toBitVec + 8#64)) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem2
+  have h_mem2'' : (Eq ((BitVec.toBytes 8 rcx.toBitVec).At (rdi.toBitVec + 8#64)) ⋆ (Eq ((BitVec.toBytes 8 rax.toBitVec).At rdi.toBitVec) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem2'
   simp at h_mem
   sym =>
   -- TODO: these would be prime examples for cancellation!
@@ -347,7 +347,7 @@ theorem move_2_regs_to_heap_correct [layout : Layout] (s₀ : MachineData)
   kstep
   tactic =>
   apply Eventually.done
-  rw [BitVec.ofInt_ofBytes_toBytes 64 8 rfl, BitVec.ofInt_ofBytes_toBytes 64 8 rfl]
+  rw [BitVec.ofBytes_toBytes 64 8 rfl, BitVec.ofBytes_toBytes 64 8 rfl]
   exact ⟨rfl, rfl, rfl⟩
 
 def sib_example := parse("
@@ -357,11 +357,9 @@ def sib_example := parse("
     movq (%rdi, %r15, 8), %rax
 ")
 
--- FIXME: I had to replace `s₀.regs.r15.toBitVec * 8#64` with `BitVec.ofInt 64
--- (s₀.regs.r15.toBitVec.toInt * 8)` to make the example go through. Why?
 theorem sib_example_correct [layout : Layout] (s₀ : MachineData)
     (v : UInt64) (R : DataMem → Prop)
-    (h_mem : s₀.dmem =⋆ Eq (v.At (s₀.regs.rdi.toBitVec + BitVec.ofInt 64 (s₀.regs.r15.toBitVec.toInt * 8))) ⋆ R) :
+    (h_mem : s₀.dmem =⋆ Eq (v.At (s₀.regs.rdi.toBitVec + s₀.regs.r15.toBitVec * 8#64)) ⋆ R) :
     Eventually (straightlineStep (layout sib_example))
       (fun s' => s'.1.regs.rax = 42)
       (s₀, layout.start) := by
@@ -369,7 +367,7 @@ theorem sib_example_correct [layout : Layout] (s₀ : MachineData)
   kprologue sib_example with s₀
   have h_bs : v.toBytes.length = 8 := UInt64.toBytes_length v
   simp at h_mem
-  have h_mem' := Mem.storeInt_sep (rdi.toBitVec + BitVec.ofInt 64 (r15.toBitVec.toInt * 8)) 8 v.toBytes R mem ⟨h_mem, h_bs⟩ 42
+  have h_mem' := Mem.storeBV_sep (rdi.toBitVec + r15.toBitVec * 8#64) 8 v.toBytes R mem ⟨h_mem, h_bs⟩ 42#64
   sym =>
   kstep
   case h_mem => tactic => simp; exact h_mem
@@ -398,21 +396,19 @@ theorem alu_mem_example_correct [layout : Layout] (s₀ : MachineData)
   apply step_cps
   kprologue alu_mem_example with s₀
   have h_bs : v.toBytes.length = 8 := UInt64.toBytes_length v
-  have h_mem1 := Mem.storeInt_sep (rdx.toBitVec + 136#64) 8 v.toBytes R mem ⟨h_mem, h_bs⟩ 42
+  have h_mem1 := Mem.storeBV_sep (rdx.toBitVec + 136#64) 8 v.toBytes R mem ⟨h_mem, h_bs⟩ 42#64
   sym =>
   kstep
   case h_mem => tactic => simp; exact h_mem
   case h_len => exact h_bs
   kstep
   case h_mem => tactic => simp; exact h_mem1
-  case h_len => exact Int.toBytes_length 8 _
+  case h_len => exact BitVec.toBytes_length 8 _
   kstep
   tactic =>
   apply Eventually.done
-  dsimp [UInt64.toBitVec]
-  change (100 : UInt64) + { toBitVec := BitVec.ofInt 64 (Int.ofBytes (Int.toBytes 8 (42#64).toInt)) } = (142 : UInt64)
-  rw [BitVec.ofInt_ofBytes_toBytes 64 8 rfl]
-  rfl
+  simp (config := { zetaDelta := true }) only [BitVec.ofBytes_toBytes 64 8 rfl]
+  bv_decide
 
 def dynamic_stack_example := parse("
     movq $99, -8(%rsp)
@@ -457,8 +453,7 @@ theorem dynamic_stack_example_correct [layout : Layout] (s₀ : MachineData)
     bv_decide
   rw [h_addr_eq] at h_mem
   replace h_mem : (Eq ((stack.drop 1016).At (rsp.toBitVec + BitVec.ofNat 64 (2^64 - 8))) ⋆ (Eq ((stack.take 1016).At (rsp.toBitVec - 1024#64)) ⋆ R)) _ := cast (congrFun (by ac_rfl) _) h_mem
-  have h_mem1 := Mem.storeInt_sep (rsp.toBitVec + BitVec.ofNat 64 (2^64 - 8)) 8 (stack.drop 1016) (Eq ((stack.take 1016).At (rsp.toBitVec - 1024#64)) ⋆ R) mem ⟨h_mem, h_len_drop⟩ 99
-
+  have h_mem1 := Mem.storeBV_sep (rsp.toBitVec + BitVec.ofNat 64 (2^64 - 8)) 8 (stack.drop 1016) (Eq ((stack.take 1016).At (rsp.toBitVec - 1024#64)) ⋆ R) mem ⟨h_mem, h_len_drop⟩ 99#64
   sym =>
   kstep
   case h_mem => tactic => simp; exact h_mem

--- a/Kraken/X64/Examples/Examples.lean
+++ b/Kraken/X64/Examples/Examples.lean
@@ -347,8 +347,7 @@ theorem move_2_regs_to_heap_correct [layout : Layout] (s₀ : MachineData)
   kstep
   tactic =>
   apply Eventually.done
-  rw [BitVec.ofBytes_toBytes 64 8 rfl, BitVec.ofBytes_toBytes 64 8 rfl]
-  exact ⟨rfl, rfl, rfl⟩
+  simp
 
 def sib_example := parse("
     movq $42, %rax
@@ -372,9 +371,6 @@ theorem sib_example_correct [layout : Layout] (s₀ : MachineData)
   kstep
   case h_mem => tactic => simp; exact h_mem
   case h_len => exact h_bs
-  kstep
-  case h_mem => tactic => simp; exact h_mem'
-  case h_len => exact by decide
   kstep
   tactic =>
   apply Eventually.done
@@ -407,8 +403,7 @@ theorem alu_mem_example_correct [layout : Layout] (s₀ : MachineData)
   kstep
   tactic =>
   apply Eventually.done
-  simp (config := { zetaDelta := true }) only [BitVec.ofBytes_toBytes 64 8 rfl]
-  bv_decide
+  rfl
 
 def dynamic_stack_example := parse("
     movq $99, -8(%rsp)

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -48,7 +48,7 @@ structure Reg64s where
   r13 : UInt64 := 0
   r14 : UInt64 := 0
   r15 : UInt64 := 0
-  deriving Repr, BEq, DecidableEq, Hashable, Hashable, Lean.ToExpr
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 @[kstep] def Reg64s.get64 (s : Reg64s) (r : Reg64) : Width.W64.type := UInt64.toBitVec (match r with
   | .rax => s.rax | .rbx => s.rbx | .rcx => s.rcx | .rdx => s.rdx
@@ -80,7 +80,7 @@ structure Reg64s where
     s.set64 r.base (old.replaceLow (BitVec.append v (s.get (.low r.base .W8))))
 
 def ZmmValue : Type := BitVec 512
-  deriving Repr, BEq, DecidableEq, Hashable, Hashable, Lean.ToExpr
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 def zmmZero : ZmmValue := 0#512
 
@@ -117,7 +117,7 @@ structure RegZmms where
   zmm29 : ZmmValue := zmmZero
   zmm30 : ZmmValue := zmmZero
   zmm31 : ZmmValue := zmmZero
-  deriving Repr, BEq, DecidableEq, Hashable, Hashable, Lean.ToExpr
+  deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr
 
 def RegZmms.get512 (s : RegZmms) (r : RegMm) : AvxWidth.W512.type := (match r with
   | .mm0  => s.zmm0  | .mm1  => s.zmm1  | .mm2  => s.zmm2  | .mm3  => s.zmm3
@@ -614,86 +614,86 @@ set_option maxHeartbeats 1000000
     s.set dst v p next)
   | .shl dst count =>
     dst.interp s p (fun a s =>
-    let count := count.interpMasked s p w
-    if count == 0 then next s else
+    let count := count.interpMaskedBV s p w
+    if count == 0#8 then next s else
     let v := a <<< count
     undefined (λ af =>
-    (λ setcf => if count < w.bits then setcf (a <<< (count-1)).msb else undefined setcf) (λ cf =>
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
+    (λ setcf => if count < w.bitsv then setcf (a <<< (count - 1#8)).msb else undefined setcf) (λ cf =>
+    (λ setof => if count == 1#8 then setof (v.msb != a.msb) else undefined setof) (λ of =>
     { s with status := .from_result v { s.status with cf, af, of } }.set dst v p next))))
   | .shr dst count =>
     dst.interp s p (fun a s =>
-    let count := count.interpMasked s p w
-    if count == 0 then next s else
-    let v := a.ushiftRight count
+    let count := count.interpMaskedBV s p w
+    if count == 0#8 then next s else
+    let v := a >>> count
     undefined (λ af =>
-    (λ setcf => if count < w.bits then setcf (a.getLsbD (count-1)) else undefined setcf) (λ cf =>
-    (λ setof => if count == 1 then setof a.msb else undefined setof) (λ of =>
+    (λ setcf => if count < w.bitsv then setcf ((a >>> (count - 1#8)).getLsbD 0) else undefined setcf) (λ cf =>
+    (λ setof => if count == 1#8 then setof a.msb else undefined setof) (λ of =>
     { s with status := .from_result v { s.status with cf, af, of } }.set dst v p next))))
   | .sar dst count =>
     dst.interp s p (fun a s =>
-    let count := count.interpMasked s p w
-    if count == 0 then next s else
-    let v := a.sshiftRight count
+    let count := count.interpMaskedBV s p w
+    if count == 0#8 then next s else
+    let v := a.sshiftRight' count
     undefined (λ af =>
-    (λ setcf => if count < w.bits then setcf (a.getLsbD (count-1)) else undefined setcf) (λ cf =>
-    (λ setof => if count == 1 then setof false else undefined setof) (λ of =>
+    (λ setcf => if count < w.bitsv then setcf ((a >>> (count - 1#8)).getLsbD 0) else undefined setcf) (λ cf =>
+    (λ setof => if count == 1#8 then setof false else undefined setof) (λ of =>
     { s with status := .from_result v { s.status with cf, af, of } }.set dst v p next))))
   | .shrd dst src count =>
     dst.interp s p (fun a s =>
     src.interp s p (fun b s =>
-    let count := count.interpMasked s p w
-    if count == 0 then next s else
+    let count := count.interpMaskedBV s p w
+    if count == 0#8 then next s else
     let v := (((b.append a) >>> count).take w.bits).setWidth _
-    (λ setstatus => if count >= w.bits then undefined setstatus else
-      let cf := a.getLsbD (count-1)
+    (λ setstatus => if count >= w.bitsv then undefined setstatus else
+      let cf := (a >>> (count - 1#8)).getLsbD 0
       undefined (λ af =>
-      (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
+      (λ setof => if count == 1#8 then setof (v.msb != a.msb) else undefined setof) (λ of =>
       setstatus (.from_result v { cf, af, of})))) (λ status =>
     { s with status }.set dst v p next)))
   | .shld dst src count =>
     dst.interp s p (fun a s =>
     src.interp s p (fun b s =>
-    let count := count.interpMasked s p w
-    if count == 0 then next s else
+    let count := count.interpMaskedBV s p w
+    if count == 0#8 then next s else
     let v := (((a.append b) <<< count).drop w.bits).setWidth _
-    (λ setstatus => if count >= w.bits then undefined setstatus else
-      let cf := (a <<< (count-1)).msb
+    (λ setstatus => if count >= w.bitsv then undefined setstatus else
+      let cf := (a <<< (count - 1#8)).msb
       undefined (λ af =>
-      (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
+      (λ setof => if count == 1#8 then setof (v.msb != a.msb) else undefined setof) (λ of =>
       setstatus (.from_result v { cf, af, of})))) (λ status =>
     { s with status }.set dst v p next)))
   | .rol dst rotcount =>
     dst.interp s p (fun a s =>
-    let count := rotcount.interpMasked s p w
-    if count == 0 then next s else
+    let count := rotcount.interpMaskedBV s p w
+    if count == 0#8 then next s else
     let v := a.rolBV (rotcount.interpRotate s p w)
     let cf := v.getLsbD 0
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
+    (λ setof => if count == 1#8 then setof (v.msb != a.msb) else undefined setof) (λ of =>
     { s with status := { s.status with cf, of } }.set dst v p next))
   | .ror dst rotcount =>
     dst.interp s p (fun a s =>
-    let count := rotcount.interpMasked s p w
-    if count == 0 then next s else
+    let count := rotcount.interpMaskedBV s p w
+    if count == 0#8 then next s else
     let v := a.rorBV (rotcount.interpRotate s p w)
     let cf := v.msb
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
+    (λ setof => if count == 1#8 then setof (v.msb != a.msb) else undefined setof) (λ of =>
     { s with status := { s.status with cf, of } }.set dst v p next))
   | .rcr dst rotcount =>
     dst.interp s p (fun a s =>
-    let count := rotcount.interpMasked s p w
-    if count == 0 then next s else
+    let count := rotcount.interpMaskedBV s p w
+    if count == 0#8 then next s else
     let t := (BitVec.ofBool s.status.cf ++ a).rorBV (rotcount.interpRotateCarry s p w)
     let (cf, v) := (t.msb, t.take w.bits)
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
+    (λ setof => if count == 1#8 then setof (v.msb != a.msb) else undefined setof) (λ of =>
     { s with status := { s.status with cf, of } }.set dst v p next))
   | .rcl dst rotcount =>
     dst.interp s p (fun a s =>
-    let count := rotcount.interpMasked s p w
-    if count == 0 then next s else
+    let count := rotcount.interpMaskedBV s p w
+    if count == 0#8 then next s else
     let t := (BitVec.ofBool s.status.cf ++ a).rolBV (rotcount.interpRotateCarry s p w)
     let (cf, v) := (t.msb, t.take w.bits)
-    (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
+    (λ setof => if count == 1#8 then setof (v.msb != a.msb) else undefined setof) (λ of =>
     { s with status := { s.status with cf, of } }.set dst v p next))
   | .bswap dst =>
     let a := s.regs.get dst

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -2,29 +2,15 @@
 -- which itself is just extracted from https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html
 
 import Kraken.Attribute
+import Kraken.BitVec
+import Kraken.Flags
 import Kraken.Layout
 import Kraken.Mem
 import Kraken.X64.Syntax
 import Lean
 import Std
 
--- injective coercions only
-attribute [-instance] BitVec.instNatCast
-attribute [-instance] BitVec.instIntCast
-instance : Coe Bool Nat where coe := Bool.toNat
-
-namespace BitVec
-def unsigned {w} (x : BitVec w) : Int := x.toNat
-def signed {w} (x : BitVec w) : Int := x.toInt
-@[kstep] def take {w} (x : BitVec w) (n : Nat) : BitVec n := x.extractLsb' 0 n
-@[kstep] def drop {w} (x : BitVec w) (n : Nat) : BitVec (w - n) := x.extractLsb' n (w-n)
-end BitVec
-attribute [kstep]
-  BitVec.extractLsb'
-  BitVec.ofInt_add
-  BitVec.ofInt_toInt
-  BitVec.signed
-  BitVec.truncate
+attribute [kstep] BitVec.extractLsb'
 def BitVec.replaceLow {w n} (old : BitVec w) (new : BitVec n) : BitVec w :=
   (BitVec.append (old.drop n) new).setWidth _
 
@@ -280,14 +266,13 @@ def MachineData.load
   (s : MachineData) (addr : BitVec 64) (w : Width)
   (ret : w.type → MachineData → Effects): Effects :=
   require_read_access addr w (fun _unit =>
-    match Mem.loadInt s.dmem addr w.bytes with
-    | .some i => ret (.ofInt _ i) s
+    match Mem.loadBV s.dmem addr w.bits w.bytes with
+    | .some v => ret v s
     | .none => nonmem_load s.dmem addr w (fun v dmem => ret v { s with dmem }))
 
--- Alternatively, we could define this in terms of BitVecs without %:
--- (addr &&& BitVec.ofNat 64 (bytes - 1)) == 0#64
+-- `bytes` is always a power of two, so alignment is a bit mask test.
 def isAligned (bytes : Nat) (addr : BitVec 64) : Bool :=
-  addr.toNat % bytes == 0
+  addr &&& BitVec.ofNat 64 (bytes - 1) == 0#64
 
 -- Legacy SSE instructions are generally stricter about alignment requirements,
 -- while AVX (VEX-encoded) instructions can mostly deal with unaligned
@@ -300,15 +285,15 @@ def MachineData.loadAvx
     .gp_unaligned addr w.bytes
   else
     require_read_access addr .W64 (fun _unit =>
-  match Mem.loadInt s.dmem addr w.bytes with
-      | .some i => ret (.ofInt _ i) s
+  match Mem.loadBV s.dmem addr w.bits w.bytes with
+      | .some v => ret v s
       | .none => unimplemented "AVX nonmem load not supported")
 
 def MachineData.store (s : MachineData) (addr : BitVec 64) {w : Width} (v : w.type) (ret: MachineData → Effects) : Effects :=
   require_write_access addr w (fun _unit =>
-    match Mem.loadInt s.dmem addr w.bytes with
+    match Mem.loadBytes s.dmem addr w.bytes with
     | .some _ =>
-        ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
+        ret { s with dmem := Mem.storeBV s.dmem addr w.bytes v }
     | .none => nonmem_store s.dmem addr v (fun dmem' => ret { s with dmem := dmem' }))
 
 def MachineData.storeAvx (s : MachineData) (addr : BitVec 64) {w : AvxWidth} (v : w.type) (ret: MachineData → Effects) (checkAlign : Bool := false) : Effects :=
@@ -316,9 +301,9 @@ def MachineData.storeAvx (s : MachineData) (addr : BitVec 64) {w : AvxWidth} (v 
     .gp_unaligned addr w.bytes
   else
     require_write_access addr .W64 (fun _unit =>
-  match Mem.loadInt s.dmem addr w.bytes with
+  match Mem.loadBytes s.dmem addr w.bytes with
       | .some _ =>
-          ret { s with dmem := Mem.storeInt s.dmem addr w.bytes v.toInt }
+          ret { s with dmem := Mem.storeBV s.dmem addr w.bytes v }
       | .none => unimplemented "AVX nonmem store not supported")
 
 class Labels where label : Label → Int64
@@ -332,15 +317,16 @@ export Labels (label)
   | .add e1 e2, p => e1.interp p + e2.interp p
   | .sub e1 e2, p => e1.interp p - e2.interp p
 
-@[kstep] def AddrExpr.interp [Labels] [address_size : AddressSize] (a : AddrExpr) (s : Reg64s) (p : Std.Rco Int64) :=
+@[kstep] def AddrExpr.interp [Labels] [address_size : AddressSize] (a : AddrExpr) (s : Reg64s) (p : Std.Rco Int64) :
+    BitVec address_size.address_size.bits :=
   let base := match a.base with
-              | .some (.reg r) => (s.get64 r).toAddressSize.signed
-              | .some .rip => p.upper.toInt
+              | .some (.reg r) => (s.get64 r).toAddressSize
+              | .some .rip => p.upper.toBitVec.toAddressSize
               | .none => 0
   let idx := match a.idx with
-             | .some ⟨r, c⟩ => (s.get64 r).toAddressSize.signed * c.bytes
+             | .some ⟨r, c⟩ => (s.get64 r).toAddressSize * BitVec.ofNat _ c.bytes
              | .none => 0
-  BitVec.ofInt address_size.address_size.bits (base + idx + (a.disp.interp p).toInt)
+  base + idx + (a.disp.interp p).toBitVec.toAddressSize
 
 @[kstep] def RegOrMem.interp {w} [Labels] [AddressSize]
   (o : RegOrMem w) (s : MachineData) (p : Std.Rco Int64)
@@ -405,8 +391,24 @@ def CondCode.interp (cc : CondCode) (s : StatusFlags) : Bool := match cc with
 @[kstep] def ShiftCountExpr.interp [Labels] (c : ShiftCountExpr) (s : MachineData) (p : Std.Rco Int64) := match c with
   | .cl => s.regs.rcx.toBitVec.take 8
   | .imm8 v => (v.interp p).toBitVec.take _
+
+@[kstep] def ShiftCountExpr.interpMaskedBV [Labels] (c : ShiftCountExpr) (s : MachineData)
+    (p : Std.Rco Int64) (w : Width) : BitVec 8 :=
+  (c.interp s p) &&& (match w with | .W64 => 0x3f#8 | _ => 0x1f#8)
+
 @[kstep] def ShiftCountExpr.interpMasked [Labels] (c : ShiftCountExpr) (s : MachineData) (p : Std.Rco Int64) (w : Width) : Nat :=
-  (c.interp s p).toNat &&& match w with | .W64 => 0x3f | _ => 0x1f -- "masked to 5 bits (or 6 bits with a 64-bit operand)"
+  (c.interpMaskedBV s p w).toNat
+
+/-- The rotate amount for `rol`/`ror`, reduced modulo the operand width. -/
+@[kstep] def ShiftCountExpr.interpRotate [Labels] (c : ShiftCountExpr) (s : MachineData)
+    (p : Std.Rco Int64) (w : Width) : BitVec w.bits :=
+  (c.interpMaskedBV s p w).setWidth w.bits &&& BitVec.ofNat w.bits (w.bits - 1)
+
+/-- The rotate amount for `rcl`/`rcr`, reduced modulo `1 + w.bits`. -/
+@[kstep] def ShiftCountExpr.interpRotateCarry [Labels] (c : ShiftCountExpr) (s : MachineData)
+    (p : Std.Rco Int64) (w : Width) : BitVec (1 + w.bits) :=
+  (c.interpMaskedBV s p w).setWidth (1 + w.bits) % BitVec.ofNat (1 + w.bits) (1 + w.bits)
+
 
 def RelRegOrMem.interp [Labels] [AddressSize]
   (o : RelRegOrMem) (s : MachineData) (p : Std.Rco Int64)
@@ -422,23 +424,15 @@ structure StatusFlags.from_result.Remaining where
   of : Bool
   deriving Repr, BEq, DecidableEq
 
--- TEMPORARY: definitions stolen from Lean 4.28's standard library, but with a
--- different name so that this file builds with both 4.27 and 4.28
-namespace BitVec
-def cpopNatRec_ {w} (x : BitVec w) (pos acc : Nat) : Nat :=
-  match pos with
-  | 0 => acc
-  | n + 1 => x.cpopNatRec_ n (acc + (x.getLsbD n).toNat)
-
-def cpop_ {w} (x : BitVec w) : BitVec w := BitVec.ofNat w (cpopNatRec_ x w 0)
-end BitVec
+-- `PF` is set when the low byte of the result has an even number of set bits.
+def BitVec.evenParity8 {w} (x : BitVec w) : Bool :=
+  !(x.getLsbD 0 ^^ x.getLsbD 1 ^^ x.getLsbD 2 ^^ x.getLsbD 3
+    ^^ x.getLsbD 4 ^^ x.getLsbD 5 ^^ x.getLsbD 6 ^^ x.getLsbD 7)
 
 @[kstep] def StatusFlags.from_result {w} (result : BitVec w) (f : from_result.Remaining) : StatusFlags :=
-  { pf := (result.take 8).cpop_ % 2 == BitVec.zero _
-    zf := result == BitVec.zero _
+  { pf := result.evenParity8
+    zf := result == 0#w
     sf := result.msb, cf := f.cf, af := f.af, of := f.of }
-
-
 
 set_option maxHeartbeats 1000000
 @[kstep] def Operation.interp [Labels] [address_size : AddressSize]
@@ -470,9 +464,9 @@ set_option maxHeartbeats 1000000
     dst.interp s p (fun b s =>
     let v := a + b
     let status := .from_result v {
-      cf := v.unsigned != a.unsigned + b.unsigned
-      af := (v.take 4).unsigned != (a.take 4).unsigned + (b.take 4).unsigned,
-      of := v.signed != a.signed + b.signed }
+      cf := Kraken.Flags.addCarry a b false
+      af := Kraken.Flags.addCarry (a.take 4) (b.take 4) false,
+      of := Kraken.Flags.addOverflow a b false }
     { s with status }.set dst v p next))
   | .adc dst src =>
     src.interp s p (fun a s =>
@@ -480,37 +474,37 @@ set_option maxHeartbeats 1000000
     let c := s.status.cf
     let v := a + b + c
     let status := .from_result v {
-      cf := v.unsigned != a.unsigned + b.unsigned + c
-      af := (v.take 4).unsigned != (a.take 4).unsigned + (b.take 4).unsigned + c,
-      of := v.signed != a.signed + b.signed + c }
+      cf := Kraken.Flags.addCarry a b c
+      af := Kraken.Flags.addCarry (a.take 4) (b.take 4) c,
+      of := Kraken.Flags.addOverflow a b c }
     { s with status }.set dst v p next))
   | .adcx dst src =>
     src.interp s p (fun a s =>
     dst.interp s p (fun b s =>
     let v := a + b + s.status.cf
-    let cf := v.unsigned != a.unsigned + b.unsigned + s.status.cf
+    let cf := Kraken.Flags.addCarry a b s.status.cf
     next { s with regs := s.regs.set dst v, status := { s.status with cf := cf }}))
   | .adox dst src =>
     src.interp s p (fun a s =>
     dst.interp s p (fun b s =>
     let v := a + b + s.status.of
-    let of := v.unsigned != a.unsigned + b.unsigned + s.status.of
+    let of := Kraken.Flags.addCarry a b s.status.of
     next { s with regs := s.regs.set dst v, status := { s.status with of := of }}))
   | .inc dst =>
     dst.interp s p (fun a s =>
     let v := a + 1
     let status := .from_result v {
       cf := s.status.cf
-      af := (v.take 4).unsigned != (a.take 4).unsigned + 1,
-      of := v.signed != a.signed + 1 }
+      af := Kraken.Flags.addCarry (a.take 4) 1#4 false,
+      of := Kraken.Flags.addOverflow a 1 false }
     { s with status }.set dst v p next)
   | .dec dst =>
     dst.interp s p (fun a s =>
     let v := a - 1
     let status := .from_result v {
       cf := s.status.cf
-      af := (v.take 4).unsigned != (a.take 4).unsigned - 1,
-      of := v.signed != a.signed - 1 }
+      af := Kraken.Flags.subBorrow (a.take 4) 1#4 false,
+      of := Kraken.Flags.subOverflow a 1 false }
     { s with status }.set dst v p next)
   | .neg dst =>
     dst.interp s p (fun b s =>
@@ -518,16 +512,16 @@ set_option maxHeartbeats 1000000
     let status := .from_result v {
       cf := b != 0
       af := (b.take 4) != 0,
-      of := v.signed != - b.signed }
+      of := Kraken.Flags.subOverflow 0 b false }
     { s with status }.set dst v p next)
   | .sub dst src =>
     src.interp s p (fun a s =>
     dst.interp s p (fun b s =>
     let v := b - a
     let status := .from_result v {
-      cf := v.unsigned != b.unsigned - a.unsigned
-      af := (v.take 4).unsigned != (b.take 4).unsigned - (a.take 4).unsigned,
-      of := v.signed != b.signed - a.signed }
+      cf := Kraken.Flags.subBorrow b a false
+      af := Kraken.Flags.subBorrow (b.take 4) (a.take 4) false,
+      of := Kraken.Flags.subOverflow b a false }
     { s with status }.set dst v p next))
   | .sbb dst src =>
     src.interp s p (fun a s =>
@@ -535,52 +529,55 @@ set_option maxHeartbeats 1000000
     let c := s.status.cf
     let v := b - a - c
     let status := .from_result v {
-      cf := v.unsigned != b.unsigned - a.unsigned - c
-      af := (v.take 4).unsigned != (b.take 4).unsigned - (a.take 4).unsigned - c,
-      of := v.signed != b.signed - a.signed - c }
+      cf := Kraken.Flags.subBorrow b a c
+      af := Kraken.Flags.subBorrow (b.take 4) (a.take 4) c,
+      of := Kraken.Flags.subOverflow b a c }
     { s with status }.set dst v p next))
   | .cmp a b =>
     a.interp s p (fun a s =>
     b.interp s p (fun b s =>
     let v := a - b
     let status := .from_result v {
-      cf := v.unsigned != a.unsigned - b.unsigned
-      af := (v.take 4).unsigned != (a.take 4).unsigned - (b.take 4).unsigned,
-      of := v.signed != a.signed - b.signed }
+      cf := Kraken.Flags.subBorrow a b false
+      af := Kraken.Flags.subBorrow (a.take 4) (b.take 4) false,
+      of := Kraken.Flags.subOverflow a b false }
     next { s with status }))
   | .mul src =>
     let a := s.regs.get (Reg.low .rax w)
     src.interp s p (fun b s =>
     let v := a * b
-    let vn := a.unsigned * b.unsigned
+    -- `BitVec.umulOverflow` says exactly that its high half is nonzero,
+    -- which is the meaning of `CF`/`OF` here.
+    let vn := a.setWidth (w.bits + w.bits) * b.setWidth (w.bits + w.bits)
     let s := if w == .W8
-      then s.setReg (.low .rax .W16) (.ofInt _ vn)
-      else (s.setReg (.low .rax w) v).setReg (.low .rdx w) (.ofInt _ (vn >>> w.bits))
+      then s.setReg (.low .rax .W16) (vn.setWidth _)
+      else (s.setReg (.low .rax w) v).setReg (.low .rdx w) (vn.extractLsb' w.bits w.bits)
     undefined (λ sf => undefined (λ zf => undefined (λ af => undefined (λ pf =>
-    next { s with status := { cf := v.unsigned != vn, pf, af, zf, sf, of := v.unsigned != vn }})))))
+    let ovf := BitVec.umulOverflow a b
+    next { s with status := { cf := ovf, pf, af, zf, sf, of := ovf }})))))
   | .mulx r_hi r_lo src1 =>
     src1.interp s p (fun a s =>
     let b := s.regs.get (.low .rdx w)
-    let v := a.unsigned * b.unsigned
-    let s := s.setReg r_lo (.ofInt _ v) -- if r_hi = r_li, hi is written:
-    let s := s.setReg r_hi (.ofInt _ (v >>> w.bits))
+    let v := a.setWidth (w.bits + w.bits) * b.setWidth (w.bits + w.bits)
+    let s := s.setReg r_lo (v.setWidth _) -- if r_hi = r_li, hi is written:
+    let s := s.setReg r_hi (v.extractLsb' w.bits w.bits)
     next s)
   -- imul1 and imul collectively describe variants of the same
   -- syntax level `imul` instruction, where imul1 is the 1-operand case
   | .imul1 src =>
     let a := s.regs.get (Reg.low .rax w)
     src.interp s p (fun b s =>
-    let v := a.toInt * b.toInt
+    let v := a.signExtend (w.bits * 2) * b.signExtend (w.bits * 2)
     let s := if w == .W8 then
-      s.setReg (.low .rax .W16) (BitVec.ofInt 16 v)
+      s.setReg (.low .rax .W16) (v.setWidth 16)
     else
-      let result := BitVec.ofInt (w.bits * 2) v
-      let low := result.take w.bits
-      let high := (result.drop w.bits).setWidth _
+      let low := v.take w.bits
+      let high := (v.drop w.bits).setWidth _
       (s.setReg (.low .rax w) low).setReg (.low .rdx w) high
     undefined (λ sf => undefined (λ zf => undefined (λ af => undefined (λ pf =>
-    let low := BitVec.ofInt w.bits v
-    let cf := v != low.toInt
+    -- `CF`/`OF` say the low half alone does not represent the product, which
+    -- is the meaning of `BitVec.smulOverflow`.
+    let cf := BitVec.smulOverflow a b
     next { s with status := { cf := cf, pf, af, zf, sf, of := cf }})))))
   | .imul dst src1 src2 =>
     src1.interp s p (fun a s =>
@@ -588,7 +585,7 @@ set_option maxHeartbeats 1000000
     let v := a * b
     s.set (match (generalizing := false) (motive := Option (RegOrMem w) → RegOrMem w)
              dst with | .some dst => dst | _ => src1) v p (fun s =>
-    let cf := v.signed != a.signed * b.signed
+    let cf := BitVec.smulOverflow a b
     undefined (λ sf => undefined (λ zf => undefined (λ af => undefined (λ pf =>
     next { s with status := { cf := cf, pf, af, zf, sf, of := cf }})))))))
 -- Bitwise
@@ -661,35 +658,35 @@ set_option maxHeartbeats 1000000
       (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
       setstatus (.from_result v { cf, af, of})))) (λ status =>
     { s with status }.set dst v p next)))
-  | .rol dst count =>
+  | .rol dst rotcount =>
     dst.interp s p (fun a s =>
-    let count := count.interpMasked s p w
+    let count := rotcount.interpMasked s p w
     if count == 0 then next s else
-    let v := a.rotateLeft count
+    let v := a.rolBV (rotcount.interpRotate s p w)
     let cf := v.getLsbD 0
     (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
     { s with status := { s.status with cf, of } }.set dst v p next))
-  | .ror dst count =>
+  | .ror dst rotcount =>
     dst.interp s p (fun a s =>
-    let count := count.interpMasked s p w
+    let count := rotcount.interpMasked s p w
     if count == 0 then next s else
-    let v := a.rotateRight count
+    let v := a.rorBV (rotcount.interpRotate s p w)
     let cf := v.msb
     (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
     { s with status := { s.status with cf, of } }.set dst v p next))
-  | .rcr dst count =>
+  | .rcr dst rotcount =>
     dst.interp s p (fun a s =>
-    let count := count.interpMasked s p w
+    let count := rotcount.interpMasked s p w
     if count == 0 then next s else
-    let t := (BitVec.ofBool s.status.cf ++ a).rotateRight count
+    let t := (BitVec.ofBool s.status.cf ++ a).rorBV (rotcount.interpRotateCarry s p w)
     let (cf, v) := (t.msb, t.take w.bits)
     (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
     { s with status := { s.status with cf, of } }.set dst v p next))
-  | .rcl dst count =>
+  | .rcl dst rotcount =>
     dst.interp s p (fun a s =>
-    let count := count.interpMasked s p w
+    let count := rotcount.interpMasked s p w
     if count == 0 then next s else
-    let t := (BitVec.ofBool s.status.cf ++ a).rotateLeft count
+    let t := (BitVec.ofBool s.status.cf ++ a).rolBV (rotcount.interpRotateCarry s p w)
     let (cf, v) := (t.msb, t.take w.bits)
     (λ setof => if count == 1 then setof (v.msb != a.msb) else undefined setof) (λ of =>
     { s with status := { s.status with cf, of } }.set dst v p next))
@@ -841,5 +838,5 @@ abbrev eval [layout : Layout] (prog : Program) := Executable.eval (layout prog)
     .instr (.regular .W64 .W64 (.inc (.reg (.low .rax .W64)))),
     .instr (.regular .W64 .W64 .ret) ]
   let start := (Executable.labels exe).label "main"
-  let data : MachineData := { dmem := Mem.storeInt {} 0x100 8 0x1337, regs := {rsp := 0x100} }
+  let data : MachineData := { dmem := Mem.storeBV {} 0x100 8 (0x1337 : BitVec 64), regs := {rsp := 0x100} }
   (Executable.eval exe (data, start) (fun (_, pc) => pc = 0x1337)).bind (fun s => .ok s.1.regs.rax)

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -407,7 +407,12 @@ def CondCode.interp (cc : CondCode) (s : StatusFlags) : Bool := match cc with
 /-- The rotate amount for `rcl`/`rcr`, reduced modulo `1 + w.bits`. -/
 @[kstep] def ShiftCountExpr.interpRotateCarry [Labels] (c : ShiftCountExpr) (s : MachineData)
     (p : Std.Rco Int64) (w : Width) : BitVec (1 + w.bits) :=
-  (c.interpMaskedBV s p w).setWidth (1 + w.bits) % BitVec.ofNat (1 + w.bits) (1 + w.bits)
+  let cnt := c.interpMaskedBV s p w
+  match w with
+  | .W8  => cnt.setWidth 9 % 9#9
+  | .W16 => cnt.setWidth 17 % 17#17
+  | .W32 => cnt.setWidth 33
+  | .W64 => cnt.setWidth 65
 
 
 def RelRegOrMem.interp [Labels] [AddressSize]
@@ -838,5 +843,5 @@ abbrev eval [layout : Layout] (prog : Program) := Executable.eval (layout prog)
     .instr (.regular .W64 .W64 (.inc (.reg (.low .rax .W64)))),
     .instr (.regular .W64 .W64 .ret) ]
   let start := (Executable.labels exe).label "main"
-  let data : MachineData := { dmem := Mem.storeBV {} 0x100 8 (0x1337 : BitVec 64), regs := {rsp := 0x100} }
+  let data : MachineData := { dmem := Mem.storeBV {} 0x100 8 0x1337#64, regs := {rsp := 0x100} }
   (Executable.eval exe (data, start) (fun (_, pc) => pc = 0x1337)).bind (fun s => .ok s.1.regs.rax)

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -266,7 +266,7 @@ def MachineData.load
   (s : MachineData) (addr : BitVec 64) (w : Width)
   (ret : w.type → MachineData → Effects): Effects :=
   require_read_access addr w (fun _unit =>
-    match Mem.loadBV s.dmem addr w.bits w.bytes with
+    match Mem.loadBV s.dmem addr w.bytes with
     | .some v => ret v s
     | .none => nonmem_load s.dmem addr w (fun v dmem => ret v { s with dmem }))
 
@@ -285,7 +285,7 @@ def MachineData.loadAvx
     .gp_unaligned addr w.bytes
   else
     require_read_access addr .W64 (fun _unit =>
-  match Mem.loadBV s.dmem addr w.bits w.bytes with
+  match Mem.loadBV s.dmem addr w.bytes with
       | .some v => ret v s
       | .none => unimplemented "AVX nonmem load not supported")
 

--- a/Kraken/X64/Semantics.lean
+++ b/Kraken/X64/Semantics.lean
@@ -270,7 +270,8 @@ def MachineData.load
     | .some v => ret v s
     | .none => nonmem_load s.dmem addr w (fun v dmem => ret v { s with dmem }))
 
--- `bytes` is always a power of two, so alignment is a bit mask test.
+-- This is equivalent to testing whether `addr % bytes == 0`:
+-- `bytes` is always a power of two, so alignment check is a bit mask test.
 def isAligned (bytes : Nat) (addr : BitVec 64) : Bool :=
   addr &&& BitVec.ofNat 64 (bytes - 1) == 0#64
 

--- a/Kraken/X64/Sep.lean
+++ b/Kraken/X64/Sep.lean
@@ -27,4 +27,4 @@ theorem load_sep (s : MachineData) (addr : BitVec 64) (w : Width) (ret : w.type 
     MachineData.load s addr w ret =
       require_read_access addr w (fun _ => ret (BitVec.ofBytes w.bits bs) s) := by
   simp only [MachineData.load,
-    Mem.loadBV_sep bs addr w.bits w.bytes R s.dmem h_mem h_len (by cases w <;> decide)]
+    Mem.loadBV_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)]

--- a/Kraken/X64/Sep.lean
+++ b/Kraken/X64/Sep.lean
@@ -11,12 +11,12 @@ theorem store_sep (s : MachineData) (addr : BitVec 64) (w : Width) (v : w.type) 
     (bs : List UInt8) (R : DataMem → Prop)
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :
-    have mem' := Mem.storeInt s.dmem addr w.bytes v.toInt
+    have mem' := Mem.storeBV s.dmem addr w.bytes v
     MachineData.store s addr v ret =
       require_write_access addr w (fun _ =>
         ret { s with dmem := mem' }) := by
-  have h_load : Mem.loadInt s.dmem addr w.bytes = some (Int.ofBytes bs) :=
-    Mem.loadInt_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)
+  have h_load : Mem.loadBytes s.dmem addr w.bytes = some bs :=
+    Mem.loadBytes_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)
   simp only [MachineData.store, h_load]
 
 @[kspec]
@@ -25,6 +25,6 @@ theorem load_sep (s : MachineData) (addr : BitVec 64) (w : Width) (ret : w.type 
     (h_mem : s.dmem =⋆ Eq (bs.At addr) ⋆ R)
     (h_len : bs.length = w.bytes) :
     MachineData.load s addr w ret =
-      require_read_access addr w (fun _ => ret (.ofInt w.bits (Int.ofBytes bs)) s) := by
+      require_read_access addr w (fun _ => ret (BitVec.ofBytes w.bits bs) s) := by
   simp only [MachineData.load,
-    Mem.loadInt_sep bs addr w.bytes R s.dmem h_mem h_len (by cases w <;> decide)]
+    Mem.loadBV_sep bs addr w.bits w.bytes R s.dmem h_mem h_len (by cases w <;> decide)]

--- a/Kraken/X64/Syntax.lean
+++ b/Kraken/X64/Syntax.lean
@@ -12,6 +12,7 @@ namespace Width
 @[kstep, simp, reducible] def bytes : Width → Nat | W8 => 1 | W16 => 2 | W32 => 4 | W64 => 8
 @[kstep, simp, reducible] def bits (w : Width) := 8 * w.bytes
 @[kstep] abbrev bytesv (w : Width) {n} : BitVec n := BitVec.ofNat n w.bytes
+@[kstep] abbrev bitsv (w : Width) {n} : BitVec n := BitVec.ofNat n w.bits
 @[kstep] abbrev type (w : Width) : Type := BitVec w.bits
 instance {w : Width} : Coe Bool w.type where coe := fun b : Bool => (BitVec.ofBool b).setWidth _
 end Width
@@ -37,6 +38,7 @@ namespace AvxWidth
 @[simp, reducible] def bytes : AvxWidth → Nat | W128 => 16 | W256 => 32 | W512 => 64
 @[simp, reducible] def bits (w : AvxWidth) := 8 * w.bytes
 abbrev bytesv (w : AvxWidth) {n} : BitVec n := BitVec.ofNat n w.bytes
+abbrev bitsv (w : AvxWidth) {n} : BitVec n := BitVec.ofNat n w.bits
 abbrev type (w : AvxWidth) : Type := BitVec w.bits
 instance {w : AvxWidth} : Coe Bool w.type where coe := fun b : Bool => (BitVec.ofBool b).setWidth _
 end AvxWidth

--- a/Kraken/X64/Syntax.lean
+++ b/Kraken/X64/Syntax.lean
@@ -13,7 +13,7 @@ namespace Width
 @[kstep, simp, reducible] def bytes : Width → Nat | W8 => 1 | W16 => 2 | W32 => 4 | W64 => 8
 @[kstep] abbrev bytesv (w : Width) {n} : BitVec n := BitVec.ofNat n w.bytes
 @[kstep] abbrev type (w : Width) : Type := BitVec w.bits
-instance {w : Width} : Coe Bool w.type where coe := fun b : Bool => BitVec.ofNat _ b.toNat
+instance {w : Width} : Coe Bool w.type where coe := fun b : Bool => (BitVec.ofBool b).setWidth _
 end Width
 
 unif_hint (w : Width) where
@@ -38,7 +38,7 @@ namespace AvxWidth
 @[simp, reducible] def bytes : AvxWidth → Nat | W128 => 16 | W256 => 32 | W512 => 64
 abbrev bytesv (w : AvxWidth) {n} : BitVec n := BitVec.ofNat n w.bytes
 abbrev type (w : AvxWidth) : Type := BitVec w.bits
-instance {w : AvxWidth} : Coe Bool w.type where coe := fun b : Bool => BitVec.ofNat _ b.toNat
+instance {w : AvxWidth} : Coe Bool w.type where coe := fun b : Bool => (BitVec.ofBool b).setWidth _
 end AvxWidth
 
 unif_hint (w : AvxWidth) where

--- a/Kraken/X64/Syntax.lean
+++ b/Kraken/X64/Syntax.lean
@@ -137,6 +137,7 @@ structure AddrExpr where
 
 class AddressSize where address_size : Width
 export AddressSize (address_size)
+attribute [kstep, reducible, simp] AddressSize.address_size
 
 inductive RegOrMem w | reg (r : Reg w) | mem (_ : AddrExpr)
   deriving Repr, BEq, DecidableEq, Hashable, Lean.ToExpr

--- a/Kraken/X64/Syntax.lean
+++ b/Kraken/X64/Syntax.lean
@@ -9,8 +9,8 @@ instance : ToString Width where
   toString | .W8 => "w8" | .W16 => "w16" | .W32 => "w32" | .W64 => "w64"
 
 namespace Width
-@[kstep, simp, reducible] def bits : Width → Nat | W8 => 8 | W16 => 16 | W32 => 32 | W64 => 64
 @[kstep, simp, reducible] def bytes : Width → Nat | W8 => 1 | W16 => 2 | W32 => 4 | W64 => 8
+@[kstep, simp, reducible] def bits (w : Width) := 8 * w.bytes
 @[kstep] abbrev bytesv (w : Width) {n} : BitVec n := BitVec.ofNat n w.bytes
 @[kstep] abbrev type (w : Width) : Type := BitVec w.bits
 instance {w : Width} : Coe Bool w.type where coe := fun b : Bool => (BitVec.ofBool b).setWidth _
@@ -34,8 +34,8 @@ instance : ToString AvxWidth where
   toString |.W128 => "w128" | .W256 => "w256" | .W512 => "w512"
 
 namespace AvxWidth
-@[simp, reducible] def bits : AvxWidth → Nat | W128 => 128 | W256 => 256 | W512 => 512
 @[simp, reducible] def bytes : AvxWidth → Nat | W128 => 16 | W256 => 32 | W512 => 64
+@[simp, reducible] def bits (w : AvxWidth) := 8 * w.bytes
 abbrev bytesv (w : AvxWidth) {n} : BitVec n := BitVec.ofNat n w.bytes
 abbrev type (w : AvxWidth) : Type := BitVec w.bits
 instance {w : AvxWidth} : Coe Bool w.type where coe := fun b : Bool => (BitVec.ofBool b).setWidth _


### PR DESCRIPTION
This PR refactors the semantics to use `BitVec` instead of unbounded integers (`Int`/`Nat`). This should make it easier to use `bv_decide` and also keeps the semantics in terms of "64-bit machine words". For multiplication and flags computation we also include some helper lemmas and specs to rewrite the `BitVec` forms into arithmetic integer-based forms. This should help with reasoning using tactics like `lia`.